### PR TITLE
Estas son las trazas de alajuela-targuases

### DIFF
--- a/bus_alajuela-targuases/asistentes/fran_2017_10_2.gpx
+++ b/bus_alajuela-targuases/asistentes/fran_2017_10_2.gpx
@@ -1,0 +1,19863 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="OSMTracker for Android™ - https://github.com/nguillaumin/osmtracker-android" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd ">
+	<wpt lat="10.014216501928423" lon="-84.21694942618792">
+		<ele>960.6272312467918</ele>
+		<time>2017-10-02T17:47:21Z</time>
+		<name><![CDATA[Hostal]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.01423223634952" lon="-84.21696485493584">
+		<ele>960.3478714684024</ele>
+		<time>2017-10-02T17:48:45Z</time>
+		<name><![CDATA[Hostal]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.01423223634952" lon="-84.21696485493584">
+		<ele>960.3478714684024</ele>
+		<time>2017-10-02T17:48:47Z</time>
+		<name><![CDATA[Hostal]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.014337066758701" lon="-84.21697692886227">
+		<ele>956.2060107374564</ele>
+		<time>2017-10-02T17:51:00Z</time>
+		<name><![CDATA[Hostal]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015233625815545" lon="-84.2133664887642">
+		<ele>957.4838182814419</ele>
+		<time>2017-10-02T18:01:19Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015235537285589" lon="-84.21336995619676">
+		<ele>954.173608686775</ele>
+		<time>2017-10-02T18:01:22Z</time>
+		<name><![CDATA[tipo 3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015631938675911" lon="-84.21192621552014">
+		<ele>963.3118428792804</ele>
+		<time>2017-10-02T18:02:47Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015631938675911" lon="-84.21192621552014">
+		<ele>963.3118428792804</ele>
+		<time>2017-10-02T18:02:49Z</time>
+		<name><![CDATA[tipo 1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.01039063244451" lon="-84.21300115657263">
+		<ele>950.0264349067584</ele>
+		<time>2017-10-02T18:13:32Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.010400223145767" lon="-84.21302655781558">
+		<ele>949.6267499485984</ele>
+		<time>2017-10-02T18:13:33Z</time>
+		<name><![CDATA[tipo 1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008613519942738" lon="-84.21055056325133">
+		<ele>945.5062991641462</ele>
+		<time>2017-10-02T18:14:50Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008613519942738" lon="-84.21055056325133">
+		<ele>945.5062991641462</ele>
+		<time>2017-10-02T18:14:51Z</time>
+		<name><![CDATA[tipo 1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.007248407089385" lon="-84.20684860218114">
+		<ele>942.0901824114844</ele>
+		<time>2017-10-02T18:17:12Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.007180728529326" lon="-84.20678290273688">
+		<ele>942.3984667211771</ele>
+		<time>2017-10-02T18:17:13Z</time>
+		<name><![CDATA[tipo 1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.005756332302429" lon="-84.20593868744223">
+		<ele>928.5045864470303</ele>
+		<time>2017-10-02T18:18:14Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.005757323040795" lon="-84.2059369147378">
+		<ele>927.4698717044666</ele>
+		<time>2017-10-02T18:18:15Z</time>
+		<name><![CDATA[tipo 1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.006005479465003" lon="-84.20427872638358">
+		<ele>930.1805077083409</ele>
+		<time>2017-10-02T18:20:33Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.006017273850889" lon="-84.20426359433993">
+		<ele>930.5789271965623</ele>
+		<time>2017-10-02T18:20:34Z</time>
+		<name><![CDATA[tipo 1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.00730288901762" lon="-84.20449125937952">
+		<ele>928.279000217095</ele>
+		<time>2017-10-02T18:21:41Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.007296423195564" lon="-84.20448807658025">
+		<ele>927.5022842427716</ele>
+		<time>2017-10-02T18:21:43Z</time>
+		<name><![CDATA[tipo 3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008771765685358" lon="-84.20327708376274">
+		<ele>925.582749241963</ele>
+		<time>2017-10-02T18:22:35Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008771765685358" lon="-84.20327708376274">
+		<ele>925.582749241963</ele>
+		<time>2017-10-02T18:22:36Z</time>
+		<name><![CDATA[tipo 3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.01021106252717" lon="-84.20212071597012">
+		<ele>962.473676671274</ele>
+		<time>2017-10-02T18:23:23Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.010209478080704" lon="-84.2021184019233">
+		<ele>963.4061851035804</ele>
+		<time>2017-10-02T18:23:24Z</time>
+		<name><![CDATA[tipo 1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.01131918163156" lon="-84.20147086371104">
+		<ele>966.2593602743</ele>
+		<time>2017-10-02T18:24:12Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.011318989276326" lon="-84.20147110535625">
+		<ele>965.9263844033703</ele>
+		<time>2017-10-02T18:24:13Z</time>
+		<name><![CDATA[tipo 1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.013157778763341" lon="-84.20083627379805">
+		<ele>964.5438336152583</ele>
+		<time>2017-10-02T18:25:16Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.013191154199657" lon="-84.2008886170188">
+		<ele>964.9577745720744</ele>
+		<time>2017-10-02T18:25:17Z</time>
+		<name><![CDATA[tipo 1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.014216277650037" lon="-84.2022666484723">
+		<ele>963.3691677609459</ele>
+		<time>2017-10-02T18:25:58Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.014216277650037" lon="-84.2022666484723">
+		<ele>963.3691677609459</ele>
+		<time>2017-10-02T18:25:58Z</time>
+		<name><![CDATA[tipo 1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015323222143298" lon="-84.20177036988946">
+		<ele>950.4884751234204</ele>
+		<time>2017-10-02T18:26:42Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015307771433053" lon="-84.20179309130965">
+		<ele>950.4839250072837</ele>
+		<time>2017-10-02T18:26:44Z</time>
+		<name><![CDATA[tipo 3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<trk>
+		<name><![CDATA[Trazado con OSMTracker para Android™]]></name>
+		<trkseg>
+			<trkpt lat="10.014356418044537" lon="-84.21724099053458">
+				<ele>814.773539765738</ele>
+				<time>2017-10-02T17:43:27Z</time>
+				<extensions>
+					<speed>1.7712002992630005</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014055157574429" lon="-84.2167997110422">
+				<ele>942.2963011292741</ele>
+				<time>2017-10-02T17:43:29Z</time>
+				<extensions>
+					<speed>0.13386015594005585</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014170602180778" lon="-84.21692767549351">
+				<ele>959.7090286193416</ele>
+				<time>2017-10-02T17:43:34Z</time>
+				<extensions>
+					<speed>0.1263371855020523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:35Z</time>
+				<extensions>
+					<speed>0.23427772521972656</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:43:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:44:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:45:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014214270116264" lon="-84.21693803011269">
+				<ele>961.8190798740834</ele>
+				<time>2017-10-02T17:46:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014211355671996" lon="-84.21694285170655">
+				<ele>961.8003343017772</ele>
+				<time>2017-10-02T17:46:01Z</time>
+				<extensions>
+					<speed>0.7572765946388245</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01420843395803" lon="-84.21694849334942">
+				<ele>961.8621001439169</ele>
+				<time>2017-10-02T17:46:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014210374865552" lon="-84.21694883242857">
+				<ele>961.8952375100926</ele>
+				<time>2017-10-02T17:46:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014210374865552" lon="-84.21694883242857">
+				<ele>961.8952375100926</ele>
+				<time>2017-10-02T17:46:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014210374865552" lon="-84.21694883242857">
+				<ele>961.8952375100926</ele>
+				<time>2017-10-02T17:46:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208304098883" lon="-84.2169541341211">
+				<ele>961.9865734800696</ele>
+				<time>2017-10-02T17:46:06Z</time>
+				<extensions>
+					<speed>0.7152307033538818</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01420734175648" lon="-84.216961548512">
+				<ele>962.09661326278</ele>
+				<time>2017-10-02T17:46:07Z</time>
+				<extensions>
+					<speed>0.8178570866584778</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014207380659284" lon="-84.21696816861095">
+				<ele>962.1605940433219</ele>
+				<time>2017-10-02T17:46:08Z</time>
+				<extensions>
+					<speed>0.5813796520233154</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014207109579894" lon="-84.21697340393204">
+				<ele>962.2392801074311</ele>
+				<time>2017-10-02T17:46:09Z</time>
+				<extensions>
+					<speed>0.4693548381328583</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014207109579894" lon="-84.21697340393204">
+				<ele>962.2392801074311</ele>
+				<time>2017-10-02T17:46:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208402482323" lon="-84.21697298348916">
+				<ele>962.2608086755499</ele>
+				<time>2017-10-02T17:46:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208611922141" lon="-84.21696608147776">
+				<ele>962.4429096477106</ele>
+				<time>2017-10-02T17:46:53Z</time>
+				<extensions>
+					<speed>1.0375069379806519</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208408927505" lon="-84.21695746581288">
+				<ele>962.2808952936903</ele>
+				<time>2017-10-02T17:46:54Z</time>
+				<extensions>
+					<speed>1.1222304105758667</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208955206776" lon="-84.21695004192865">
+				<ele>961.8292939309031</ele>
+				<time>2017-10-02T17:46:55Z</time>
+				<extensions>
+					<speed>0.7660447955131531</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01421327696549" lon="-84.21694702499371">
+				<ele>961.2610287908465</ele>
+				<time>2017-10-02T17:46:56Z</time>
+				<extensions>
+					<speed>0.4644773602485657</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:46:57Z</time>
+				<extensions>
+					<speed>0.013131367042660713</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:46:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:46:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:47:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:48:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:48:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:48:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:48:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:48:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:48:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:48:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:48:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:48:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:48:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:48:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:48:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:48:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:48:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:48:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:48:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:48:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216501928423" lon="-84.21694942618792">
+				<ele>960.6272312467918</ele>
+				<time>2017-10-02T17:48:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014223424735615" lon="-84.216956579903">
+				<ele>960.1454959241673</ele>
+				<time>2017-10-02T17:48:18Z</time>
+				<extensions>
+					<speed>0.6373561024665833</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229709341665" lon="-84.2169624070179">
+				<ele>960.2965863663703</ele>
+				<time>2017-10-02T17:48:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423223634952" lon="-84.21696485493584">
+				<ele>960.3478714684024</ele>
+				<time>2017-10-02T17:48:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014233274345129" lon="-84.21696067730063">
+				<ele>960.4337859833613</ele>
+				<time>2017-10-02T17:48:56Z</time>
+				<extensions>
+					<speed>0.735028862953186</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014235124145287" lon="-84.21695570736712">
+				<ele>960.8084414424375</ele>
+				<time>2017-10-02T17:48:57Z</time>
+				<extensions>
+					<speed>0.85792475938797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014236981636799" lon="-84.21694828248863">
+				<ele>961.3554013082758</ele>
+				<time>2017-10-02T17:48:58Z</time>
+				<extensions>
+					<speed>1.0438421964645386</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014239144059413" lon="-84.21694254518651">
+				<ele>961.8586653219536</ele>
+				<time>2017-10-02T17:48:59Z</time>
+				<extensions>
+					<speed>0.8633465766906738</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014239597617662" lon="-84.21693731148088">
+				<ele>962.14385142643</ele>
+				<time>2017-10-02T17:49:00Z</time>
+				<extensions>
+					<speed>0.6327242255210876</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014239525096318" lon="-84.21693809018986">
+				<ele>962.6345364442095</ele>
+				<time>2017-10-02T17:49:01Z</time>
+				<extensions>
+					<speed>0.3405786454677582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:02Z</time>
+				<extensions>
+					<speed>0.12491883337497711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423953209414" lon="-84.21693968953394">
+				<ele>962.9608756201342</ele>
+				<time>2017-10-02T17:49:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014239307371332" lon="-84.21693112659537">
+				<ele>963.0219467254356</ele>
+				<time>2017-10-02T17:49:30Z</time>
+				<extensions>
+					<speed>0.6685124039649963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014240710956317" lon="-84.21692981014971">
+				<ele>963.1302335904911</ele>
+				<time>2017-10-02T17:49:31Z</time>
+				<extensions>
+					<speed>0.43526312708854675</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01424288419711" lon="-84.21693316532526">
+				<ele>963.2392430156469</ele>
+				<time>2017-10-02T17:49:32Z</time>
+				<extensions>
+					<speed>0.16423755884170532</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01424288419711" lon="-84.21693316532526">
+				<ele>963.2392430156469</ele>
+				<time>2017-10-02T17:49:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01424288419711" lon="-84.21693316532526">
+				<ele>963.2392430156469</ele>
+				<time>2017-10-02T17:49:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01424288419711" lon="-84.21693316532526">
+				<ele>963.2392430156469</ele>
+				<time>2017-10-02T17:49:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01424288419711" lon="-84.21693316532526">
+				<ele>963.2392430156469</ele>
+				<time>2017-10-02T17:49:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01424288419711" lon="-84.21693316532526">
+				<ele>963.2392430156469</ele>
+				<time>2017-10-02T17:49:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01424288419711" lon="-84.21693316532526">
+				<ele>963.2392430156469</ele>
+				<time>2017-10-02T17:49:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01424288419711" lon="-84.21693316532526">
+				<ele>963.2392430156469</ele>
+				<time>2017-10-02T17:49:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014243606062937" lon="-84.21692913982669">
+				<ele>963.2761637410149</ele>
+				<time>2017-10-02T17:49:40Z</time>
+				<extensions>
+					<speed>0.7250142693519592</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01424361543186" lon="-84.21692635854251">
+				<ele>963.0988612323999</ele>
+				<time>2017-10-02T17:49:41Z</time>
+				<extensions>
+					<speed>0.4714326560497284</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014245273081851" lon="-84.21692229843535">
+				<ele>963.0977807464078</ele>
+				<time>2017-10-02T17:49:42Z</time>
+				<extensions>
+					<speed>0.4017690420150757</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014245273081851" lon="-84.21692229843535">
+				<ele>963.0977807464078</ele>
+				<time>2017-10-02T17:49:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014244054984248" lon="-84.21692170325053">
+				<ele>963.1165409572423</ele>
+				<time>2017-10-02T17:49:44Z</time>
+				<extensions>
+					<speed>0.09457244724035263</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014244054984248" lon="-84.21692170325053">
+				<ele>963.1165409572423</ele>
+				<time>2017-10-02T17:49:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014244054984248" lon="-84.21692170325053">
+				<ele>963.1165409572423</ele>
+				<time>2017-10-02T17:49:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014244054984248" lon="-84.21692170325053">
+				<ele>963.1165409572423</ele>
+				<time>2017-10-02T17:49:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014244054984248" lon="-84.21692170325053">
+				<ele>963.1165409572423</ele>
+				<time>2017-10-02T17:49:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014244054984248" lon="-84.21692170325053">
+				<ele>963.1165409572423</ele>
+				<time>2017-10-02T17:49:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01424829248816" lon="-84.21692208770163">
+				<ele>963.4144610418007</ele>
+				<time>2017-10-02T17:49:50Z</time>
+				<extensions>
+					<speed>0.6238869428634644</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014253477710568" lon="-84.21691907977726">
+				<ele>963.7679615104571</ele>
+				<time>2017-10-02T17:49:51Z</time>
+				<extensions>
+					<speed>0.7722933888435364</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014256484103868" lon="-84.21691230089422">
+				<ele>963.9042220395058</ele>
+				<time>2017-10-02T17:49:52Z</time>
+				<extensions>
+					<speed>0.9326491951942444</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014262214559832" lon="-84.21691069525353">
+				<ele>963.57120273076</ele>
+				<time>2017-10-02T17:49:53Z</time>
+				<extensions>
+					<speed>0.7595712542533875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014263061757942" lon="-84.21690872088114">
+				<ele>963.4752135360613</ele>
+				<time>2017-10-02T17:49:54Z</time>
+				<extensions>
+					<speed>0.3925780653953552</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014260602373971" lon="-84.2169046996144">
+				<ele>963.321393028833</ele>
+				<time>2017-10-02T17:49:55Z</time>
+				<extensions>
+					<speed>0.6406697034835815</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014259799244249" lon="-84.21690109716337">
+				<ele>963.320176509209</ele>
+				<time>2017-10-02T17:49:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014259146155254" lon="-84.21689884751926">
+				<ele>963.3325465852395</ele>
+				<time>2017-10-02T17:49:57Z</time>
+				<extensions>
+					<speed>0.6394208073616028</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014259711448107" lon="-84.21689714803927">
+				<ele>963.327786911279</ele>
+				<time>2017-10-02T17:49:58Z</time>
+				<extensions>
+					<speed>0.7158656120300293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014261410381904" lon="-84.21689599151628">
+				<ele>963.1539265271276</ele>
+				<time>2017-10-02T17:49:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014264401735018" lon="-84.21690050277557">
+				<ele>963.3333020731807</ele>
+				<time>2017-10-02T17:50:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014264401735018" lon="-84.21690050277557">
+				<ele>963.3333020731807</ele>
+				<time>2017-10-02T17:50:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014264401735018" lon="-84.21690050277557">
+				<ele>963.3333020731807</ele>
+				<time>2017-10-02T17:50:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014264401735018" lon="-84.21690050277557">
+				<ele>963.3333020731807</ele>
+				<time>2017-10-02T17:50:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014264401735018" lon="-84.21690050277557">
+				<ele>963.3333020731807</ele>
+				<time>2017-10-02T17:50:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014264401735018" lon="-84.21690050277557">
+				<ele>963.3333020731807</ele>
+				<time>2017-10-02T17:50:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014264401735018" lon="-84.21690050277557">
+				<ele>963.3333020731807</ele>
+				<time>2017-10-02T17:50:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014264401735018" lon="-84.21690050277557">
+				<ele>963.3333020731807</ele>
+				<time>2017-10-02T17:50:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014264401735018" lon="-84.21690050277557">
+				<ele>963.3333020731807</ele>
+				<time>2017-10-02T17:50:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014279691461429" lon="-84.21692205123912">
+				<ele>963.3100140672177</ele>
+				<time>2017-10-02T17:50:09Z</time>
+				<extensions>
+					<speed>0.814318835735321</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014289315101639" lon="-84.2169310768534">
+				<ele>963.2382044205442</ele>
+				<time>2017-10-02T17:50:10Z</time>
+				<extensions>
+					<speed>0.833035945892334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014295279201558" lon="-84.21693759033037">
+				<ele>962.8766408087686</ele>
+				<time>2017-10-02T17:50:11Z</time>
+				<extensions>
+					<speed>0.6113395690917969</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014296689701547" lon="-84.21693905342339">
+				<ele>962.4652604721487</ele>
+				<time>2017-10-02T17:50:12Z</time>
+				<extensions>
+					<speed>0.12295639514923096</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014296837770367" lon="-84.21693515625645">
+				<ele>961.8994132196531</ele>
+				<time>2017-10-02T17:50:13Z</time>
+				<extensions>
+					<speed>0.5162079334259033</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014301382443863" lon="-84.21693679700236">
+				<ele>961.0357277002186</ele>
+				<time>2017-10-02T17:50:14Z</time>
+				<extensions>
+					<speed>0.6152758598327637</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014303975248689" lon="-84.21693894652273">
+				<ele>960.6190664442256</ele>
+				<time>2017-10-02T17:50:15Z</time>
+				<extensions>
+					<speed>0.5691568851470947</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01431026061503" lon="-84.21694000589896">
+				<ele>960.0807455517352</ele>
+				<time>2017-10-02T17:50:16Z</time>
+				<extensions>
+					<speed>0.5871812701225281</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014317057646089" lon="-84.21694604429547">
+				<ele>959.6125247273594</ele>
+				<time>2017-10-02T17:50:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320532939706" lon="-84.21695401664402">
+				<ele>958.3815804682672</ele>
+				<time>2017-10-02T17:50:50Z</time>
+				<extensions>
+					<speed>0.6100074052810669</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432422629459" lon="-84.21695689109802">
+				<ele>956.9057583641261</ele>
+				<time>2017-10-02T17:50:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014329720711752" lon="-84.21696649799911">
+				<ele>956.1418629242107</ele>
+				<time>2017-10-02T17:50:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014329720711752" lon="-84.21696649799911">
+				<ele>956.1418629242107</ele>
+				<time>2017-10-02T17:50:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014329720711752" lon="-84.21696649799911">
+				<ele>956.1418629242107</ele>
+				<time>2017-10-02T17:50:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014329720711752" lon="-84.21696649799911">
+				<ele>956.1418629242107</ele>
+				<time>2017-10-02T17:50:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014329720711752" lon="-84.21696649799911">
+				<ele>956.1418629242107</ele>
+				<time>2017-10-02T17:50:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014329720711752" lon="-84.21696649799911">
+				<ele>956.1418629242107</ele>
+				<time>2017-10-02T17:50:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014331366910344" lon="-84.2169734070928">
+				<ele>956.0970512330532</ele>
+				<time>2017-10-02T17:50:58Z</time>
+				<extensions>
+					<speed>0.6176300644874573</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337377396705" lon="-84.21697632121393">
+				<ele>955.9846385139972</ele>
+				<time>2017-10-02T17:50:59Z</time>
+				<extensions>
+					<speed>0.2608073651790619</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:00Z</time>
+				<extensions>
+					<speed>0.022227603942155838</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:51:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:52:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:53:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:54:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:55:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:56:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:56:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:56:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:56:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:56:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:56:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:56:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:56:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:56:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:56:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:56:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:56:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:56:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:56:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:56:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337066758701" lon="-84.21697692886227">
+				<ele>956.2060107374564</ele>
+				<time>2017-10-02T17:56:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014334719956741" lon="-84.21697853918758">
+				<ele>956.1370367798954</ele>
+				<time>2017-10-02T17:56:16Z</time>
+				<extensions>
+					<speed>0.6066535115242004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330386810773" lon="-84.21698154696955">
+				<ele>956.0744918519631</ele>
+				<time>2017-10-02T17:56:17Z</time>
+				<extensions>
+					<speed>0.4508172571659088</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:56:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:57:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:57:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:57:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:57:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327495512003" lon="-84.21698250459936">
+				<ele>956.0518778031692</ele>
+				<time>2017-10-02T17:57:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327879070818" lon="-84.21697949155848">
+				<ele>955.923126350157</ele>
+				<time>2017-10-02T17:57:05Z</time>
+				<extensions>
+					<speed>0.6865362524986267</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014326155087915" lon="-84.21698198050633">
+				<ele>955.9686112524942</ele>
+				<time>2017-10-02T17:57:06Z</time>
+				<extensions>
+					<speed>0.5358713865280151</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432478829771" lon="-84.2169848636829">
+				<ele>955.8452949216589</ele>
+				<time>2017-10-02T17:57:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014322512587098" lon="-84.21697673303508">
+				<ele>956.7277000574395</ele>
+				<time>2017-10-02T17:57:51Z</time>
+				<extensions>
+					<speed>0.8240898847579956</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014321969996283" lon="-84.21696563200872">
+				<ele>957.2363325012848</ele>
+				<time>2017-10-02T17:57:52Z</time>
+				<extensions>
+					<speed>0.9391586780548096</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014323534031586" lon="-84.21695221364581">
+				<ele>958.1172402435914</ele>
+				<time>2017-10-02T17:57:53Z</time>
+				<extensions>
+					<speed>1.2944798469543457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014326532847596" lon="-84.21693445593716">
+				<ele>957.1133289737627</ele>
+				<time>2017-10-02T17:57:54Z</time>
+				<extensions>
+					<speed>1.5308020114898682</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014332551451547" lon="-84.21691423019672">
+				<ele>956.2525178305805</ele>
+				<time>2017-10-02T17:57:55Z</time>
+				<extensions>
+					<speed>1.9587119817733765</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014336153940695" lon="-84.21689050647416">
+				<ele>955.0270470557734</ele>
+				<time>2017-10-02T17:57:56Z</time>
+				<extensions>
+					<speed>1.9497151374816895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337193748409" lon="-84.21686625615342">
+				<ele>953.7299948334694</ele>
+				<time>2017-10-02T17:57:57Z</time>
+				<extensions>
+					<speed>1.9853891134262085</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014340549226024" lon="-84.21684335444938">
+				<ele>952.6208080928773</ele>
+				<time>2017-10-02T17:57:58Z</time>
+				<extensions>
+					<speed>1.8049832582473755</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014344761998638" lon="-84.2168235285779">
+				<ele>951.4047568570822</ele>
+				<time>2017-10-02T17:57:59Z</time>
+				<extensions>
+					<speed>1.5027884244918823</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014347829406965" lon="-84.21680956938961">
+				<ele>950.831694140099</ele>
+				<time>2017-10-02T17:58:00Z</time>
+				<extensions>
+					<speed>0.6769958138465881</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014347845062746" lon="-84.21680387068265">
+				<ele>950.7579340329394</ele>
+				<time>2017-10-02T17:58:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014347893152001" lon="-84.21680252264468">
+				<ele>950.3949980353937</ele>
+				<time>2017-10-02T17:58:02Z</time>
+				<extensions>
+					<speed>0.03090248629450798</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014347893152001" lon="-84.21680252264468">
+				<ele>950.3949980353937</ele>
+				<time>2017-10-02T17:58:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014347893152001" lon="-84.21680252264468">
+				<ele>950.3949980353937</ele>
+				<time>2017-10-02T17:58:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014347893152001" lon="-84.21680252264468">
+				<ele>950.3949980353937</ele>
+				<time>2017-10-02T17:58:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014347893152001" lon="-84.21680252264468">
+				<ele>950.3949980353937</ele>
+				<time>2017-10-02T17:58:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014347893152001" lon="-84.21680252264468">
+				<ele>950.3949980353937</ele>
+				<time>2017-10-02T17:58:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350375024074" lon="-84.21679685022421">
+				<ele>950.8385464251041</ele>
+				<time>2017-10-02T17:58:08Z</time>
+				<extensions>
+					<speed>0.9202747941017151</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01435470780814" lon="-84.21678595785983">
+				<ele>951.0875382237136</ele>
+				<time>2017-10-02T17:58:09Z</time>
+				<extensions>
+					<speed>1.420143485069275</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01435842471475" lon="-84.21677196598782">
+				<ele>951.2692050775513</ele>
+				<time>2017-10-02T17:58:10Z</time>
+				<extensions>
+					<speed>1.5476304292678833</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014362375882325" lon="-84.21675848969191">
+				<ele>951.2071722541004</ele>
+				<time>2017-10-02T17:58:11Z</time>
+				<extensions>
+					<speed>1.319106936454773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014364219921758" lon="-84.21674520460431">
+				<ele>950.9388347389176</ele>
+				<time>2017-10-02T17:58:12Z</time>
+				<extensions>
+					<speed>1.0576988458633423</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014366175234219" lon="-84.2167298167239">
+				<ele>950.9402814283967</ele>
+				<time>2017-10-02T17:58:13Z</time>
+				<extensions>
+					<speed>1.6864349842071533</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014367740964243" lon="-84.21671046585155">
+				<ele>951.1309731267393</ele>
+				<time>2017-10-02T17:58:14Z</time>
+				<extensions>
+					<speed>1.5987036228179932</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014368558533363" lon="-84.2166910161548">
+				<ele>951.3422015970573</ele>
+				<time>2017-10-02T17:58:15Z</time>
+				<extensions>
+					<speed>1.5918081998825073</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014370525102205" lon="-84.2166735485361">
+				<ele>951.8739037681371</ele>
+				<time>2017-10-02T17:58:16Z</time>
+				<extensions>
+					<speed>1.3801612854003906</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437204225172" lon="-84.21665902905491">
+				<ele>952.2658637687564</ele>
+				<time>2017-10-02T17:58:17Z</time>
+				<extensions>
+					<speed>1.100595474243164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014372427864002" lon="-84.21665120388421">
+				<ele>952.4488644404337</ele>
+				<time>2017-10-02T17:58:18Z</time>
+				<extensions>
+					<speed>0.344823956489563</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:19Z</time>
+				<extensions>
+					<speed>0.042861904948949814</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437062050446" lon="-84.2166497974771">
+				<ele>952.4885867927223</ele>
+				<time>2017-10-02T17:58:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014372680424762" lon="-84.21664500843363">
+				<ele>952.7459985539317</ele>
+				<time>2017-10-02T17:58:56Z</time>
+				<extensions>
+					<speed>0.8668198585510254</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014377127836896" lon="-84.21663206783717">
+				<ele>953.0433081081137</ele>
+				<time>2017-10-02T17:58:57Z</time>
+				<extensions>
+					<speed>2.0152313709259033</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014383628687217" lon="-84.21660846057063">
+				<ele>953.1359058767557</ele>
+				<time>2017-10-02T17:58:58Z</time>
+				<extensions>
+					<speed>3.318927764892578</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01439202917951" lon="-84.21657679238429">
+				<ele>953.6096782330424</ele>
+				<time>2017-10-02T17:58:59Z</time>
+				<extensions>
+					<speed>3.7980430126190186</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014403218884475" lon="-84.2165376548737">
+				<ele>954.0799745777622</ele>
+				<time>2017-10-02T17:59:00Z</time>
+				<extensions>
+					<speed>4.763948917388916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014417374925086" lon="-84.21649246275261">
+				<ele>954.5295989559963</ele>
+				<time>2017-10-02T17:59:01Z</time>
+				<extensions>
+					<speed>5.220850944519043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014432497127714" lon="-84.21644392520129">
+				<ele>954.6424125386402</ele>
+				<time>2017-10-02T17:59:02Z</time>
+				<extensions>
+					<speed>5.32058572769165</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0144469168558" lon="-84.21639297688098">
+				<ele>955.073087034747</ele>
+				<time>2017-10-02T17:59:03Z</time>
+				<extensions>
+					<speed>5.624999523162842</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014460671969546" lon="-84.21633965921497">
+				<ele>955.1709293089807</ele>
+				<time>2017-10-02T17:59:04Z</time>
+				<extensions>
+					<speed>5.841805934906006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014475337089845" lon="-84.21628476498866">
+				<ele>955.1842974741012</ele>
+				<time>2017-10-02T17:59:05Z</time>
+				<extensions>
+					<speed>6.017167568206787</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014492585294356" lon="-84.21622939074196">
+				<ele>955.2591335307807</ele>
+				<time>2017-10-02T17:59:06Z</time>
+				<extensions>
+					<speed>5.911483287811279</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014508160998487" lon="-84.21617796087146">
+				<ele>955.1056176247075</ele>
+				<time>2017-10-02T17:59:07Z</time>
+				<extensions>
+					<speed>5.242839813232422</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014522319149467" lon="-84.2161339010997">
+				<ele>954.9970748145133</ele>
+				<time>2017-10-02T17:59:08Z</time>
+				<extensions>
+					<speed>4.518540382385254</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014535180268595" lon="-84.21609536714533">
+				<ele>954.5792931439355</ele>
+				<time>2017-10-02T17:59:09Z</time>
+				<extensions>
+					<speed>3.9551100730895996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014546047376816" lon="-84.2160612187404">
+				<ele>954.5171235185117</ele>
+				<time>2017-10-02T17:59:10Z</time>
+				<extensions>
+					<speed>3.4311883449554443</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014554064586065" lon="-84.21602950838144">
+				<ele>954.4973454885185</ele>
+				<time>2017-10-02T17:59:11Z</time>
+				<extensions>
+					<speed>2.9575841426849365</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014560321840058" lon="-84.21600455949681">
+				<ele>954.4417558684945</ele>
+				<time>2017-10-02T17:59:12Z</time>
+				<extensions>
+					<speed>2.3422255516052246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014566082451106" lon="-84.21598605401142">
+				<ele>954.4458088157699</ele>
+				<time>2017-10-02T17:59:13Z</time>
+				<extensions>
+					<speed>1.6569325923919678</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01457051014746" lon="-84.21597365298983">
+				<ele>954.5414824644104</ele>
+				<time>2017-10-02T17:59:14Z</time>
+				<extensions>
+					<speed>0.8043724298477173</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014573475793982" lon="-84.21596655884835">
+				<ele>955.1522606164217</ele>
+				<time>2017-10-02T17:59:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014573475793982" lon="-84.21596655884835">
+				<ele>955.1522606164217</ele>
+				<time>2017-10-02T17:59:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014575901439759" lon="-84.21596969458872">
+				<ele>955.2498499136418</ele>
+				<time>2017-10-02T17:59:17Z</time>
+				<extensions>
+					<speed>0.7688086032867432</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014573475793982" lon="-84.21596655884835">
+				<ele>955.1522606164217</ele>
+				<time>2017-10-02T17:59:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014573475793982" lon="-84.21596655884835">
+				<ele>955.1522606164217</ele>
+				<time>2017-10-02T17:59:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014573475793982" lon="-84.21596655884835">
+				<ele>955.1522606164217</ele>
+				<time>2017-10-02T17:59:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014573475793982" lon="-84.21596655884835">
+				<ele>955.1522606164217</ele>
+				<time>2017-10-02T17:59:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0145767174725" lon="-84.21595958286397">
+				<ele>955.4597738664597</ele>
+				<time>2017-10-02T17:59:22Z</time>
+				<extensions>
+					<speed>1.0538105964660645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014583290228096" lon="-84.21594406462152">
+				<ele>955.961253201589</ele>
+				<time>2017-10-02T17:59:23Z</time>
+				<extensions>
+					<speed>2.3418726921081543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014591493916756" lon="-84.21591895566763">
+				<ele>956.1913723275065</ele>
+				<time>2017-10-02T17:59:24Z</time>
+				<extensions>
+					<speed>3.0851643085479736</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014600187978024" lon="-84.21588738348672">
+				<ele>956.4160521030426</ele>
+				<time>2017-10-02T17:59:25Z</time>
+				<extensions>
+					<speed>3.6020114421844482</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014609319049974" lon="-84.21585156448302">
+				<ele>956.5362763637677</ele>
+				<time>2017-10-02T17:59:26Z</time>
+				<extensions>
+					<speed>3.9844813346862793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014618240991743" lon="-84.21580974126965">
+				<ele>956.5373671231791</ele>
+				<time>2017-10-02T17:59:27Z</time>
+				<extensions>
+					<speed>4.723381996154785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014627465147456" lon="-84.21576337096768">
+				<ele>956.6769982976839</ele>
+				<time>2017-10-02T17:59:28Z</time>
+				<extensions>
+					<speed>5.122822284698486</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014638561682517" lon="-84.21571520176992">
+				<ele>956.8930059494451</ele>
+				<time>2017-10-02T17:59:29Z</time>
+				<extensions>
+					<speed>5.336277484893799</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014650849074794" lon="-84.21566614973683">
+				<ele>957.1024564607069</ele>
+				<time>2017-10-02T17:59:30Z</time>
+				<extensions>
+					<speed>5.321689605712891</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014663642378386" lon="-84.21561956202635">
+				<ele>957.3679234106094</ele>
+				<time>2017-10-02T17:59:31Z</time>
+				<extensions>
+					<speed>5.284755229949951</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014677768408191" lon="-84.21557367019739">
+				<ele>957.4951637508348</ele>
+				<time>2017-10-02T17:59:32Z</time>
+				<extensions>
+					<speed>5.086033344268799</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014689691941244" lon="-84.21552926694893">
+				<ele>957.6030641598627</ele>
+				<time>2017-10-02T17:59:33Z</time>
+				<extensions>
+					<speed>4.705542087554932</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014700249137992" lon="-84.21548955534585">
+				<ele>957.9273614613339</ele>
+				<time>2017-10-02T17:59:34Z</time>
+				<extensions>
+					<speed>3.9014594554901123</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014709752362744" lon="-84.21546020709945">
+				<ele>958.4167865850031</ele>
+				<time>2017-10-02T17:59:35Z</time>
+				<extensions>
+					<speed>2.632096767425537</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014714237391496" lon="-84.21544492557449">
+				<ele>958.3218138767406</ele>
+				<time>2017-10-02T17:59:36Z</time>
+				<extensions>
+					<speed>0.435846209526062</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014712123531607" lon="-84.21544205553815">
+				<ele>957.9029334578663</ele>
+				<time>2017-10-02T17:59:37Z</time>
+				<extensions>
+					<speed>0.27603113651275635</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014712123531607" lon="-84.21544205553815">
+				<ele>957.9029334578663</ele>
+				<time>2017-10-02T17:59:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014712123531607" lon="-84.21544205553815">
+				<ele>957.9029334578663</ele>
+				<time>2017-10-02T17:59:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014712123531607" lon="-84.21544205553815">
+				<ele>957.9029334578663</ele>
+				<time>2017-10-02T17:59:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014712123531607" lon="-84.21544205553815">
+				<ele>957.9029334578663</ele>
+				<time>2017-10-02T17:59:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014712123531607" lon="-84.21544205553815">
+				<ele>957.9029334578663</ele>
+				<time>2017-10-02T17:59:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014712123531607" lon="-84.21544205553815">
+				<ele>957.9029334578663</ele>
+				<time>2017-10-02T17:59:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014712123531607" lon="-84.21544205553815">
+				<ele>957.9029334578663</ele>
+				<time>2017-10-02T17:59:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014712123531607" lon="-84.21544205553815">
+				<ele>957.9029334578663</ele>
+				<time>2017-10-02T17:59:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014712123531607" lon="-84.21544205553815">
+				<ele>957.9029334578663</ele>
+				<time>2017-10-02T17:59:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014712123531607" lon="-84.21544205553815">
+				<ele>957.9029334578663</ele>
+				<time>2017-10-02T17:59:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014712504430905" lon="-84.2154349906834">
+				<ele>956.9123176615685</ele>
+				<time>2017-10-02T17:59:48Z</time>
+				<extensions>
+					<speed>0.8720097541809082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014719447434683" lon="-84.2154200485651">
+				<ele>956.1201392142102</ele>
+				<time>2017-10-02T17:59:49Z</time>
+				<extensions>
+					<speed>1.9747196435928345</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014729010833234" lon="-84.21539053667598">
+				<ele>956.4374746978283</ele>
+				<time>2017-10-02T17:59:50Z</time>
+				<extensions>
+					<speed>2.921670913696289</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01473552834807" lon="-84.21535614284731">
+				<ele>956.4621211085469</ele>
+				<time>2017-10-02T17:59:51Z</time>
+				<extensions>
+					<speed>3.3970980644226074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014743785791895" lon="-84.21532191852131">
+				<ele>956.2465995550156</ele>
+				<time>2017-10-02T17:59:52Z</time>
+				<extensions>
+					<speed>3.775456666946411</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014750042340639" lon="-84.21528789538087">
+				<ele>955.3792870566249</ele>
+				<time>2017-10-02T17:59:53Z</time>
+				<extensions>
+					<speed>3.559619188308716</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014755174273578" lon="-84.21525807721571">
+				<ele>955.0655466169119</ele>
+				<time>2017-10-02T17:59:54Z</time>
+				<extensions>
+					<speed>3.0530192852020264</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014760372646041" lon="-84.21523283997207">
+				<ele>954.9395887544379</ele>
+				<time>2017-10-02T17:59:55Z</time>
+				<extensions>
+					<speed>2.5220680236816406</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014763878250582" lon="-84.21521242680689">
+				<ele>954.5509226545691</ele>
+				<time>2017-10-02T17:59:56Z</time>
+				<extensions>
+					<speed>1.9623905420303345</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01476791327806" lon="-84.21519985385984">
+				<ele>954.430605540052</ele>
+				<time>2017-10-02T17:59:57Z</time>
+				<extensions>
+					<speed>1.1287840604782104</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014775248427906" lon="-84.2151944236482">
+				<ele>954.3321699993685</ele>
+				<time>2017-10-02T17:59:58Z</time>
+				<extensions>
+					<speed>1.0625598430633545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014786875162342" lon="-84.2151887915307">
+				<ele>954.5174725726247</ele>
+				<time>2017-10-02T17:59:59Z</time>
+				<extensions>
+					<speed>1.4548413753509521</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014796820466811" lon="-84.2151772451716">
+				<ele>954.6492899097502</ele>
+				<time>2017-10-02T18:00:00Z</time>
+				<extensions>
+					<speed>1.4217524528503418</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014802381792803" lon="-84.21516366100921">
+				<ele>954.8369768457487</ele>
+				<time>2017-10-02T18:00:01Z</time>
+				<extensions>
+					<speed>1.3054208755493164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014803237069344" lon="-84.21515185325458">
+				<ele>954.7289367904887</ele>
+				<time>2017-10-02T18:00:02Z</time>
+				<extensions>
+					<speed>0.9778259992599487</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014803237069344" lon="-84.21515185325458">
+				<ele>954.7289367904887</ele>
+				<time>2017-10-02T18:00:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014800212438972" lon="-84.2151489153488">
+				<ele>953.9876718847081</ele>
+				<time>2017-10-02T18:00:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014799654045369" lon="-84.21514124787463">
+				<ele>953.8897512210533</ele>
+				<time>2017-10-02T18:00:26Z</time>
+				<extensions>
+					<speed>1.2469621896743774</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014803095985362" lon="-84.2151232893657">
+				<ele>953.6762415105477</ele>
+				<time>2017-10-02T18:00:27Z</time>
+				<extensions>
+					<speed>2.3904805183410645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014807634730344" lon="-84.21509624955596">
+				<ele>953.698460190557</ele>
+				<time>2017-10-02T18:00:28Z</time>
+				<extensions>
+					<speed>3.2366111278533936</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01481371926986" lon="-84.21506129424841">
+				<ele>953.4874140629545</ele>
+				<time>2017-10-02T18:00:29Z</time>
+				<extensions>
+					<speed>4.0594940185546875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014822679537867" lon="-84.21501896043873">
+				<ele>953.4867710964754</ele>
+				<time>2017-10-02T18:00:30Z</time>
+				<extensions>
+					<speed>4.893763542175293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014833288254263" lon="-84.21496906261306">
+				<ele>953.398874219507</ele>
+				<time>2017-10-02T18:00:31Z</time>
+				<extensions>
+					<speed>5.576037883758545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01484327693453" lon="-84.21491532095642">
+				<ele>953.3640248570591</ele>
+				<time>2017-10-02T18:00:32Z</time>
+				<extensions>
+					<speed>5.861454486846924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014853454515961" lon="-84.21485911786804">
+				<ele>953.3904505111277</ele>
+				<time>2017-10-02T18:00:33Z</time>
+				<extensions>
+					<speed>6.228487491607666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014865931764893" lon="-84.21479936420428">
+				<ele>953.8444092404097</ele>
+				<time>2017-10-02T18:00:34Z</time>
+				<extensions>
+					<speed>6.592861175537109</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014881977347695" lon="-84.21473927647358">
+				<ele>954.1357765942812</ele>
+				<time>2017-10-02T18:00:35Z</time>
+				<extensions>
+					<speed>6.749434947967529</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01490012997224" lon="-84.21468071273995">
+				<ele>954.2666942020878</ele>
+				<time>2017-10-02T18:00:36Z</time>
+				<extensions>
+					<speed>6.492547512054443</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014917054675605" lon="-84.21462465773801">
+				<ele>954.356144153513</ele>
+				<time>2017-10-02T18:00:37Z</time>
+				<extensions>
+					<speed>6.272485733032227</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014932374167772" lon="-84.21456623589434">
+				<ele>954.4068920854479</ele>
+				<time>2017-10-02T18:00:38Z</time>
+				<extensions>
+					<speed>6.6767659187316895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014944046825564" lon="-84.21450524014894">
+				<ele>954.4528083764017</ele>
+				<time>2017-10-02T18:00:39Z</time>
+				<extensions>
+					<speed>6.704281806945801</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014957812503313" lon="-84.21444561799449">
+				<ele>954.4817141601816</ele>
+				<time>2017-10-02T18:00:40Z</time>
+				<extensions>
+					<speed>6.615530490875244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014970580345894" lon="-84.2143888917657">
+				<ele>954.477040886879</ele>
+				<time>2017-10-02T18:00:41Z</time>
+				<extensions>
+					<speed>6.2909698486328125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01498282548399" lon="-84.21433711930099">
+				<ele>954.5955891618505</ele>
+				<time>2017-10-02T18:00:42Z</time>
+				<extensions>
+					<speed>5.620316505432129</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014990820453795" lon="-84.21428802741397">
+				<ele>954.5181518597528</ele>
+				<time>2017-10-02T18:00:43Z</time>
+				<extensions>
+					<speed>5.208737850189209</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014997480193022" lon="-84.2142449968628">
+				<ele>954.4722692025825</ele>
+				<time>2017-10-02T18:00:44Z</time>
+				<extensions>
+					<speed>4.699769496917725</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015005451190133" lon="-84.21420820840548">
+				<ele>954.114957136102</ele>
+				<time>2017-10-02T18:00:45Z</time>
+				<extensions>
+					<speed>3.854679584503174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015012223413443" lon="-84.21418222366867">
+				<ele>953.7934899898246</ele>
+				<time>2017-10-02T18:00:46Z</time>
+				<extensions>
+					<speed>2.275785207748413</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01501553911299" lon="-84.21417023542674">
+				<ele>953.6874747909606</ele>
+				<time>2017-10-02T18:00:47Z</time>
+				<extensions>
+					<speed>0.501464307308197</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015017407714758" lon="-84.21416919433376">
+				<ele>953.3319349139929</ele>
+				<time>2017-10-02T18:00:48Z</time>
+				<extensions>
+					<speed>0.05852174758911133</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015017407714758" lon="-84.21416919433376">
+				<ele>953.3319349139929</ele>
+				<time>2017-10-02T18:00:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015020257112223" lon="-84.21417863942348">
+				<ele>953.4571060668677</ele>
+				<time>2017-10-02T18:00:50Z</time>
+				<extensions>
+					<speed>1.3134278059005737</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015020695852963" lon="-84.21418912356201">
+				<ele>954.0241599818692</ele>
+				<time>2017-10-02T18:00:51Z</time>
+				<extensions>
+					<speed>1.1569643020629883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015018497197431" lon="-84.21419897016278">
+				<ele>954.5610426608473</ele>
+				<time>2017-10-02T18:00:52Z</time>
+				<extensions>
+					<speed>1.0178905725479126</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01501564811762" lon="-84.21420597400646">
+				<ele>954.8324441267177</ele>
+				<time>2017-10-02T18:00:53Z</time>
+				<extensions>
+					<speed>0.6793622970581055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01501564811762" lon="-84.21420597400646">
+				<ele>954.8324441267177</ele>
+				<time>2017-10-02T18:00:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015015130277515" lon="-84.21420683972985">
+				<ele>955.1905904514715</ele>
+				<time>2017-10-02T18:00:55Z</time>
+				<extensions>
+					<speed>0.02504708431661129</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015015130277515" lon="-84.21420683972985">
+				<ele>955.1905904514715</ele>
+				<time>2017-10-02T18:00:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015015130277515" lon="-84.21420683972985">
+				<ele>955.1905904514715</ele>
+				<time>2017-10-02T18:00:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015015130277515" lon="-84.21420683972985">
+				<ele>955.1905904514715</ele>
+				<time>2017-10-02T18:00:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015015130277515" lon="-84.21420683972985">
+				<ele>955.1905904514715</ele>
+				<time>2017-10-02T18:00:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015017508660359" lon="-84.21420380942293">
+				<ele>955.9083875054494</ele>
+				<time>2017-10-02T18:01:00Z</time>
+				<extensions>
+					<speed>0.7588188052177429</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015022278863396" lon="-84.21419449240503">
+				<ele>956.2579029267654</ele>
+				<time>2017-10-02T18:01:01Z</time>
+				<extensions>
+					<speed>1.7279043197631836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015034800660878" lon="-84.21417511416175">
+				<ele>956.66934628319</ele>
+				<time>2017-10-02T18:01:02Z</time>
+				<extensions>
+					<speed>3.014533519744873</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015052231562375" lon="-84.21414552265954">
+				<ele>956.9764978373423</ele>
+				<time>2017-10-02T18:01:03Z</time>
+				<extensions>
+					<speed>4.228298664093018</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015071283947286" lon="-84.21410444958495">
+				<ele>957.2608184423298</ele>
+				<time>2017-10-02T18:01:04Z</time>
+				<extensions>
+					<speed>5.188246726989746</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015088362385328" lon="-84.21405586407538">
+				<ele>957.3119797166437</ele>
+				<time>2017-10-02T18:01:05Z</time>
+				<extensions>
+					<speed>5.766726970672607</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0151064314369" lon="-84.21400154045948">
+				<ele>957.2386527061462</ele>
+				<time>2017-10-02T18:01:06Z</time>
+				<extensions>
+					<speed>6.235392093658447</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015123409799974" lon="-84.21393900036162">
+				<ele>957.3595338724554</ele>
+				<time>2017-10-02T18:01:07Z</time>
+				<extensions>
+					<speed>6.820333003997803</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015137080985811" lon="-84.21387454642752">
+				<ele>957.1702867439017</ele>
+				<time>2017-10-02T18:01:08Z</time>
+				<extensions>
+					<speed>7.105033874511719</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01515014382961" lon="-84.21380629754812">
+				<ele>957.1694487854838</ele>
+				<time>2017-10-02T18:01:09Z</time>
+				<extensions>
+					<speed>7.300590991973877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015158764732314" lon="-84.21374086018602">
+				<ele>957.1134823318571</ele>
+				<time>2017-10-02T18:01:10Z</time>
+				<extensions>
+					<speed>7.195811748504639</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015169768193225" lon="-84.2136742513218">
+				<ele>957.2494018096477</ele>
+				<time>2017-10-02T18:01:11Z</time>
+				<extensions>
+					<speed>7.324404716491699</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015181102254513" lon="-84.21360607066757">
+				<ele>957.3046226175502</ele>
+				<time>2017-10-02T18:01:12Z</time>
+				<extensions>
+					<speed>7.463953971862793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191626356758" lon="-84.21353931642516">
+				<ele>957.5515110567212</ele>
+				<time>2017-10-02T18:01:13Z</time>
+				<extensions>
+					<speed>7.097379684448242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015203103277068" lon="-84.21347808147702">
+				<ele>957.79980566632</ele>
+				<time>2017-10-02T18:01:14Z</time>
+				<extensions>
+					<speed>6.387394905090332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015212842310495" lon="-84.21342450868512">
+				<ele>958.1147662587464</ele>
+				<time>2017-10-02T18:01:15Z</time>
+				<extensions>
+					<speed>5.6693549156188965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01521686474903" lon="-84.21338220540358">
+				<ele>957.6836223099381</ele>
+				<time>2017-10-02T18:01:16Z</time>
+				<extensions>
+					<speed>4.0504937171936035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015225042128982" lon="-84.21335990644047">
+				<ele>957.6889803111553</ele>
+				<time>2017-10-02T18:01:17Z</time>
+				<extensions>
+					<speed>1.7451648712158203</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01522919316879" lon="-84.21335514145177">
+				<ele>958.1462037069723</ele>
+				<time>2017-10-02T18:01:18Z</time>
+				<extensions>
+					<speed>0.12537160515785217</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233625815545" lon="-84.2133664887642">
+				<ele>957.4838182814419</ele>
+				<time>2017-10-02T18:01:19Z</time>
+				<extensions>
+					<speed>0.7653456926345825</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233625815545" lon="-84.2133664887642">
+				<ele>957.4838182814419</ele>
+				<time>2017-10-02T18:01:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015235537285589" lon="-84.21336995619676">
+				<ele>954.173608686775</ele>
+				<time>2017-10-02T18:01:21Z</time>
+				<extensions>
+					<speed>0.4444352984428406</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015235537285589" lon="-84.21336995619676">
+				<ele>954.173608686775</ele>
+				<time>2017-10-02T18:01:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:23Z</time>
+				<extensions>
+					<speed>0.14161527156829834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233907385266" lon="-84.21337146730374">
+				<ele>953.2061686366796</ele>
+				<time>2017-10-02T18:01:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015236256809553" lon="-84.21336592459392">
+				<ele>953.4204580672085</ele>
+				<time>2017-10-02T18:02:00Z</time>
+				<extensions>
+					<speed>0.8362992405891418</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01523988588347" lon="-84.21335587941022">
+				<ele>953.7467855419964</ele>
+				<time>2017-10-02T18:02:01Z</time>
+				<extensions>
+					<speed>1.3328748941421509</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015243274096374" lon="-84.2133441524472">
+				<ele>954.1361898258328</ele>
+				<time>2017-10-02T18:02:02Z</time>
+				<extensions>
+					<speed>1.3382259607315063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015246833680976" lon="-84.21333098180746">
+				<ele>954.440021013841</ele>
+				<time>2017-10-02T18:02:03Z</time>
+				<extensions>
+					<speed>1.5350176095962524</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015249538340054" lon="-84.21331668436329">
+				<ele>954.640972757712</ele>
+				<time>2017-10-02T18:02:04Z</time>
+				<extensions>
+					<speed>1.8350411653518677</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015253725969272" lon="-84.21329568512547">
+				<ele>954.804322087206</ele>
+				<time>2017-10-02T18:02:05Z</time>
+				<extensions>
+					<speed>2.3370258808135986</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015263979511547" lon="-84.21326655396619">
+				<ele>954.8743322249502</ele>
+				<time>2017-10-02T18:02:06Z</time>
+				<extensions>
+					<speed>3.4184396266937256</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015272786538802" lon="-84.21323406832987">
+				<ele>954.9765740297735</ele>
+				<time>2017-10-02T18:02:07Z</time>
+				<extensions>
+					<speed>3.77278208732605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01528427196375" lon="-84.21319007280209">
+				<ele>955.1319019980729</ele>
+				<time>2017-10-02T18:02:08Z</time>
+				<extensions>
+					<speed>4.389019012451172</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015301979167868" lon="-84.21314207349914">
+				<ele>955.162494928576</ele>
+				<time>2017-10-02T18:02:09Z</time>
+				<extensions>
+					<speed>4.970666885375977</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015320498217582" lon="-84.21308921977578">
+				<ele>955.3029274577275</ele>
+				<time>2017-10-02T18:02:10Z</time>
+				<extensions>
+					<speed>5.6326069831848145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015342549556477" lon="-84.21303444685854">
+				<ele>955.3348403405398</ele>
+				<time>2017-10-02T18:02:11Z</time>
+				<extensions>
+					<speed>5.8620147705078125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015356624276425" lon="-84.21297775968033">
+				<ele>955.6028938237578</ele>
+				<time>2017-10-02T18:02:12Z</time>
+				<extensions>
+					<speed>6.027309417724609</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015367676844935" lon="-84.21292353067402">
+				<ele>955.8011001618579</ele>
+				<time>2017-10-02T18:02:13Z</time>
+				<extensions>
+					<speed>6.189309120178223</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015381059878363" lon="-84.21287299197596">
+				<ele>955.8987697083503</ele>
+				<time>2017-10-02T18:02:14Z</time>
+				<extensions>
+					<speed>5.838055610656738</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015398640138239" lon="-84.2128253229954">
+				<ele>956.057395638898</ele>
+				<time>2017-10-02T18:02:15Z</time>
+				<extensions>
+					<speed>5.37569522857666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015412539004801" lon="-84.21278062205155">
+				<ele>956.1454023141414</ele>
+				<time>2017-10-02T18:02:16Z</time>
+				<extensions>
+					<speed>5.182714462280273</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015422845941991" lon="-84.21274630216043">
+				<ele>956.2900637257844</ele>
+				<time>2017-10-02T18:02:17Z</time>
+				<extensions>
+					<speed>4.258821487426758</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015434487689301" lon="-84.21270148646002">
+				<ele>956.2533895326778</ele>
+				<time>2017-10-02T18:02:18Z</time>
+				<extensions>
+					<speed>4.665159225463867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015446079104787" lon="-84.21265198102748">
+				<ele>956.4607838643715</ele>
+				<time>2017-10-02T18:02:19Z</time>
+				<extensions>
+					<speed>5.015297889709473</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015461061254241" lon="-84.21259605293245">
+				<ele>956.806292373687</ele>
+				<time>2017-10-02T18:02:20Z</time>
+				<extensions>
+					<speed>5.558608055114746</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015475042579329" lon="-84.21253583855695">
+				<ele>957.1213091006503</ele>
+				<time>2017-10-02T18:02:21Z</time>
+				<extensions>
+					<speed>5.885952472686768</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015494338127487" lon="-84.21248572543804">
+				<ele>957.2750895926729</ele>
+				<time>2017-10-02T18:02:22Z</time>
+				<extensions>
+					<speed>5.625519752502441</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015507707612278" lon="-84.21243756324508">
+				<ele>957.3232771167532</ele>
+				<time>2017-10-02T18:02:23Z</time>
+				<extensions>
+					<speed>5.6216721534729</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015519460845724" lon="-84.21238821560243">
+				<ele>957.7527165310457</ele>
+				<time>2017-10-02T18:02:24Z</time>
+				<extensions>
+					<speed>5.311084747314453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01553047492257" lon="-84.21234560022438">
+				<ele>958.5550368465483</ele>
+				<time>2017-10-02T18:02:25Z</time>
+				<extensions>
+					<speed>5.132873058319092</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015538975648358" lon="-84.21229331844918">
+				<ele>959.1420258013532</ele>
+				<time>2017-10-02T18:02:26Z</time>
+				<extensions>
+					<speed>5.7771220207214355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015547071208124" lon="-84.21224181155843">
+				<ele>959.6267098374665</ele>
+				<time>2017-10-02T18:02:27Z</time>
+				<extensions>
+					<speed>5.640500068664551</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01556101533708" lon="-84.21219032989741">
+				<ele>959.881581700407</ele>
+				<time>2017-10-02T18:02:28Z</time>
+				<extensions>
+					<speed>5.8744659423828125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015575145025945" lon="-84.21213545852697">
+				<ele>960.205487488769</ele>
+				<time>2017-10-02T18:02:29Z</time>
+				<extensions>
+					<speed>5.6850481033325195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015589319218932" lon="-84.21208343790829">
+				<ele>960.6011230330914</ele>
+				<time>2017-10-02T18:02:30Z</time>
+				<extensions>
+					<speed>5.417128086090088</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015603154066396" lon="-84.21203754301537">
+				<ele>960.9201499875635</ele>
+				<time>2017-10-02T18:02:31Z</time>
+				<extensions>
+					<speed>4.803653717041016</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015615175378441" lon="-84.21199471647027">
+				<ele>961.2431139051914</ele>
+				<time>2017-10-02T18:02:32Z</time>
+				<extensions>
+					<speed>4.429784774780273</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015624654542073" lon="-84.21195545040749">
+				<ele>961.5141583159566</ele>
+				<time>2017-10-02T18:02:33Z</time>
+				<extensions>
+					<speed>3.6773362159729004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015629601342901" lon="-84.2119263482806">
+				<ele>961.9251284422353</ele>
+				<time>2017-10-02T18:02:34Z</time>
+				<extensions>
+					<speed>1.8810851573944092</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015631388636061" lon="-84.21191322340415">
+				<ele>962.3366262800992</ele>
+				<time>2017-10-02T18:02:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015632108997096" lon="-84.21191303619929">
+				<ele>962.5436963252723</ele>
+				<time>2017-10-02T18:02:36Z</time>
+				<extensions>
+					<speed>0.5434918403625488</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0156309933847" lon="-84.21191745663288">
+				<ele>962.7211111271754</ele>
+				<time>2017-10-02T18:02:37Z</time>
+				<extensions>
+					<speed>0.7977458238601685</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0156309933847" lon="-84.21191745663288">
+				<ele>962.7211111271754</ele>
+				<time>2017-10-02T18:02:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01563087670054" lon="-84.21192271993561">
+				<ele>963.0497029377148</ele>
+				<time>2017-10-02T18:02:39Z</time>
+				<extensions>
+					<speed>0.766476571559906</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01563087670054" lon="-84.21192271993561">
+				<ele>963.0497029377148</ele>
+				<time>2017-10-02T18:02:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015631938675911" lon="-84.21192621552014">
+				<ele>963.3118428792804</ele>
+				<time>2017-10-02T18:02:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015631938675911" lon="-84.21192621552014">
+				<ele>963.3118428792804</ele>
+				<time>2017-10-02T18:02:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015631938675911" lon="-84.21192621552014">
+				<ele>963.3118428792804</ele>
+				<time>2017-10-02T18:02:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015631938675911" lon="-84.21192621552014">
+				<ele>963.3118428792804</ele>
+				<time>2017-10-02T18:02:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015631938675911" lon="-84.21192621552014">
+				<ele>963.3118428792804</ele>
+				<time>2017-10-02T18:02:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015631938675911" lon="-84.21192621552014">
+				<ele>963.3118428792804</ele>
+				<time>2017-10-02T18:02:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015631938675911" lon="-84.21192621552014">
+				<ele>963.3118428792804</ele>
+				<time>2017-10-02T18:02:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015631938675911" lon="-84.21192621552014">
+				<ele>963.3118428792804</ele>
+				<time>2017-10-02T18:02:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015631938675911" lon="-84.21192621552014">
+				<ele>963.3118428792804</ele>
+				<time>2017-10-02T18:02:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015631938675911" lon="-84.21192621552014">
+				<ele>963.3118428792804</ele>
+				<time>2017-10-02T18:02:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015631938675911" lon="-84.21192621552014">
+				<ele>963.3118428792804</ele>
+				<time>2017-10-02T18:02:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015631938675911" lon="-84.21192621552014">
+				<ele>963.3118428792804</ele>
+				<time>2017-10-02T18:02:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01563233281385" lon="-84.21192779700365">
+				<ele>963.3788018133491</ele>
+				<time>2017-10-02T18:02:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015633055665702" lon="-84.21192705456745">
+				<ele>963.5732811586931</ele>
+				<time>2017-10-02T18:02:54Z</time>
+				<extensions>
+					<speed>0.07453195005655289</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01563375605336" lon="-84.21192729501314">
+				<ele>963.811642896384</ele>
+				<time>2017-10-02T18:02:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01563375605336" lon="-84.21192729501314">
+				<ele>963.811642896384</ele>
+				<time>2017-10-02T18:02:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01563469667394" lon="-84.21191623795565">
+				<ele>963.1590196816251</ele>
+				<time>2017-10-02T18:02:57Z</time>
+				<extensions>
+					<speed>0.8546543121337891</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015640157576907" lon="-84.21190352895495">
+				<ele>963.2439808212221</ele>
+				<time>2017-10-02T18:02:58Z</time>
+				<extensions>
+					<speed>1.7848707437515259</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015649482807998" lon="-84.21188471203516">
+				<ele>963.5140697425231</ele>
+				<time>2017-10-02T18:02:59Z</time>
+				<extensions>
+					<speed>2.5189743041992188</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015673367308864" lon="-84.21184903090094">
+				<ele>964.6209046747535</ele>
+				<time>2017-10-02T18:03:00Z</time>
+				<extensions>
+					<speed>3.661489725112915</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015699380017008" lon="-84.21180941024834">
+				<ele>966.346015359275</ele>
+				<time>2017-10-02T18:03:01Z</time>
+				<extensions>
+					<speed>4.176239013671875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015713092394392" lon="-84.21176841554355">
+				<ele>966.9344613561407</ele>
+				<time>2017-10-02T18:03:02Z</time>
+				<extensions>
+					<speed>4.685634136199951</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015724880072797" lon="-84.21172212610581">
+				<ele>967.1233111061156</ele>
+				<time>2017-10-02T18:03:03Z</time>
+				<extensions>
+					<speed>4.98199987411499</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015736920332696" lon="-84.21167662005007">
+				<ele>967.3362196944654</ele>
+				<time>2017-10-02T18:03:04Z</time>
+				<extensions>
+					<speed>4.721370697021484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01574734137165" lon="-84.21163458948828">
+				<ele>967.4077721880749</ele>
+				<time>2017-10-02T18:03:05Z</time>
+				<extensions>
+					<speed>4.138529300689697</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01575593029988" lon="-84.21159892531907">
+				<ele>967.4583138413727</ele>
+				<time>2017-10-02T18:03:06Z</time>
+				<extensions>
+					<speed>3.5541224479675293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01576113306003" lon="-84.21157194530578">
+				<ele>967.4534012563527</ele>
+				<time>2017-10-02T18:03:07Z</time>
+				<extensions>
+					<speed>2.3862831592559814</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01576278271027" lon="-84.21155426504444">
+				<ele>967.3580874344334</ele>
+				<time>2017-10-02T18:03:08Z</time>
+				<extensions>
+					<speed>1.3131664991378784</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015761126888899" lon="-84.21154499797433">
+				<ele>967.2875225348398</ele>
+				<time>2017-10-02T18:03:09Z</time>
+				<extensions>
+					<speed>0.4903145730495453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015761126888899" lon="-84.21154499797433">
+				<ele>967.2875225348398</ele>
+				<time>2017-10-02T18:03:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01575920391928" lon="-84.21154766466442">
+				<ele>967.3081788010895</ele>
+				<time>2017-10-02T18:03:11Z</time>
+				<extensions>
+					<speed>0.41245225071907043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01575920391928" lon="-84.21154766466442">
+				<ele>967.3081788010895</ele>
+				<time>2017-10-02T18:03:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015757788470246" lon="-84.21155242792236">
+				<ele>967.3969625718892</ele>
+				<time>2017-10-02T18:03:13Z</time>
+				<extensions>
+					<speed>0.540778636932373</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015757788470246" lon="-84.21155242792236">
+				<ele>967.3969625718892</ele>
+				<time>2017-10-02T18:03:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015757961701672" lon="-84.21155332195423">
+				<ele>967.5820240480825</ele>
+				<time>2017-10-02T18:03:15Z</time>
+				<extensions>
+					<speed>0.04210586100816727</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015757961701672" lon="-84.21155332195423">
+				<ele>967.5820240480825</ele>
+				<time>2017-10-02T18:03:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015757961701672" lon="-84.21155332195423">
+				<ele>967.5820240480825</ele>
+				<time>2017-10-02T18:03:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015757961701672" lon="-84.21155332195423">
+				<ele>967.5820240480825</ele>
+				<time>2017-10-02T18:03:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015757961701672" lon="-84.21155332195423">
+				<ele>967.5820240480825</ele>
+				<time>2017-10-02T18:03:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015757961701672" lon="-84.21155332195423">
+				<ele>967.5820240480825</ele>
+				<time>2017-10-02T18:03:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015757961701672" lon="-84.21155332195423">
+				<ele>967.5820240480825</ele>
+				<time>2017-10-02T18:03:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015757961701672" lon="-84.21155332195423">
+				<ele>967.5820240480825</ele>
+				<time>2017-10-02T18:03:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015757961701672" lon="-84.21155332195423">
+				<ele>967.5820240480825</ele>
+				<time>2017-10-02T18:03:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015757961701672" lon="-84.21155332195423">
+				<ele>967.5820240480825</ele>
+				<time>2017-10-02T18:03:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015757914234943" lon="-84.21155169108086">
+				<ele>967.7768920846283</ele>
+				<time>2017-10-02T18:03:25Z</time>
+				<extensions>
+					<speed>0.6055940985679626</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01575793986273" lon="-84.2115435749647">
+				<ele>967.7344452580437</ele>
+				<time>2017-10-02T18:03:26Z</time>
+				<extensions>
+					<speed>1.1859558820724487</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015753099845949" lon="-84.21152863336279">
+				<ele>967.3637646557763</ele>
+				<time>2017-10-02T18:03:27Z</time>
+				<extensions>
+					<speed>2.1051900386810303</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01573975872674" lon="-84.2115126316603">
+				<ele>967.4542825194076</ele>
+				<time>2017-10-02T18:03:28Z</time>
+				<extensions>
+					<speed>2.6942174434661865</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015715978543989" lon="-84.21149468019763">
+				<ele>967.5289587751031</ele>
+				<time>2017-10-02T18:03:29Z</time>
+				<extensions>
+					<speed>3.7386794090270996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01568385590982" lon="-84.21147841854349">
+				<ele>967.5130317974836</ele>
+				<time>2017-10-02T18:03:30Z</time>
+				<extensions>
+					<speed>4.295216083526611</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015647077394943" lon="-84.2114649658922">
+				<ele>967.5674344766885</ele>
+				<time>2017-10-02T18:03:31Z</time>
+				<extensions>
+					<speed>4.801151752471924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015605632049338" lon="-84.21145456076228">
+				<ele>967.5062072090805</ele>
+				<time>2017-10-02T18:03:32Z</time>
+				<extensions>
+					<speed>4.906628608703613</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015560301666751" lon="-84.21144478208217">
+				<ele>967.3243572050706</ele>
+				<time>2017-10-02T18:03:33Z</time>
+				<extensions>
+					<speed>5.045240879058838</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015514382619555" lon="-84.21143380329175">
+				<ele>967.4127780012786</ele>
+				<time>2017-10-02T18:03:34Z</time>
+				<extensions>
+					<speed>4.8704705238342285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015500290107747" lon="-84.2114315078265">
+				<ele>966.8923090519384</ele>
+				<time>2017-10-02T18:03:35Z</time>
+				<extensions>
+					<speed>2.7363927364349365</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015481032389838" lon="-84.21142498519255">
+				<ele>967.0389894479886</ele>
+				<time>2017-10-02T18:03:36Z</time>
+				<extensions>
+					<speed>1.691070556640625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01547228969088" lon="-84.21141779284133">
+				<ele>967.0107335997745</ele>
+				<time>2017-10-02T18:03:37Z</time>
+				<extensions>
+					<speed>0.8915145397186279</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015469010345031" lon="-84.21141166254174">
+				<ele>966.8731316076592</ele>
+				<time>2017-10-02T18:03:38Z</time>
+				<extensions>
+					<speed>0.41736745834350586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015461004756329" lon="-84.21141829514434">
+				<ele>968.4951302157715</ele>
+				<time>2017-10-02T18:03:39Z</time>
+				<extensions>
+					<speed>1.5142606496810913</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015454194818927" lon="-84.21142583769073">
+				<ele>969.3247438455</ele>
+				<time>2017-10-02T18:03:40Z</time>
+				<extensions>
+					<speed>0.5814858078956604</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015457039039811" lon="-84.21142658535796">
+				<ele>969.5717554250732</ele>
+				<time>2017-10-02T18:03:41Z</time>
+				<extensions>
+					<speed>0.7908384203910828</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015457039039811" lon="-84.21142658535796">
+				<ele>969.5717554250732</ele>
+				<time>2017-10-02T18:03:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015469418659332" lon="-84.21142316063246">
+				<ele>969.3836914394051</ele>
+				<time>2017-10-02T18:03:43Z</time>
+				<extensions>
+					<speed>0.86236572265625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015480167442606" lon="-84.21142055361707">
+				<ele>968.9050415894017</ele>
+				<time>2017-10-02T18:03:44Z</time>
+				<extensions>
+					<speed>0.5018778443336487</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015480167442606" lon="-84.21142055361707">
+				<ele>968.9050415894017</ele>
+				<time>2017-10-02T18:03:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015485614864629" lon="-84.2114092128912">
+				<ele>965.9602665193379</ele>
+				<time>2017-10-02T18:03:46Z</time>
+				<extensions>
+					<speed>0.06787645071744919</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015485614864629" lon="-84.2114092128912">
+				<ele>965.9602665193379</ele>
+				<time>2017-10-02T18:03:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015485614864629" lon="-84.2114092128912">
+				<ele>965.9602665193379</ele>
+				<time>2017-10-02T18:03:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015480641624173" lon="-84.2114116083041">
+				<ele>966.657773854211</ele>
+				<time>2017-10-02T18:03:49Z</time>
+				<extensions>
+					<speed>1.0976893901824951</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015466357639925" lon="-84.21140960659135">
+				<ele>967.0554707376286</ele>
+				<time>2017-10-02T18:03:50Z</time>
+				<extensions>
+					<speed>1.877946138381958</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015444501862179" lon="-84.21140195062519">
+				<ele>966.4091769289225</ele>
+				<time>2017-10-02T18:03:51Z</time>
+				<extensions>
+					<speed>2.64785099029541</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015416229948816" lon="-84.21139615237587">
+				<ele>965.8967241160572</ele>
+				<time>2017-10-02T18:03:52Z</time>
+				<extensions>
+					<speed>3.0065114498138428</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387080243482" lon="-84.21139065862592">
+				<ele>966.0592010607943</ele>
+				<time>2017-10-02T18:03:53Z</time>
+				<extensions>
+					<speed>3.1113057136535645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0153575116171" lon="-84.21138131992375">
+				<ele>966.5179616529495</ele>
+				<time>2017-10-02T18:03:54Z</time>
+				<extensions>
+					<speed>3.4507479667663574</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01532425994752" lon="-84.21137367998371">
+				<ele>966.5033463547006</ele>
+				<time>2017-10-02T18:03:55Z</time>
+				<extensions>
+					<speed>3.5772910118103027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015290777298905" lon="-84.21136896301289">
+				<ele>966.6574246976525</ele>
+				<time>2017-10-02T18:03:56Z</time>
+				<extensions>
+					<speed>3.6453874111175537</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015253861211423" lon="-84.21136291998529">
+				<ele>966.5681959465146</ele>
+				<time>2017-10-02T18:03:57Z</time>
+				<extensions>
+					<speed>4.295555114746094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01521054886029" lon="-84.21135373517806">
+				<ele>966.6648324243724</ele>
+				<time>2017-10-02T18:03:58Z</time>
+				<extensions>
+					<speed>5.037724494934082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015160980766677" lon="-84.21133709378309">
+				<ele>966.7976683471352</ele>
+				<time>2017-10-02T18:03:59Z</time>
+				<extensions>
+					<speed>6.307243824005127</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015100945499041" lon="-84.21131511597103">
+				<ele>967.0146136926487</ele>
+				<time>2017-10-02T18:04:00Z</time>
+				<extensions>
+					<speed>7.591984748840332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015027656944296" lon="-84.21128974522297">
+				<ele>967.2693792684004</ele>
+				<time>2017-10-02T18:04:01Z</time>
+				<extensions>
+					<speed>9.32900619506836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014941877222482" lon="-84.21125878672002">
+				<ele>967.5597344199196</ele>
+				<time>2017-10-02T18:04:02Z</time>
+				<extensions>
+					<speed>10.648547172546387</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014846942519123" lon="-84.21122395392017">
+				<ele>967.5293129822239</ele>
+				<time>2017-10-02T18:04:03Z</time>
+				<extensions>
+					<speed>11.266661643981934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014747789597742" lon="-84.21118891522418">
+				<ele>967.7184392306954</ele>
+				<time>2017-10-02T18:04:04Z</time>
+				<extensions>
+					<speed>11.47337818145752</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014652953833062" lon="-84.2111516412581">
+				<ele>969.5687561370432</ele>
+				<time>2017-10-02T18:04:05Z</time>
+				<extensions>
+					<speed>11.107172966003418</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014559397007872" lon="-84.21111313812607">
+				<ele>970.6714400593191</ele>
+				<time>2017-10-02T18:04:06Z</time>
+				<extensions>
+					<speed>11.061355590820313</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014467769319294" lon="-84.2110790702753">
+				<ele>971.1166711393744</ele>
+				<time>2017-10-02T18:04:07Z</time>
+				<extensions>
+					<speed>10.250997543334961</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01438643319812" lon="-84.2110469233735">
+				<ele>971.2942502778023</ele>
+				<time>2017-10-02T18:04:08Z</time>
+				<extensions>
+					<speed>8.970672607421875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01431508059579" lon="-84.21101835146872">
+				<ele>971.50397400558</ele>
+				<time>2017-10-02T18:04:09Z</time>
+				<extensions>
+					<speed>7.832597255706787</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014248543361424" lon="-84.21098649559694">
+				<ele>971.6523379441351</ele>
+				<time>2017-10-02T18:04:10Z</time>
+				<extensions>
+					<speed>7.9611287117004395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014189860843592" lon="-84.21095821669752">
+				<ele>971.8500436078757</ele>
+				<time>2017-10-02T18:04:11Z</time>
+				<extensions>
+					<speed>6.739620208740234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01414293571604" lon="-84.2109372522673">
+				<ele>972.2447287812829</ele>
+				<time>2017-10-02T18:04:12Z</time>
+				<extensions>
+					<speed>5.8503289222717285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014100188490865" lon="-84.21091588811791">
+				<ele>972.389545195736</ele>
+				<time>2017-10-02T18:04:13Z</time>
+				<extensions>
+					<speed>5.141295433044434</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014069847125636" lon="-84.2109094257311">
+				<ele>972.5511643765494</ele>
+				<time>2017-10-02T18:04:14Z</time>
+				<extensions>
+					<speed>3.303778886795044</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014053093031032" lon="-84.21090096057641">
+				<ele>972.7626603227109</ele>
+				<time>2017-10-02T18:04:15Z</time>
+				<extensions>
+					<speed>1.784369945526123</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014043666290018" lon="-84.21089546144076">
+				<ele>972.9894349901006</ele>
+				<time>2017-10-02T18:04:16Z</time>
+				<extensions>
+					<speed>0.9673960208892822</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014042833919502" lon="-84.21088906495447">
+				<ele>973.2241662079468</ele>
+				<time>2017-10-02T18:04:17Z</time>
+				<extensions>
+					<speed>0.5335397124290466</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01404845718104" lon="-84.21088167089675">
+				<ele>973.4199187746271</ele>
+				<time>2017-10-02T18:04:18Z</time>
+				<extensions>
+					<speed>0.4563053846359253</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014058477254093" lon="-84.21087365176402">
+				<ele>973.6644689086825</ele>
+				<time>2017-10-02T18:04:19Z</time>
+				<extensions>
+					<speed>0.5569652318954468</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014067211568026" lon="-84.21086703878156">
+				<ele>973.8563220016658</ele>
+				<time>2017-10-02T18:04:20Z</time>
+				<extensions>
+					<speed>0.629837155342102</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014073377155537" lon="-84.21086197176767">
+				<ele>974.0461317328736</ele>
+				<time>2017-10-02T18:04:21Z</time>
+				<extensions>
+					<speed>0.6049203276634216</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014078026213097" lon="-84.21085727607188">
+				<ele>974.2359323203564</ele>
+				<time>2017-10-02T18:04:22Z</time>
+				<extensions>
+					<speed>0.49834302067756653</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014080683053598" lon="-84.21085019925859">
+				<ele>974.4072229601443</ele>
+				<time>2017-10-02T18:04:23Z</time>
+				<extensions>
+					<speed>0.46590232849121094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014081656915014" lon="-84.21084343172136">
+				<ele>974.5650368966162</ele>
+				<time>2017-10-02T18:04:24Z</time>
+				<extensions>
+					<speed>0.48326656222343445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014084451906236" lon="-84.2108386119222">
+				<ele>974.7430549245328</ele>
+				<time>2017-10-02T18:04:25Z</time>
+				<extensions>
+					<speed>0.46898528933525085</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01408618468556" lon="-84.21082773123668">
+				<ele>974.9297735048458</ele>
+				<time>2017-10-02T18:04:26Z</time>
+				<extensions>
+					<speed>0.5272102355957031</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014088621443728" lon="-84.21082156963388">
+				<ele>975.0455452995375</ele>
+				<time>2017-10-02T18:04:27Z</time>
+				<extensions>
+					<speed>0.5410206317901611</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01409314367184" lon="-84.21081933989122">
+				<ele>975.0961131835356</ele>
+				<time>2017-10-02T18:04:28Z</time>
+				<extensions>
+					<speed>0.5623252391815186</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014093386626785" lon="-84.2108195041855">
+				<ele>975.162175851874</ele>
+				<time>2017-10-02T18:04:29Z</time>
+				<extensions>
+					<speed>0.5288209319114685</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014096648218242" lon="-84.2108067543997">
+				<ele>975.2646682048216</ele>
+				<time>2017-10-02T18:04:30Z</time>
+				<extensions>
+					<speed>0.6144795417785645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014104444008714" lon="-84.21079479373154">
+				<ele>975.3720001224428</ele>
+				<time>2017-10-02T18:04:31Z</time>
+				<extensions>
+					<speed>0.6494318246841431</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014100464611465" lon="-84.21079476742044">
+				<ele>975.4139941036701</ele>
+				<time>2017-10-02T18:04:32Z</time>
+				<extensions>
+					<speed>0.6064887046813965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014110569873287" lon="-84.2108019032486">
+				<ele>975.4189680982381</ele>
+				<time>2017-10-02T18:04:33Z</time>
+				<extensions>
+					<speed>0.41553059220314026</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014119206295538" lon="-84.21083030418092">
+				<ele>975.1427627420053</ele>
+				<time>2017-10-02T18:04:34Z</time>
+				<extensions>
+					<speed>0.21717271208763123</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014123490630851" lon="-84.21083011572357">
+				<ele>975.1342233521864</ele>
+				<time>2017-10-02T18:04:35Z</time>
+				<extensions>
+					<speed>0.036572083830833435</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014123490630851" lon="-84.21083011572357">
+				<ele>975.0769493952394</ele>
+				<time>2017-10-02T18:04:36Z</time>
+				<extensions>
+					<speed>0.11774047464132309</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014123490630851" lon="-84.21083011572357">
+				<ele>975.1155028557405</ele>
+				<time>2017-10-02T18:04:37Z</time>
+				<extensions>
+					<speed>0.2981092035770416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014123490630851" lon="-84.21083011572357">
+				<ele>975.1626476757228</ele>
+				<time>2017-10-02T18:04:38Z</time>
+				<extensions>
+					<speed>0.24143652617931366</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014122769335358" lon="-84.21081656234422">
+				<ele>975.2134394403547</ele>
+				<time>2017-10-02T18:04:39Z</time>
+				<extensions>
+					<speed>0.2961568534374237</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014153463666496" lon="-84.21082246437325">
+				<ele>975.2919710520655</ele>
+				<time>2017-10-02T18:04:40Z</time>
+				<extensions>
+					<speed>0.4819949269294739</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014184585845598" lon="-84.2108131632585">
+				<ele>975.0909550031647</ele>
+				<time>2017-10-02T18:04:41Z</time>
+				<extensions>
+					<speed>0.6122273206710815</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014209726449229" lon="-84.21081298457571">
+				<ele>975.1416558083147</ele>
+				<time>2017-10-02T18:04:42Z</time>
+				<extensions>
+					<speed>0.6167705059051514</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014221705929913" lon="-84.21081873522054">
+				<ele>975.2848434997723</ele>
+				<time>2017-10-02T18:04:43Z</time>
+				<extensions>
+					<speed>0.48373720049858093</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014220633911547" lon="-84.21082049321117">
+				<ele>975.3633082630113</ele>
+				<time>2017-10-02T18:04:44Z</time>
+				<extensions>
+					<speed>0.32403016090393066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014225714637565" lon="-84.2108227488915">
+				<ele>975.3664808310568</ele>
+				<time>2017-10-02T18:04:45Z</time>
+				<extensions>
+					<speed>0.2999823987483978</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014228316114817" lon="-84.21082743902026">
+				<ele>975.2976905293763</ele>
+				<time>2017-10-02T18:04:46Z</time>
+				<extensions>
+					<speed>0.2869913876056671</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014225677019319" lon="-84.21082971452003">
+				<ele>975.2395623968914</ele>
+				<time>2017-10-02T18:04:47Z</time>
+				<extensions>
+					<speed>0.27048808336257935</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014223369329653" lon="-84.21083023815487">
+				<ele>975.2125210789964</ele>
+				<time>2017-10-02T18:04:48Z</time>
+				<extensions>
+					<speed>0.18873566389083862</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014206423828409" lon="-84.21083040152591">
+				<ele>975.1600366672501</ele>
+				<time>2017-10-02T18:04:49Z</time>
+				<extensions>
+					<speed>0.16653262078762054</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01419669361973" lon="-84.21083043647836">
+				<ele>975.1272929795086</ele>
+				<time>2017-10-02T18:04:50Z</time>
+				<extensions>
+					<speed>0.39373865723609924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014174617668658" lon="-84.21080752672975">
+				<ele>975.2018676977605</ele>
+				<time>2017-10-02T18:04:51Z</time>
+				<extensions>
+					<speed>0.5250260233879089</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01411763510959" lon="-84.21076084777113">
+				<ele>975.4059582613409</ele>
+				<time>2017-10-02T18:04:52Z</time>
+				<extensions>
+					<speed>1.1670924425125122</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014084064239093" lon="-84.2107270767559">
+				<ele>975.4901556484401</ele>
+				<time>2017-10-02T18:04:53Z</time>
+				<extensions>
+					<speed>1.7711875438690186</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014056866659619" lon="-84.21070534712898">
+				<ele>975.5366807430983</ele>
+				<time>2017-10-02T18:04:54Z</time>
+				<extensions>
+					<speed>1.9868888854980469</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014032293965126" lon="-84.21068908215803">
+				<ele>975.5954930242151</ele>
+				<time>2017-10-02T18:04:55Z</time>
+				<extensions>
+					<speed>1.8543763160705566</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01401089355153" lon="-84.21066982573682">
+				<ele>975.6914158063009</ele>
+				<time>2017-10-02T18:04:56Z</time>
+				<extensions>
+					<speed>1.8250988721847534</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013992079349695" lon="-84.21065365643538">
+				<ele>975.7586409347132</ele>
+				<time>2017-10-02T18:04:57Z</time>
+				<extensions>
+					<speed>1.8607895374298096</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013974158909487" lon="-84.21065129239548">
+				<ele>975.5828813007101</ele>
+				<time>2017-10-02T18:04:58Z</time>
+				<extensions>
+					<speed>2.1804652214050293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013954970881707" lon="-84.2106421739264">
+				<ele>975.4239677572623</ele>
+				<time>2017-10-02T18:04:59Z</time>
+				<extensions>
+					<speed>2.453326463699341</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013926869356235" lon="-84.21064052332082">
+				<ele>975.3175632366911</ele>
+				<time>2017-10-02T18:05:00Z</time>
+				<extensions>
+					<speed>3.07377028465271</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013898390144547" lon="-84.21063858938122">
+				<ele>975.3802698710933</ele>
+				<time>2017-10-02T18:05:01Z</time>
+				<extensions>
+					<speed>3.75211501121521</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013862487218553" lon="-84.21064243003764">
+				<ele>975.7368248682469</ele>
+				<time>2017-10-02T18:05:02Z</time>
+				<extensions>
+					<speed>4.7225751876831055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013828025474087" lon="-84.2106254147779">
+				<ele>976.0660776942968</ele>
+				<time>2017-10-02T18:05:03Z</time>
+				<extensions>
+					<speed>5.05665922164917</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013783531075095" lon="-84.2106294300498">
+				<ele>976.5212659165263</ele>
+				<time>2017-10-02T18:05:04Z</time>
+				<extensions>
+					<speed>4.857751369476318</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01374033408327" lon="-84.2106240137982">
+				<ele>976.6544273942709</ele>
+				<time>2017-10-02T18:05:05Z</time>
+				<extensions>
+					<speed>4.928248882293701</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013703533680617" lon="-84.21061229584836">
+				<ele>976.9742464758456</ele>
+				<time>2017-10-02T18:05:06Z</time>
+				<extensions>
+					<speed>4.0452561378479</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013679786587938" lon="-84.21059703357282">
+				<ele>977.4416869357228</ele>
+				<time>2017-10-02T18:05:07Z</time>
+				<extensions>
+					<speed>2.578899383544922</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013668033142444" lon="-84.21058973958074">
+				<ele>978.0364251825958</ele>
+				<time>2017-10-02T18:05:08Z</time>
+				<extensions>
+					<speed>1.3467297554016113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013661300725667" lon="-84.21058486740513">
+				<ele>978.4691216209903</ele>
+				<time>2017-10-02T18:05:09Z</time>
+				<extensions>
+					<speed>0.7560687065124512</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01366024847338" lon="-84.21058645173835">
+				<ele>978.7641748152673</ele>
+				<time>2017-10-02T18:05:10Z</time>
+				<extensions>
+					<speed>0.4826950430870056</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013670294827694" lon="-84.21059988384334">
+				<ele>979.6605791505426</ele>
+				<time>2017-10-02T18:05:11Z</time>
+				<extensions>
+					<speed>0.3020159900188446</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013678068998338" lon="-84.21060579806714">
+				<ele>980.3523580152541</ele>
+				<time>2017-10-02T18:05:12Z</time>
+				<extensions>
+					<speed>0.19212386012077332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013682646297017" lon="-84.21060969522662">
+				<ele>980.3480496751145</ele>
+				<time>2017-10-02T18:05:13Z</time>
+				<extensions>
+					<speed>0.2230837345123291</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013686465161443" lon="-84.21061358563314">
+				<ele>979.37775442563</ele>
+				<time>2017-10-02T18:05:14Z</time>
+				<extensions>
+					<speed>0.2406906634569168</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013689817210887" lon="-84.21061939446223">
+				<ele>978.2564441869035</ele>
+				<time>2017-10-02T18:05:15Z</time>
+				<extensions>
+					<speed>0.1165713220834732</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0136932218396" lon="-84.21062446166438">
+				<ele>977.1169179296121</ele>
+				<time>2017-10-02T18:05:16Z</time>
+				<extensions>
+					<speed>0.08987300097942352</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01369669446378" lon="-84.21063091273712">
+				<ele>975.9822625694796</ele>
+				<time>2017-10-02T18:05:17Z</time>
+				<extensions>
+					<speed>0.10247597098350525</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013698954931892" lon="-84.21063914895169">
+				<ele>974.6096763778478</ele>
+				<time>2017-10-02T18:05:18Z</time>
+				<extensions>
+					<speed>0.07941208779811859</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013699672821096" lon="-84.21064133202421">
+				<ele>973.9352158047259</ele>
+				<time>2017-10-02T18:05:19Z</time>
+				<extensions>
+					<speed>0.06691662967205048</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013703851707637" lon="-84.21064197330944">
+				<ele>973.2883866159245</ele>
+				<time>2017-10-02T18:05:20Z</time>
+				<extensions>
+					<speed>0.05364368110895157</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013707440722442" lon="-84.21064152786045">
+				<ele>972.60924486164</ele>
+				<time>2017-10-02T18:05:21Z</time>
+				<extensions>
+					<speed>0.06111735850572586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013709289612615" lon="-84.21064833642173">
+				<ele>971.7594961738214</ele>
+				<time>2017-10-02T18:05:22Z</time>
+				<extensions>
+					<speed>0.023809760808944702</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013709289612615" lon="-84.21064833642173">
+				<ele>971.4242542842403</ele>
+				<time>2017-10-02T18:05:23Z</time>
+				<extensions>
+					<speed>0.06459009647369385</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013709289612615" lon="-84.21064833642173">
+				<ele>970.9559225086123</ele>
+				<time>2017-10-02T18:05:24Z</time>
+				<extensions>
+					<speed>0.08508016914129257</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013709289612615" lon="-84.21064833642173">
+				<ele>970.5699640102684</ele>
+				<time>2017-10-02T18:05:25Z</time>
+				<extensions>
+					<speed>0.10817041993141174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01371578454463" lon="-84.21066735017227">
+				<ele>970.4028421528637</ele>
+				<time>2017-10-02T18:05:26Z</time>
+				<extensions>
+					<speed>0.1121831014752388</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01371980461957" lon="-84.21067394847404">
+				<ele>970.3599149882793</ele>
+				<time>2017-10-02T18:05:27Z</time>
+				<extensions>
+					<speed>0.14874939620494843</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013720825345967" lon="-84.21068516670485">
+				<ele>970.2852115314454</ele>
+				<time>2017-10-02T18:05:28Z</time>
+				<extensions>
+					<speed>0.19055357575416565</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013718171283553" lon="-84.21069118066715">
+				<ele>970.3665110096335</ele>
+				<time>2017-10-02T18:05:29Z</time>
+				<extensions>
+					<speed>0.19846639037132263</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013716414326867" lon="-84.21069244137657">
+				<ele>971.0801975894719</ele>
+				<time>2017-10-02T18:05:30Z</time>
+				<extensions>
+					<speed>0.04503000155091286</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01371403236458" lon="-84.21068958441249">
+				<ele>972.0025738589466</ele>
+				<time>2017-10-02T18:05:31Z</time>
+				<extensions>
+					<speed>0.050944432616233826</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013711536601628" lon="-84.21068425479704">
+				<ele>972.922164445743</ele>
+				<time>2017-10-02T18:05:32Z</time>
+				<extensions>
+					<speed>0.07170288264751434</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013708061982292" lon="-84.21068577420276">
+				<ele>973.915628165938</ele>
+				<time>2017-10-02T18:05:33Z</time>
+				<extensions>
+					<speed>0.07368670403957367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013704421347951" lon="-84.21068892423743">
+				<ele>974.7677013529465</ele>
+				<time>2017-10-02T18:05:34Z</time>
+				<extensions>
+					<speed>0.08102834224700928</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013700777953177" lon="-84.21068993175956">
+				<ele>975.7883071908727</ele>
+				<time>2017-10-02T18:05:35Z</time>
+				<extensions>
+					<speed>0.08983994275331497</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013697507115324" lon="-84.21068706571626">
+				<ele>976.8600370166823</ele>
+				<time>2017-10-02T18:05:36Z</time>
+				<extensions>
+					<speed>0.10140326619148254</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013694923080738" lon="-84.21068262542464">
+				<ele>977.6095580141991</ele>
+				<time>2017-10-02T18:05:37Z</time>
+				<extensions>
+					<speed>0.10784412175416946</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013691143318873" lon="-84.21068640866496">
+				<ele>978.5408101929352</ele>
+				<time>2017-10-02T18:05:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013685587895566" lon="-84.21069214019293">
+				<ele>979.6110334517434</ele>
+				<time>2017-10-02T18:05:39Z</time>
+				<extensions>
+					<speed>0.08599916845560074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013676739636631" lon="-84.21069282438776">
+				<ele>981.0036841072142</ele>
+				<time>2017-10-02T18:05:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01367053546933" lon="-84.21068148762717">
+				<ele>981.4522156622261</ele>
+				<time>2017-10-02T18:05:41Z</time>
+				<extensions>
+					<speed>0.14892444014549255</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013664138178596" lon="-84.21066647705625">
+				<ele>981.6932307258248</ele>
+				<time>2017-10-02T18:05:42Z</time>
+				<extensions>
+					<speed>0.1291380375623703</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013662671340336" lon="-84.21065772865983">
+				<ele>982.0126288309693</ele>
+				<time>2017-10-02T18:05:43Z</time>
+				<extensions>
+					<speed>0.022814825177192688</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013662671340336" lon="-84.21065772865983">
+				<ele>982.2582944128662</ele>
+				<time>2017-10-02T18:05:44Z</time>
+				<extensions>
+					<speed>0.051308367401361465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013662671340336" lon="-84.21065772865983">
+				<ele>980.5904471408576</ele>
+				<time>2017-10-02T18:05:45Z</time>
+				<extensions>
+					<speed>0.2464713305234909</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013662671340336" lon="-84.21065772865983">
+				<ele>979.9370403606445</ele>
+				<time>2017-10-02T18:05:46Z</time>
+				<extensions>
+					<speed>0.12718063592910767</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013678125002317" lon="-84.21060504771036">
+				<ele>976.5324349058792</ele>
+				<time>2017-10-02T18:05:47Z</time>
+				<extensions>
+					<speed>0.09837347269058228</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013678125002317" lon="-84.21060504771036">
+				<ele>976.5324349058792</ele>
+				<time>2017-10-02T18:05:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013678125002317" lon="-84.21060504771036">
+				<ele>976.5324349058792</ele>
+				<time>2017-10-02T18:05:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013678125002317" lon="-84.21060504771036">
+				<ele>976.5324349058792</ele>
+				<time>2017-10-02T18:05:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013678125002317" lon="-84.21060504771036">
+				<ele>976.5324349058792</ele>
+				<time>2017-10-02T18:05:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013678125002317" lon="-84.21060504771036">
+				<ele>976.5324349058792</ele>
+				<time>2017-10-02T18:05:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013678125002317" lon="-84.21060504771036">
+				<ele>976.5324349058792</ele>
+				<time>2017-10-02T18:05:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013678125002317" lon="-84.21060504771036">
+				<ele>976.5324349058792</ele>
+				<time>2017-10-02T18:05:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013678125002317" lon="-84.21060504771036">
+				<ele>976.5324349058792</ele>
+				<time>2017-10-02T18:05:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013678125002317" lon="-84.21060504771036">
+				<ele>976.5324349058792</ele>
+				<time>2017-10-02T18:05:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013678125002317" lon="-84.21060504771036">
+				<ele>976.5324349058792</ele>
+				<time>2017-10-02T18:05:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013666527544581" lon="-84.21060726233577">
+				<ele>977.9750158395618</ele>
+				<time>2017-10-02T18:05:58Z</time>
+				<extensions>
+					<speed>1.0326473712921143</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013654295030276" lon="-84.21061005602253">
+				<ele>979.8392685325816</ele>
+				<time>2017-10-02T18:05:59Z</time>
+				<extensions>
+					<speed>1.039196252822876</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013641052341079" lon="-84.21061134609043">
+				<ele>979.73226525262</ele>
+				<time>2017-10-02T18:06:00Z</time>
+				<extensions>
+					<speed>1.0854252576828003</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013628489963441" lon="-84.2106107640702">
+				<ele>980.0120542328805</ele>
+				<time>2017-10-02T18:06:01Z</time>
+				<extensions>
+					<speed>1.2311750650405884</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013615798869107" lon="-84.21060790595355">
+				<ele>980.3911903155968</ele>
+				<time>2017-10-02T18:06:02Z</time>
+				<extensions>
+					<speed>1.4663060903549194</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01359908621253" lon="-84.21060219201428">
+				<ele>980.5009763240814</ele>
+				<time>2017-10-02T18:06:03Z</time>
+				<extensions>
+					<speed>2.104682445526123</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01357784792894" lon="-84.21059678446633">
+				<ele>979.8584017138928</ele>
+				<time>2017-10-02T18:06:04Z</time>
+				<extensions>
+					<speed>2.4462881088256836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013553996717796" lon="-84.21059254545507">
+				<ele>978.8362601557747</ele>
+				<time>2017-10-02T18:06:05Z</time>
+				<extensions>
+					<speed>2.458280563354492</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013532094620185" lon="-84.21058809175602">
+				<ele>977.8461144221947</ele>
+				<time>2017-10-02T18:06:06Z</time>
+				<extensions>
+					<speed>2.346649408340454</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01351235339862" lon="-84.21058465981118">
+				<ele>976.2357826530933</ele>
+				<time>2017-10-02T18:06:07Z</time>
+				<extensions>
+					<speed>1.8921476602554321</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013498621409964" lon="-84.21058142939289">
+				<ele>977.0546626914293</ele>
+				<time>2017-10-02T18:06:08Z</time>
+				<extensions>
+					<speed>1.1551172733306885</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013489017779065" lon="-84.21058515887964">
+				<ele>976.39037338458</ele>
+				<time>2017-10-02T18:06:09Z</time>
+				<extensions>
+					<speed>0.40093091130256653</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01348595635289" lon="-84.21058805954246">
+				<ele>976.1991949724033</ele>
+				<time>2017-10-02T18:06:10Z</time>
+				<extensions>
+					<speed>0.24779632687568665</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01348595635289" lon="-84.21058805954246">
+				<ele>976.1991949724033</ele>
+				<time>2017-10-02T18:06:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01348595635289" lon="-84.21058805954246">
+				<ele>976.1991949724033</ele>
+				<time>2017-10-02T18:06:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01348665366578" lon="-84.21059179765865">
+				<ele>976.4188783438876</ele>
+				<time>2017-10-02T18:06:13Z</time>
+				<extensions>
+					<speed>0.6022673845291138</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013488189341855" lon="-84.21059354581533">
+				<ele>976.2729938337579</ele>
+				<time>2017-10-02T18:06:14Z</time>
+				<extensions>
+					<speed>0.04803904518485069</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013488951055336" lon="-84.21059421858517">
+				<ele>976.1783067192882</ele>
+				<time>2017-10-02T18:06:15Z</time>
+				<extensions>
+					<speed>0.3713088035583496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013488951055336" lon="-84.21059421858517">
+				<ele>976.1783067192882</ele>
+				<time>2017-10-02T18:06:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013488951055336" lon="-84.21059421858517">
+				<ele>976.1783067192882</ele>
+				<time>2017-10-02T18:06:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013488951055336" lon="-84.21059421858517">
+				<ele>976.1783067192882</ele>
+				<time>2017-10-02T18:06:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013488951055336" lon="-84.21059421858517">
+				<ele>976.1783067192882</ele>
+				<time>2017-10-02T18:06:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013488951055336" lon="-84.21059421858517">
+				<ele>976.1783067192882</ele>
+				<time>2017-10-02T18:06:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013488951055336" lon="-84.21059421858517">
+				<ele>976.1783067192882</ele>
+				<time>2017-10-02T18:06:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013488951055336" lon="-84.21059421858517">
+				<ele>976.1783067192882</ele>
+				<time>2017-10-02T18:06:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013488951055336" lon="-84.21059421858517">
+				<ele>976.1783067192882</ele>
+				<time>2017-10-02T18:06:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013488951055336" lon="-84.21059421858517">
+				<ele>976.1783067192882</ele>
+				<time>2017-10-02T18:06:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013488951055336" lon="-84.21059421858517">
+				<ele>976.1783067192882</ele>
+				<time>2017-10-02T18:06:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013488951055336" lon="-84.21059421858517">
+				<ele>976.1783067192882</ele>
+				<time>2017-10-02T18:06:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013486625181464" lon="-84.21059218384927">
+				<ele>977.0174914626405</ele>
+				<time>2017-10-02T18:06:27Z</time>
+				<extensions>
+					<speed>0.695347785949707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013477730029754" lon="-84.21058689550644">
+				<ele>977.6214258326218</ele>
+				<time>2017-10-02T18:06:28Z</time>
+				<extensions>
+					<speed>1.442996859550476</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013465308321805" lon="-84.21057768705562">
+				<ele>977.9420538460836</ele>
+				<time>2017-10-02T18:06:29Z</time>
+				<extensions>
+					<speed>1.8340990543365479</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013452557730746" lon="-84.21056781576962">
+				<ele>978.7178035676479</ele>
+				<time>2017-10-02T18:06:30Z</time>
+				<extensions>
+					<speed>1.727858066558838</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013443614632548" lon="-84.21055513856541">
+				<ele>979.6108043109998</ele>
+				<time>2017-10-02T18:06:31Z</time>
+				<extensions>
+					<speed>1.4378365278244019</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013438434661843" lon="-84.21055025283201">
+				<ele>980.5212487988174</ele>
+				<time>2017-10-02T18:06:32Z</time>
+				<extensions>
+					<speed>0.335404634475708</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437993252614" lon="-84.21054880975417">
+				<ele>981.2410739231855</ele>
+				<time>2017-10-02T18:06:33Z</time>
+				<extensions>
+					<speed>0.16121971607208252</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437993252614" lon="-84.21054880975417">
+				<ele>981.2410739231855</ele>
+				<time>2017-10-02T18:06:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437993252614" lon="-84.21054880975417">
+				<ele>981.2410739231855</ele>
+				<time>2017-10-02T18:06:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437993252614" lon="-84.21054880975417">
+				<ele>981.2410739231855</ele>
+				<time>2017-10-02T18:06:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437993252614" lon="-84.21054880975417">
+				<ele>981.2410739231855</ele>
+				<time>2017-10-02T18:06:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437993252614" lon="-84.21054880975417">
+				<ele>981.2410739231855</ele>
+				<time>2017-10-02T18:06:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437993252614" lon="-84.21054880975417">
+				<ele>981.2410739231855</ele>
+				<time>2017-10-02T18:06:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437993252614" lon="-84.21054880975417">
+				<ele>981.2410739231855</ele>
+				<time>2017-10-02T18:06:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437993252614" lon="-84.21054880975417">
+				<ele>981.2410739231855</ele>
+				<time>2017-10-02T18:06:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437993252614" lon="-84.21054880975417">
+				<ele>981.2410739231855</ele>
+				<time>2017-10-02T18:06:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437993252614" lon="-84.21054880975417">
+				<ele>981.2410739231855</ele>
+				<time>2017-10-02T18:06:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437993252614" lon="-84.21054880975417">
+				<ele>981.2410739231855</ele>
+				<time>2017-10-02T18:06:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437993252614" lon="-84.21054880975417">
+				<ele>981.2410739231855</ele>
+				<time>2017-10-02T18:06:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437993252614" lon="-84.21054880975417">
+				<ele>981.2410739231855</ele>
+				<time>2017-10-02T18:06:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437993252614" lon="-84.21054880975417">
+				<ele>981.2410739231855</ele>
+				<time>2017-10-02T18:06:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437993252614" lon="-84.21054880975417">
+				<ele>981.2410739231855</ele>
+				<time>2017-10-02T18:06:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437993252614" lon="-84.21054880975417">
+				<ele>981.2410739231855</ele>
+				<time>2017-10-02T18:06:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437993252614" lon="-84.21054880975417">
+				<ele>981.2410739231855</ele>
+				<time>2017-10-02T18:06:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437993252614" lon="-84.21054880975417">
+				<ele>981.2410739231855</ele>
+				<time>2017-10-02T18:06:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437993252614" lon="-84.21054880975417">
+				<ele>981.2410739231855</ele>
+				<time>2017-10-02T18:06:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013433296902992" lon="-84.21054745685059">
+				<ele>981.2948359949514</ele>
+				<time>2017-10-02T18:06:53Z</time>
+				<extensions>
+					<speed>0.7639179229736328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013426502940202" lon="-84.21054181940457">
+				<ele>980.935592665337</ele>
+				<time>2017-10-02T18:06:54Z</time>
+				<extensions>
+					<speed>0.9277624487876892</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013420464598042" lon="-84.21053496727826">
+				<ele>980.8658210393041</ele>
+				<time>2017-10-02T18:06:55Z</time>
+				<extensions>
+					<speed>0.7597986459732056</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013413727409896" lon="-84.21052911796735">
+				<ele>981.3581042569131</ele>
+				<time>2017-10-02T18:06:56Z</time>
+				<extensions>
+					<speed>0.8135570287704468</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013406031036386" lon="-84.21052428372857">
+				<ele>981.4499613903463</ele>
+				<time>2017-10-02T18:06:57Z</time>
+				<extensions>
+					<speed>0.9952752590179443</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013399602681302" lon="-84.21051576776132">
+				<ele>981.4287900710478</ele>
+				<time>2017-10-02T18:06:58Z</time>
+				<extensions>
+					<speed>0.8987951874732971</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013394490088833" lon="-84.21050540144431">
+				<ele>980.4865606110543</ele>
+				<time>2017-10-02T18:06:59Z</time>
+				<extensions>
+					<speed>0.8545228838920593</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013389184068425" lon="-84.21049846564866">
+				<ele>980.3215985521674</ele>
+				<time>2017-10-02T18:07:00Z</time>
+				<extensions>
+					<speed>0.7977689504623413</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013383687201777" lon="-84.21049528499154">
+				<ele>980.0214880518615</ele>
+				<time>2017-10-02T18:07:01Z</time>
+				<extensions>
+					<speed>0.6306165456771851</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013379597864757" lon="-84.21049445109188">
+				<ele>980.1076811803505</ele>
+				<time>2017-10-02T18:07:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013380233539614" lon="-84.21049557381191">
+				<ele>980.1602180181071</ele>
+				<time>2017-10-02T18:07:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013380233539614" lon="-84.21049557381191">
+				<ele>980.1602180181071</ele>
+				<time>2017-10-02T18:07:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013380233539614" lon="-84.21049557381191">
+				<ele>980.1602180181071</ele>
+				<time>2017-10-02T18:07:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013373807753354" lon="-84.21049407947066">
+				<ele>980.1909713530913</ele>
+				<time>2017-10-02T18:07:06Z</time>
+				<extensions>
+					<speed>1.1703991889953613</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013362272286864" lon="-84.21048824739073">
+				<ele>980.2208414897323</ele>
+				<time>2017-10-02T18:07:07Z</time>
+				<extensions>
+					<speed>1.6699095964431763</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013343267981726" lon="-84.21047760272225">
+				<ele>980.1502268789336</ele>
+				<time>2017-10-02T18:07:08Z</time>
+				<extensions>
+					<speed>2.617415428161621</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01331416047244" lon="-84.21046021571685">
+				<ele>980.3899683384225</ele>
+				<time>2017-10-02T18:07:09Z</time>
+				<extensions>
+					<speed>4.039883136749268</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013273904625878" lon="-84.21043962783979">
+				<ele>980.7472732849419</ele>
+				<time>2017-10-02T18:07:10Z</time>
+				<extensions>
+					<speed>5.123820781707764</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013227084995416" lon="-84.21041750670106">
+				<ele>981.0453854352236</ele>
+				<time>2017-10-02T18:07:11Z</time>
+				<extensions>
+					<speed>5.843215465545654</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013175343317107" lon="-84.21039499595032">
+				<ele>981.4645084077492</ele>
+				<time>2017-10-02T18:07:12Z</time>
+				<extensions>
+					<speed>6.534015655517578</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013117856638058" lon="-84.2103722198915">
+				<ele>982.0027984622866</ele>
+				<time>2017-10-02T18:07:13Z</time>
+				<extensions>
+					<speed>6.986607551574707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01305729063004" lon="-84.21034946763237">
+				<ele>981.8468287819996</ele>
+				<time>2017-10-02T18:07:14Z</time>
+				<extensions>
+					<speed>7.000211715698242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012999476120799" lon="-84.21032935456526">
+				<ele>981.6084660012275</ele>
+				<time>2017-10-02T18:07:15Z</time>
+				<extensions>
+					<speed>6.468957901000977</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012945046049106" lon="-84.21030896991117">
+				<ele>981.3952800454572</ele>
+				<time>2017-10-02T18:07:16Z</time>
+				<extensions>
+					<speed>6.073233127593994</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01290240845486" lon="-84.21029626515028">
+				<ele>980.8631250979379</ele>
+				<time>2017-10-02T18:07:17Z</time>
+				<extensions>
+					<speed>4.220447063446045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012878052291748" lon="-84.2102855198937">
+				<ele>980.59546230454</ele>
+				<time>2017-10-02T18:07:18Z</time>
+				<extensions>
+					<speed>1.7518138885498047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012875818847771" lon="-84.2102768316278">
+				<ele>980.5449020639062</ele>
+				<time>2017-10-02T18:07:19Z</time>
+				<extensions>
+					<speed>0.6959172487258911</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012883299095435" lon="-84.21027317838868">
+				<ele>980.8492658138275</ele>
+				<time>2017-10-02T18:07:20Z</time>
+				<extensions>
+					<speed>1.0890419483184814</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01289000845724" lon="-84.21026706622196">
+				<ele>981.6245198976249</ele>
+				<time>2017-10-02T18:07:21Z</time>
+				<extensions>
+					<speed>0.8094961643218994</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01289000845724" lon="-84.21026706622196">
+				<ele>981.6245198976249</ele>
+				<time>2017-10-02T18:07:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0129006260327" lon="-84.21027248204214">
+				<ele>981.6220362400636</ele>
+				<time>2017-10-02T18:07:23Z</time>
+				<extensions>
+					<speed>1.0655837059020996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012912212585803" lon="-84.21028203270485">
+				<ele>981.5350539563224</ele>
+				<time>2017-10-02T18:07:24Z</time>
+				<extensions>
+					<speed>1.169127345085144</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012924182491012" lon="-84.21029223941223">
+				<ele>981.3988496735692</ele>
+				<time>2017-10-02T18:07:25Z</time>
+				<extensions>
+					<speed>1.2973626852035522</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012933209529507" lon="-84.21030019431997">
+				<ele>981.3108017481863</ele>
+				<time>2017-10-02T18:07:26Z</time>
+				<extensions>
+					<speed>0.9062434434890747</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012933209529507" lon="-84.21030019431997">
+				<ele>981.3108017481863</ele>
+				<time>2017-10-02T18:07:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012935574388305" lon="-84.21030478158997">
+				<ele>981.403103493154</ele>
+				<time>2017-10-02T18:07:28Z</time>
+				<extensions>
+					<speed>0.3963690400123596</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012935574388305" lon="-84.21030478158997">
+				<ele>981.403103493154</ele>
+				<time>2017-10-02T18:07:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012935574388305" lon="-84.21030478158997">
+				<ele>981.403103493154</ele>
+				<time>2017-10-02T18:07:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012935574388305" lon="-84.21030478158997">
+				<ele>981.403103493154</ele>
+				<time>2017-10-02T18:07:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012935574388305" lon="-84.21030478158997">
+				<ele>981.403103493154</ele>
+				<time>2017-10-02T18:07:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012935574388305" lon="-84.21030478158997">
+				<ele>981.403103493154</ele>
+				<time>2017-10-02T18:07:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012935574388305" lon="-84.21030478158997">
+				<ele>981.403103493154</ele>
+				<time>2017-10-02T18:07:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012935574388305" lon="-84.21030478158997">
+				<ele>981.403103493154</ele>
+				<time>2017-10-02T18:07:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012935574388305" lon="-84.21030478158997">
+				<ele>981.403103493154</ele>
+				<time>2017-10-02T18:07:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012935574388305" lon="-84.21030478158997">
+				<ele>981.403103493154</ele>
+				<time>2017-10-02T18:07:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012935574388305" lon="-84.21030478158997">
+				<ele>981.403103493154</ele>
+				<time>2017-10-02T18:07:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012935574388305" lon="-84.21030478158997">
+				<ele>981.403103493154</ele>
+				<time>2017-10-02T18:07:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012935574388305" lon="-84.21030478158997">
+				<ele>981.403103493154</ele>
+				<time>2017-10-02T18:07:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012935574388305" lon="-84.21030478158997">
+				<ele>981.403103493154</ele>
+				<time>2017-10-02T18:07:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:07:42Z</time>
+				<extensions>
+					<speed>0.13004256784915924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:07:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:07:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:07:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:07:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:07:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:07:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:07:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:07:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:07:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:07:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:07:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:07:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:07:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:07:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:07:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:07:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:07:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:08:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:09:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01293684882129" lon="-84.21030217422638">
+				<ele>981.3965671453625</ele>
+				<time>2017-10-02T18:09:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01291902756792" lon="-84.21029638798294">
+				<ele>981.5639397939667</ele>
+				<time>2017-10-02T18:09:02Z</time>
+				<extensions>
+					<speed>2.123466730117798</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012894429201788" lon="-84.2102904524844">
+				<ele>980.9184538181871</ele>
+				<time>2017-10-02T18:09:03Z</time>
+				<extensions>
+					<speed>3.1208574771881104</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012860207111" lon="-84.21028707179313">
+				<ele>978.6008188277483</ele>
+				<time>2017-10-02T18:09:04Z</time>
+				<extensions>
+					<speed>4.046555042266846</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012815888280416" lon="-84.21028362915595">
+				<ele>975.9183011641726</ele>
+				<time>2017-10-02T18:09:05Z</time>
+				<extensions>
+					<speed>4.510340690612793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012775088854818" lon="-84.21027259018085">
+				<ele>975.8887861957774</ele>
+				<time>2017-10-02T18:09:06Z</time>
+				<extensions>
+					<speed>4.474664688110352</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012736419263122" lon="-84.21026485352257">
+				<ele>975.9664172623307</ele>
+				<time>2017-10-02T18:09:07Z</time>
+				<extensions>
+					<speed>4.120492458343506</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012702478354829" lon="-84.21025935706079">
+				<ele>975.3463314231485</ele>
+				<time>2017-10-02T18:09:08Z</time>
+				<extensions>
+					<speed>3.461638927459717</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012673713804839" lon="-84.21025612229268">
+				<ele>974.4468823643401</ele>
+				<time>2017-10-02T18:09:09Z</time>
+				<extensions>
+					<speed>3.0202884674072266</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01265151342177" lon="-84.21025985263532">
+				<ele>973.2957794582471</ele>
+				<time>2017-10-02T18:09:10Z</time>
+				<extensions>
+					<speed>2.505276679992676</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012633121583" lon="-84.21027009761734">
+				<ele>972.9604858150706</ele>
+				<time>2017-10-02T18:09:11Z</time>
+				<extensions>
+					<speed>2.2605321407318115</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012619922954478" lon="-84.21028397380847">
+				<ele>973.0569168832153</ele>
+				<time>2017-10-02T18:09:12Z</time>
+				<extensions>
+					<speed>2.224210023880005</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012609668489647" lon="-84.21030123821741">
+				<ele>972.6039734873921</ele>
+				<time>2017-10-02T18:09:13Z</time>
+				<extensions>
+					<speed>2.2161991596221924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012602894046362" lon="-84.21031838421519">
+				<ele>972.3700714474544</ele>
+				<time>2017-10-02T18:09:14Z</time>
+				<extensions>
+					<speed>2.2052712440490723</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012595747217823" lon="-84.21033629358833">
+				<ele>971.9898683754727</ele>
+				<time>2017-10-02T18:09:15Z</time>
+				<extensions>
+					<speed>2.268528461456299</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012585922878747" lon="-84.21034999472252">
+				<ele>971.5784547049552</ele>
+				<time>2017-10-02T18:09:16Z</time>
+				<extensions>
+					<speed>1.8146278858184814</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012573656355544" lon="-84.21036259447239">
+				<ele>971.2488167136908</ele>
+				<time>2017-10-02T18:09:17Z</time>
+				<extensions>
+					<speed>2.3139519691467285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01256077508523" lon="-84.21037518673187">
+				<ele>970.9269027225673</ele>
+				<time>2017-10-02T18:09:18Z</time>
+				<extensions>
+					<speed>1.8599021434783936</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012552238364828" lon="-84.2103840192252">
+				<ele>970.8915516240522</ele>
+				<time>2017-10-02T18:09:19Z</time>
+				<extensions>
+					<speed>1.5499051809310913</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01254706753546" lon="-84.21038640861934">
+				<ele>970.9175132913515</ele>
+				<time>2017-10-02T18:09:20Z</time>
+				<extensions>
+					<speed>0.6799764037132263</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012547702873395" lon="-84.21038798457818">
+				<ele>970.9784284140915</ele>
+				<time>2017-10-02T18:09:21Z</time>
+				<extensions>
+					<speed>0.025372490286827087</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012547702873395" lon="-84.21038798457818">
+				<ele>970.9784284140915</ele>
+				<time>2017-10-02T18:09:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012547702873395" lon="-84.21038798457818">
+				<ele>970.9784284140915</ele>
+				<time>2017-10-02T18:09:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012547702873395" lon="-84.21038798457818">
+				<ele>970.9784284140915</ele>
+				<time>2017-10-02T18:09:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01255672366423" lon="-84.21039065057317">
+				<ele>971.4948641965166</ele>
+				<time>2017-10-02T18:09:25Z</time>
+				<extensions>
+					<speed>0.769304096698761</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01255672366423" lon="-84.21039065057317">
+				<ele>971.4948641965166</ele>
+				<time>2017-10-02T18:09:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012560284034567" lon="-84.21040170042401">
+				<ele>971.6233391333371</ele>
+				<time>2017-10-02T18:09:27Z</time>
+				<extensions>
+					<speed>1.242719054222107</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01256204496573" lon="-84.21041672671285">
+				<ele>972.0334259076044</ele>
+				<time>2017-10-02T18:09:28Z</time>
+				<extensions>
+					<speed>1.9477381706237793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012558154676519" lon="-84.21043407372781">
+				<ele>972.1316429059952</ele>
+				<time>2017-10-02T18:09:29Z</time>
+				<extensions>
+					<speed>2.046405792236328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012551605366669" lon="-84.21045063872232">
+				<ele>972.159405650571</ele>
+				<time>2017-10-02T18:09:30Z</time>
+				<extensions>
+					<speed>2.0205211639404297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01254267476043" lon="-84.21046668279135">
+				<ele>972.0435048462823</ele>
+				<time>2017-10-02T18:09:31Z</time>
+				<extensions>
+					<speed>2.1296582221984863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012533518069379" lon="-84.21048738622004">
+				<ele>972.1620913268998</ele>
+				<time>2017-10-02T18:09:32Z</time>
+				<extensions>
+					<speed>2.359663248062134</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012534611470251" lon="-84.210515342292">
+				<ele>971.8305825898424</ele>
+				<time>2017-10-02T18:09:33Z</time>
+				<extensions>
+					<speed>2.5367932319641113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012542525487596" lon="-84.21055207211354">
+				<ele>971.3080976689234</ele>
+				<time>2017-10-02T18:09:34Z</time>
+				<extensions>
+					<speed>3.4078938961029053</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012557340330229" lon="-84.21058804868917">
+				<ele>971.7495453506708</ele>
+				<time>2017-10-02T18:09:35Z</time>
+				<extensions>
+					<speed>4.112608909606934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012559864109347" lon="-84.2106346664923">
+				<ele>972.1866949629039</ele>
+				<time>2017-10-02T18:09:36Z</time>
+				<extensions>
+					<speed>4.425968647003174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012564636185735" lon="-84.21067987207832">
+				<ele>972.1293480060995</ele>
+				<time>2017-10-02T18:09:37Z</time>
+				<extensions>
+					<speed>4.358161449432373</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012566066734353" lon="-84.2107225678365">
+				<ele>972.1857527326792</ele>
+				<time>2017-10-02T18:09:38Z</time>
+				<extensions>
+					<speed>4.299121379852295</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012560233170964" lon="-84.21076321074138">
+				<ele>972.1458878507838</ele>
+				<time>2017-10-02T18:09:39Z</time>
+				<extensions>
+					<speed>4.131015300750732</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012547816240373" lon="-84.21080065499685">
+				<ele>972.0885206442326</ele>
+				<time>2017-10-02T18:09:40Z</time>
+				<extensions>
+					<speed>4.1363205909729</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012533432822483" lon="-84.21083477209652">
+				<ele>971.6729559339583</ele>
+				<time>2017-10-02T18:09:41Z</time>
+				<extensions>
+					<speed>3.7236006259918213</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012518541318594" lon="-84.21086602003861">
+				<ele>971.6445524310693</ele>
+				<time>2017-10-02T18:09:42Z</time>
+				<extensions>
+					<speed>3.6178574562072754</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0125033477178" lon="-84.21089781727696">
+				<ele>971.3406321052462</ele>
+				<time>2017-10-02T18:09:43Z</time>
+				<extensions>
+					<speed>3.432697296142578</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012488550150419" lon="-84.21092425671766">
+				<ele>971.3592104362324</ele>
+				<time>2017-10-02T18:09:44Z</time>
+				<extensions>
+					<speed>3.0797932147979736</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01247380306508" lon="-84.21094945515752">
+				<ele>971.4009101064876</ele>
+				<time>2017-10-02T18:09:45Z</time>
+				<extensions>
+					<speed>3.0702576637268066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012458010732294" lon="-84.21097614843642">
+				<ele>971.4189064940438</ele>
+				<time>2017-10-02T18:09:46Z</time>
+				<extensions>
+					<speed>3.1679134368896484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012440282371424" lon="-84.2110102188089">
+				<ele>971.0622628815472</ele>
+				<time>2017-10-02T18:09:47Z</time>
+				<extensions>
+					<speed>3.794909715652466</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012427247153184" lon="-84.21105078705962">
+				<ele>970.8655776241794</ele>
+				<time>2017-10-02T18:09:48Z</time>
+				<extensions>
+					<speed>4.136184215545654</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012412073030484" lon="-84.21109423951843">
+				<ele>970.3377576684579</ele>
+				<time>2017-10-02T18:09:49Z</time>
+				<extensions>
+					<speed>4.396286964416504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012399948158508" lon="-84.21114547787991">
+				<ele>969.571781934239</ele>
+				<time>2017-10-02T18:09:50Z</time>
+				<extensions>
+					<speed>5.075597286224365</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012386832916524" lon="-84.21120174362383">
+				<ele>968.9754332890734</ele>
+				<time>2017-10-02T18:09:51Z</time>
+				<extensions>
+					<speed>5.7063093185424805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012371623285098" lon="-84.21125790700692">
+				<ele>968.5729679260403</ele>
+				<time>2017-10-02T18:09:52Z</time>
+				<extensions>
+					<speed>5.744183540344238</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012353987660477" lon="-84.21131392424911">
+				<ele>968.0910662245005</ele>
+				<time>2017-10-02T18:09:53Z</time>
+				<extensions>
+					<speed>5.773470401763916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012339413139124" lon="-84.21136506326451">
+				<ele>967.6882263207808</ele>
+				<time>2017-10-02T18:09:54Z</time>
+				<extensions>
+					<speed>5.44771146774292</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012325268663318" lon="-84.21140529151658">
+				<ele>967.5402607927099</ele>
+				<time>2017-10-02T18:09:55Z</time>
+				<extensions>
+					<speed>4.789021015167236</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012313822502446" lon="-84.21142872239972">
+				<ele>967.6236030999571</ele>
+				<time>2017-10-02T18:09:56Z</time>
+				<extensions>
+					<speed>3.2063801288604736</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012304890212896" lon="-84.21145761572427">
+				<ele>967.8438081657514</ele>
+				<time>2017-10-02T18:09:57Z</time>
+				<extensions>
+					<speed>2.413215160369873</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012299170608648" lon="-84.21147267608761">
+				<ele>968.0487192319706</ele>
+				<time>2017-10-02T18:09:58Z</time>
+				<extensions>
+					<speed>0.8025649785995483</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012293131026535" lon="-84.21148492241512">
+				<ele>967.9504395928234</ele>
+				<time>2017-10-02T18:09:59Z</time>
+				<extensions>
+					<speed>0.7975874543190002</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012293131026535" lon="-84.21148492241512">
+				<ele>967.9504395928234</ele>
+				<time>2017-10-02T18:10:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012286969034564" lon="-84.21149403067324">
+				<ele>967.6182077722624</ele>
+				<time>2017-10-02T18:10:01Z</time>
+				<extensions>
+					<speed>0.7920247912406921</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012286969034564" lon="-84.21149403067324">
+				<ele>967.6182077722624</ele>
+				<time>2017-10-02T18:10:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012284940205904" lon="-84.21149878045738">
+				<ele>967.2726112958044</ele>
+				<time>2017-10-02T18:10:03Z</time>
+				<extensions>
+					<speed>0.390690416097641</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012284940205904" lon="-84.21149878045738">
+				<ele>967.2726112958044</ele>
+				<time>2017-10-02T18:10:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012284940205904" lon="-84.21149878045738">
+				<ele>967.2726112958044</ele>
+				<time>2017-10-02T18:10:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012284940205904" lon="-84.21149878045738">
+				<ele>967.2726112958044</ele>
+				<time>2017-10-02T18:10:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012299727119968" lon="-84.21153094467745">
+				<ele>967.1904686335474</ele>
+				<time>2017-10-02T18:10:07Z</time>
+				<extensions>
+					<speed>1.2820422649383545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012303289544008" lon="-84.21154011200709">
+				<ele>967.0566930053756</ele>
+				<time>2017-10-02T18:10:08Z</time>
+				<extensions>
+					<speed>1.2342519760131836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012301942159462" lon="-84.21155264632121">
+				<ele>967.294054210186</ele>
+				<time>2017-10-02T18:10:09Z</time>
+				<extensions>
+					<speed>1.615251064300537</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012300368763928" lon="-84.21157508115843">
+				<ele>968.2704750625417</ele>
+				<time>2017-10-02T18:10:10Z</time>
+				<extensions>
+					<speed>2.5116593837738037</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012292221237631" lon="-84.21159556483433">
+				<ele>968.0159957073629</ele>
+				<time>2017-10-02T18:10:11Z</time>
+				<extensions>
+					<speed>2.9265146255493164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012287741170633" lon="-84.21162585943247">
+				<ele>968.2223530421034</ele>
+				<time>2017-10-02T18:10:12Z</time>
+				<extensions>
+					<speed>3.2441048622131348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282312166299" lon="-84.21165679264014">
+				<ele>967.583764789626</ele>
+				<time>2017-10-02T18:10:13Z</time>
+				<extensions>
+					<speed>3.221611499786377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012277260883696" lon="-84.21169143794815">
+				<ele>968.3297911370173</ele>
+				<time>2017-10-02T18:10:14Z</time>
+				<extensions>
+					<speed>3.3526270389556885</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012273512474541" lon="-84.21172279108912">
+				<ele>969.1889988696203</ele>
+				<time>2017-10-02T18:10:15Z</time>
+				<extensions>
+					<speed>3.1908321380615234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012273557306289" lon="-84.21174834984413">
+				<ele>969.8043642845005</ele>
+				<time>2017-10-02T18:10:16Z</time>
+				<extensions>
+					<speed>2.4248275756835938</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01227437707093" lon="-84.21175937433222">
+				<ele>969.8946862490848</ele>
+				<time>2017-10-02T18:10:17Z</time>
+				<extensions>
+					<speed>1.5812599658966064</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012278266172823" lon="-84.21176166739383">
+				<ele>970.5598034942523</ele>
+				<time>2017-10-02T18:10:18Z</time>
+				<extensions>
+					<speed>0.6240725517272949</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282519997399" lon="-84.21175517249688">
+				<ele>971.0298450803384</ele>
+				<time>2017-10-02T18:10:19Z</time>
+				<extensions>
+					<speed>0.7939032912254333</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282519997399" lon="-84.21175517249688">
+				<ele>971.0298450803384</ele>
+				<time>2017-10-02T18:10:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012281937802669" lon="-84.21174934079755">
+				<ele>971.6725664520636</ele>
+				<time>2017-10-02T18:10:21Z</time>
+				<extensions>
+					<speed>0.5641101002693176</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012281937802669" lon="-84.21174934079755">
+				<ele>971.6725664520636</ele>
+				<time>2017-10-02T18:10:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282098890138" lon="-84.21174896959162">
+				<ele>972.3917749961838</ele>
+				<time>2017-10-02T18:10:23Z</time>
+				<extensions>
+					<speed>0.0353819876909256</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282098890138" lon="-84.21174896959162">
+				<ele>972.3917749961838</ele>
+				<time>2017-10-02T18:10:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282098890138" lon="-84.21174896959162">
+				<ele>972.3917749961838</ele>
+				<time>2017-10-02T18:10:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282098890138" lon="-84.21174896959162">
+				<ele>972.3917749961838</ele>
+				<time>2017-10-02T18:10:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282098890138" lon="-84.21174896959162">
+				<ele>972.3917749961838</ele>
+				<time>2017-10-02T18:10:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282098890138" lon="-84.21174896959162">
+				<ele>972.3917749961838</ele>
+				<time>2017-10-02T18:10:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282098890138" lon="-84.21174896959162">
+				<ele>972.3917749961838</ele>
+				<time>2017-10-02T18:10:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282098890138" lon="-84.21174896959162">
+				<ele>972.3917749961838</ele>
+				<time>2017-10-02T18:10:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282098890138" lon="-84.21174896959162">
+				<ele>972.3917749961838</ele>
+				<time>2017-10-02T18:10:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282098890138" lon="-84.21174896959162">
+				<ele>972.3917749961838</ele>
+				<time>2017-10-02T18:10:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012281874570354" lon="-84.21174613519626">
+				<ele>972.7850186750293</ele>
+				<time>2017-10-02T18:10:33Z</time>
+				<extensions>
+					<speed>0.6112380027770996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282098890138" lon="-84.21174896959162">
+				<ele>972.3917749961838</ele>
+				<time>2017-10-02T18:10:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282098890138" lon="-84.21174896959162">
+				<ele>972.3917749961838</ele>
+				<time>2017-10-02T18:10:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282098890138" lon="-84.21174896959162">
+				<ele>972.3917749961838</ele>
+				<time>2017-10-02T18:10:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282098890138" lon="-84.21174896959162">
+				<ele>972.3917749961838</ele>
+				<time>2017-10-02T18:10:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282098890138" lon="-84.21174896959162">
+				<ele>972.3917749961838</ele>
+				<time>2017-10-02T18:10:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282098890138" lon="-84.21174896959162">
+				<ele>972.3917749961838</ele>
+				<time>2017-10-02T18:10:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282098890138" lon="-84.21174896959162">
+				<ele>972.3917749961838</ele>
+				<time>2017-10-02T18:10:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012282098890138" lon="-84.21174896959162">
+				<ele>972.3917749961838</ele>
+				<time>2017-10-02T18:10:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01227799253733" lon="-84.21175727540627">
+				<ele>972.3685499606654</ele>
+				<time>2017-10-02T18:10:42Z</time>
+				<extensions>
+					<speed>1.2856594324111938</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01227105601845" lon="-84.21177126629341">
+				<ele>972.019753488712</ele>
+				<time>2017-10-02T18:10:43Z</time>
+				<extensions>
+					<speed>1.971587061882019</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012264466641044" lon="-84.21179532592117">
+				<ele>970.9160894416273</ele>
+				<time>2017-10-02T18:10:44Z</time>
+				<extensions>
+					<speed>2.7719273567199707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012258628414791" lon="-84.21182485718889">
+				<ele>969.3331264518201</ele>
+				<time>2017-10-02T18:10:45Z</time>
+				<extensions>
+					<speed>3.047872304916382</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012248476441249" lon="-84.21185311718166">
+				<ele>968.0894754435867</ele>
+				<time>2017-10-02T18:10:46Z</time>
+				<extensions>
+					<speed>3.278923273086548</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01223870979474" lon="-84.2118814017186">
+				<ele>967.705965436995</ele>
+				<time>2017-10-02T18:10:47Z</time>
+				<extensions>
+					<speed>3.2788894176483154</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012228208469532" lon="-84.21191120643252">
+				<ele>967.2514383718371</ele>
+				<time>2017-10-02T18:10:48Z</time>
+				<extensions>
+					<speed>3.319542646408081</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012216266100179" lon="-84.21194103189083">
+				<ele>967.0464516282082</ele>
+				<time>2017-10-02T18:10:49Z</time>
+				<extensions>
+					<speed>3.3873839378356934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012206310659131" lon="-84.21197232838828">
+				<ele>966.8986453330144</ele>
+				<time>2017-10-02T18:10:50Z</time>
+				<extensions>
+					<speed>3.4687206745147705</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012197875269912" lon="-84.21201891322634">
+				<ele>966.1797376507893</ele>
+				<time>2017-10-02T18:10:51Z</time>
+				<extensions>
+					<speed>3.8957014083862305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012188807347698" lon="-84.21207531055127">
+				<ele>965.2553692795336</ele>
+				<time>2017-10-02T18:10:52Z</time>
+				<extensions>
+					<speed>4.597392559051514</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012178536798396" lon="-84.2121370175154">
+				<ele>964.122058163397</ele>
+				<time>2017-10-02T18:10:53Z</time>
+				<extensions>
+					<speed>5.287436485290527</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012158739731907" lon="-84.21221215442408">
+				<ele>962.4607242047787</ele>
+				<time>2017-10-02T18:10:54Z</time>
+				<extensions>
+					<speed>6.388488292694092</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012130587288333" lon="-84.21227998635514">
+				<ele>961.2477425821126</ele>
+				<time>2017-10-02T18:10:55Z</time>
+				<extensions>
+					<speed>6.660329818725586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012105844602237" lon="-84.21234081088541">
+				<ele>959.855794548057</ele>
+				<time>2017-10-02T18:10:56Z</time>
+				<extensions>
+					<speed>6.34675931930542</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012093894098392" lon="-84.212408820721">
+				<ele>958.4602635577321</ele>
+				<time>2017-10-02T18:10:57Z</time>
+				<extensions>
+					<speed>6.092782497406006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012081131441136" lon="-84.2124676652676">
+				<ele>958.5393457105383</ele>
+				<time>2017-10-02T18:10:58Z</time>
+				<extensions>
+					<speed>5.59006929397583</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012064601348598" lon="-84.21251904586549">
+				<ele>958.3062245864421</ele>
+				<time>2017-10-02T18:10:59Z</time>
+				<extensions>
+					<speed>5.034252166748047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012050499565827" lon="-84.21256463998466">
+				<ele>958.0202932683751</ele>
+				<time>2017-10-02T18:11:00Z</time>
+				<extensions>
+					<speed>4.328089237213135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012032869325399" lon="-84.2126018277261">
+				<ele>957.3677092222497</ele>
+				<time>2017-10-02T18:11:01Z</time>
+				<extensions>
+					<speed>4.092957496643066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012015588691755" lon="-84.2126254636031">
+				<ele>957.1756700789556</ele>
+				<time>2017-10-02T18:11:02Z</time>
+				<extensions>
+					<speed>2.7231500148773193</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011998395259576" lon="-84.21264275424093">
+				<ele>956.6254933523014</ele>
+				<time>2017-10-02T18:11:03Z</time>
+				<extensions>
+					<speed>2.0323312282562256</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989950981686" lon="-84.21264431668828">
+				<ele>957.1687662834302</ele>
+				<time>2017-10-02T18:11:04Z</time>
+				<extensions>
+					<speed>0.5950281023979187</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983431965545" lon="-84.21264381925958">
+				<ele>957.1654638806358</ele>
+				<time>2017-10-02T18:11:05Z</time>
+				<extensions>
+					<speed>0.8000449538230896</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011979746720018" lon="-84.21263517313776">
+				<ele>957.1218763077632</ele>
+				<time>2017-10-02T18:11:06Z</time>
+				<extensions>
+					<speed>1.132027506828308</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011979609406719" lon="-84.21262532676741">
+				<ele>956.7858419753611</ele>
+				<time>2017-10-02T18:11:07Z</time>
+				<extensions>
+					<speed>1.2163130044937134</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011978845694717" lon="-84.21261742052745">
+				<ele>956.1775953378528</ele>
+				<time>2017-10-02T18:11:08Z</time>
+				<extensions>
+					<speed>1.053269863128662</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983737424885" lon="-84.21261099008642">
+				<ele>955.7374735623598</ele>
+				<time>2017-10-02T18:11:09Z</time>
+				<extensions>
+					<speed>0.9098734855651855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983737424885" lon="-84.21261099008642">
+				<ele>955.7374735623598</ele>
+				<time>2017-10-02T18:11:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011990851906294" lon="-84.21260327977994">
+				<ele>955.6920982990414</ele>
+				<time>2017-10-02T18:11:11Z</time>
+				<extensions>
+					<speed>0.8666957020759583</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011990851906294" lon="-84.21260327977994">
+				<ele>955.6920982990414</ele>
+				<time>2017-10-02T18:11:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:13Z</time>
+				<extensions>
+					<speed>0.321561723947525</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989605353154" lon="-84.2126000940175">
+				<ele>955.5473906276748</ele>
+				<time>2017-10-02T18:11:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011987718316265" lon="-84.21260613003153">
+				<ele>955.7353802938014</ele>
+				<time>2017-10-02T18:11:49Z</time>
+				<extensions>
+					<speed>0.8563262820243835</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011984955916953" lon="-84.21261930161971">
+				<ele>956.0030625648797</ele>
+				<time>2017-10-02T18:11:50Z</time>
+				<extensions>
+					<speed>1.6834815740585327</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011978733415042" lon="-84.21264302037011">
+				<ele>956.2746553514153</ele>
+				<time>2017-10-02T18:11:51Z</time>
+				<extensions>
+					<speed>2.8776800632476807</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011969758763552" lon="-84.21267481628998">
+				<ele>956.361265216954</ele>
+				<time>2017-10-02T18:11:52Z</time>
+				<extensions>
+					<speed>3.6004221439361572</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01195768664244" lon="-84.21271362194727">
+				<ele>955.990350686945</ele>
+				<time>2017-10-02T18:11:53Z</time>
+				<extensions>
+					<speed>4.553616046905518</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011947086972498" lon="-84.21276028104118">
+				<ele>955.5616450989619</ele>
+				<time>2017-10-02T18:11:54Z</time>
+				<extensions>
+					<speed>5.190302848815918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011938163727693" lon="-84.21281304825054">
+				<ele>954.9912760294974</ele>
+				<time>2017-10-02T18:11:55Z</time>
+				<extensions>
+					<speed>5.7281107902526855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01192325239659" lon="-84.21287155733583">
+				<ele>954.8759809089825</ele>
+				<time>2017-10-02T18:11:56Z</time>
+				<extensions>
+					<speed>6.210322856903076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011906429756797" lon="-84.2129259450493">
+				<ele>954.5341104399413</ele>
+				<time>2017-10-02T18:11:57Z</time>
+				<extensions>
+					<speed>5.714259624481201</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891152778784" lon="-84.2129780593369">
+				<ele>954.4447895232588</ele>
+				<time>2017-10-02T18:11:58Z</time>
+				<extensions>
+					<speed>5.387571811676025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011877169211932" lon="-84.21302636569443">
+				<ele>954.3445479702204</ele>
+				<time>2017-10-02T18:11:59Z</time>
+				<extensions>
+					<speed>5.121661186218262</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011862611731777" lon="-84.21307470096528">
+				<ele>954.1795220496133</ele>
+				<time>2017-10-02T18:12:00Z</time>
+				<extensions>
+					<speed>5.1523518562316895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011848821662387" lon="-84.21312397380528">
+				<ele>954.475306273438</ele>
+				<time>2017-10-02T18:12:01Z</time>
+				<extensions>
+					<speed>5.126158237457275</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011835965266757" lon="-84.21317450665065">
+				<ele>954.9082608819008</ele>
+				<time>2017-10-02T18:12:02Z</time>
+				<extensions>
+					<speed>4.96552038192749</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011820038421797" lon="-84.2132244147946">
+				<ele>955.4501924002543</ele>
+				<time>2017-10-02T18:12:03Z</time>
+				<extensions>
+					<speed>4.966761589050293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01180308885194" lon="-84.21326808420572">
+				<ele>955.9794042119756</ele>
+				<time>2017-10-02T18:12:04Z</time>
+				<extensions>
+					<speed>3.8806042671203613</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011787531350059" lon="-84.21330523169595">
+				<ele>956.4092275872827</ele>
+				<time>2017-10-02T18:12:05Z</time>
+				<extensions>
+					<speed>2.787635564804077</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011774281528927" lon="-84.21333264258209">
+				<ele>956.16048657801</ele>
+				<time>2017-10-02T18:12:06Z</time>
+				<extensions>
+					<speed>1.6573415994644165</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011765254589454" lon="-84.2133522405713">
+				<ele>956.0415905024856</ele>
+				<time>2017-10-02T18:12:07Z</time>
+				<extensions>
+					<speed>1.193494200706482</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011761147542169" lon="-84.21336494837934">
+				<ele>955.669123432599</ele>
+				<time>2017-10-02T18:12:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011761147542169" lon="-84.21336494837934">
+				<ele>955.669123432599</ele>
+				<time>2017-10-02T18:12:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011761147542169" lon="-84.21336494837934">
+				<ele>955.669123432599</ele>
+				<time>2017-10-02T18:12:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011761147542169" lon="-84.21336494837934">
+				<ele>955.669123432599</ele>
+				<time>2017-10-02T18:12:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011760388130464" lon="-84.21336196454803">
+				<ele>955.5268383668736</ele>
+				<time>2017-10-02T18:12:12Z</time>
+				<extensions>
+					<speed>0.7770264744758606</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011760388130464" lon="-84.21336196454803">
+				<ele>955.5268383668736</ele>
+				<time>2017-10-02T18:12:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011758726846972" lon="-84.21335744300171">
+				<ele>954.66641670838</ele>
+				<time>2017-10-02T18:12:14Z</time>
+				<extensions>
+					<speed>0.40423884987831116</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011758726846972" lon="-84.21335744300171">
+				<ele>954.66641670838</ele>
+				<time>2017-10-02T18:12:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011758154334586" lon="-84.21336164270303">
+				<ele>954.7662006625906</ele>
+				<time>2017-10-02T18:12:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011758154334586" lon="-84.21336164270303">
+				<ele>954.7662006625906</ele>
+				<time>2017-10-02T18:12:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011758154334586" lon="-84.21336164270303">
+				<ele>954.7662006625906</ele>
+				<time>2017-10-02T18:12:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011758154334586" lon="-84.21336164270303">
+				<ele>954.7662006625906</ele>
+				<time>2017-10-02T18:12:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011753748199425" lon="-84.21337317606593">
+				<ele>954.843412084505</ele>
+				<time>2017-10-02T18:12:20Z</time>
+				<extensions>
+					<speed>1.7395126819610596</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01174684164675" lon="-84.21339725055617">
+				<ele>955.0674731396139</ele>
+				<time>2017-10-02T18:12:21Z</time>
+				<extensions>
+					<speed>3.044764995574951</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01173853220265" lon="-84.2134324245318">
+				<ele>954.6985300900415</ele>
+				<time>2017-10-02T18:12:22Z</time>
+				<extensions>
+					<speed>4.496715545654297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01173067275924" lon="-84.21347637294816">
+				<ele>954.3843564223498</ele>
+				<time>2017-10-02T18:12:23Z</time>
+				<extensions>
+					<speed>5.145730972290039</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011721388306661" lon="-84.21352629560315">
+				<ele>954.1648482410237</ele>
+				<time>2017-10-02T18:12:24Z</time>
+				<extensions>
+					<speed>5.629121780395508</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011710490524429" lon="-84.21357740126892">
+				<ele>953.974988414906</ele>
+				<time>2017-10-02T18:12:25Z</time>
+				<extensions>
+					<speed>5.426679611206055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011694830994271" lon="-84.21363055234856">
+				<ele>954.0742661273107</ele>
+				<time>2017-10-02T18:12:26Z</time>
+				<extensions>
+					<speed>6.0573225021362305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011676946586567" lon="-84.2136846679963">
+				<ele>954.0509717380628</ele>
+				<time>2017-10-02T18:12:27Z</time>
+				<extensions>
+					<speed>6.09337043762207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011659453342661" lon="-84.21373236522989">
+				<ele>954.1271653426811</ele>
+				<time>2017-10-02T18:12:28Z</time>
+				<extensions>
+					<speed>5.351088523864746</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01161565126194" lon="-84.21377881947565">
+				<ele>954.2565559828654</ele>
+				<time>2017-10-02T18:12:29Z</time>
+				<extensions>
+					<speed>5.357203483581543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011560641657626" lon="-84.2138034304287">
+				<ele>954.5249923802912</ele>
+				<time>2017-10-02T18:12:30Z</time>
+				<extensions>
+					<speed>6.35609245300293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011502239313225" lon="-84.21380881803911">
+				<ele>954.5373348006979</ele>
+				<time>2017-10-02T18:12:31Z</time>
+				<extensions>
+					<speed>6.337375164031982</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011439897030817" lon="-84.21380917023706">
+				<ele>954.3057081131265</ele>
+				<time>2017-10-02T18:12:32Z</time>
+				<extensions>
+					<speed>6.9332990646362305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011369386655417" lon="-84.21380065100418">
+				<ele>954.3818504074588</ele>
+				<time>2017-10-02T18:12:33Z</time>
+				<extensions>
+					<speed>7.626791000366211</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011290540046438" lon="-84.21378546677303">
+				<ele>954.4684927845374</ele>
+				<time>2017-10-02T18:12:34Z</time>
+				<extensions>
+					<speed>8.834834098815918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011202657416694" lon="-84.21376322989391">
+				<ele>954.4406699761748</ele>
+				<time>2017-10-02T18:12:35Z</time>
+				<extensions>
+					<speed>10.197402954101563</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011108054260443" lon="-84.21373527111584">
+				<ele>954.3012934690341</ele>
+				<time>2017-10-02T18:12:36Z</time>
+				<extensions>
+					<speed>11.310408592224121</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011011632305312" lon="-84.21369814756895">
+				<ele>954.357410508208</ele>
+				<time>2017-10-02T18:12:37Z</time>
+				<extensions>
+					<speed>11.219736099243164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01091229944868" lon="-84.21365800116335">
+				<ele>954.5614366708323</ele>
+				<time>2017-10-02T18:12:38Z</time>
+				<extensions>
+					<speed>11.682611465454102</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010810382980209" lon="-84.21361705099518">
+				<ele>954.4232611348853</ele>
+				<time>2017-10-02T18:12:39Z</time>
+				<extensions>
+					<speed>11.93360424041748</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01070262751982" lon="-84.21358239381729">
+				<ele>954.1315197292715</ele>
+				<time>2017-10-02T18:12:40Z</time>
+				<extensions>
+					<speed>12.265830039978027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01059430887579" lon="-84.21355082887862">
+				<ele>953.8635353855789</ele>
+				<time>2017-10-02T18:12:41Z</time>
+				<extensions>
+					<speed>12.199395179748535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010491345611038" lon="-84.21352095383473">
+				<ele>953.9377011703327</ele>
+				<time>2017-10-02T18:12:42Z</time>
+				<extensions>
+					<speed>11.602843284606934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010402325459454" lon="-84.21348798003693">
+				<ele>954.0792440259829</ele>
+				<time>2017-10-02T18:12:43Z</time>
+				<extensions>
+					<speed>10.14433479309082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0103294628843" lon="-84.21345952324974">
+				<ele>954.2069920729846</ele>
+				<time>2017-10-02T18:12:44Z</time>
+				<extensions>
+					<speed>7.705862998962402</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01024560113339" lon="-84.2134191034312">
+				<ele>956.5782755855471</ele>
+				<time>2017-10-02T18:12:45Z</time>
+				<extensions>
+					<speed>6.150464057922363</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010196995112409" lon="-84.2133843312227">
+				<ele>957.4330320004374</ele>
+				<time>2017-10-02T18:12:46Z</time>
+				<extensions>
+					<speed>5.25016975402832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010169250641955" lon="-84.21334757552866">
+				<ele>957.8661266323179</ele>
+				<time>2017-10-02T18:12:47Z</time>
+				<extensions>
+					<speed>4.295035362243652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01016209134257" lon="-84.21330156574803">
+				<ele>958.2082732934505</ele>
+				<time>2017-10-02T18:12:48Z</time>
+				<extensions>
+					<speed>4.550487995147705</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010153653223016" lon="-84.21326793898884">
+				<ele>958.3780008088797</ele>
+				<time>2017-10-02T18:12:49Z</time>
+				<extensions>
+					<speed>3.419283390045166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010152477563873" lon="-84.21325094057762">
+				<ele>958.3474565260112</ele>
+				<time>2017-10-02T18:12:50Z</time>
+				<extensions>
+					<speed>1.4360215663909912</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010152168784641" lon="-84.21324203073878">
+				<ele>958.9315187847242</ele>
+				<time>2017-10-02T18:12:51Z</time>
+				<extensions>
+					<speed>0.5480480790138245</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010152168784641" lon="-84.21324203073878">
+				<ele>958.9315187847242</ele>
+				<time>2017-10-02T18:12:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01015156595436" lon="-84.21324792759691">
+				<ele>959.2499404950067</ele>
+				<time>2017-10-02T18:12:53Z</time>
+				<extensions>
+					<speed>1.0696885585784912</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01015970678073" lon="-84.21325443201037">
+				<ele>959.5232458990067</ele>
+				<time>2017-10-02T18:12:54Z</time>
+				<extensions>
+					<speed>0.9884364604949951</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01015970678073" lon="-84.21325443201037">
+				<ele>959.5232458990067</ele>
+				<time>2017-10-02T18:12:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010157029961013" lon="-84.21325073815014">
+				<ele>960.057575118728</ele>
+				<time>2017-10-02T18:12:56Z</time>
+				<extensions>
+					<speed>0.2553212344646454</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010157029961013" lon="-84.21325073815014">
+				<ele>960.057575118728</ele>
+				<time>2017-10-02T18:12:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010157029961013" lon="-84.21325073815014">
+				<ele>960.057575118728</ele>
+				<time>2017-10-02T18:12:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010150662828623" lon="-84.21324912175926">
+				<ele>960.3681473899633</ele>
+				<time>2017-10-02T18:12:59Z</time>
+				<extensions>
+					<speed>0.12464608997106552</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010150662828623" lon="-84.21324912175926">
+				<ele>960.3681473899633</ele>
+				<time>2017-10-02T18:13:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010150662828623" lon="-84.21324912175926">
+				<ele>960.3681473899633</ele>
+				<time>2017-10-02T18:13:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010150662828623" lon="-84.21324912175926">
+				<ele>960.3681473899633</ele>
+				<time>2017-10-02T18:13:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010150662828623" lon="-84.21324912175926">
+				<ele>960.3681473899633</ele>
+				<time>2017-10-02T18:13:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010150662828623" lon="-84.21324912175926">
+				<ele>960.3681473899633</ele>
+				<time>2017-10-02T18:13:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010150662828623" lon="-84.21324912175926">
+				<ele>960.3681473899633</ele>
+				<time>2017-10-02T18:13:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010150662828623" lon="-84.21324912175926">
+				<ele>960.3681473899633</ele>
+				<time>2017-10-02T18:13:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010150662828623" lon="-84.21324912175926">
+				<ele>960.3681473899633</ele>
+				<time>2017-10-02T18:13:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010150662828623" lon="-84.21324912175926">
+				<ele>960.3681473899633</ele>
+				<time>2017-10-02T18:13:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010150662828623" lon="-84.21324912175926">
+				<ele>960.3681473899633</ele>
+				<time>2017-10-02T18:13:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010150662828623" lon="-84.21324912175926">
+				<ele>960.3681473899633</ele>
+				<time>2017-10-02T18:13:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010150662828623" lon="-84.21324912175926">
+				<ele>960.3681473899633</ele>
+				<time>2017-10-02T18:13:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010150662828623" lon="-84.21324912175926">
+				<ele>960.3681473899633</ele>
+				<time>2017-10-02T18:13:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010150662828623" lon="-84.21324912175926">
+				<ele>960.3681473899633</ele>
+				<time>2017-10-02T18:13:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010155476241387" lon="-84.21323754919175">
+				<ele>959.3618690017611</ele>
+				<time>2017-10-02T18:13:14Z</time>
+				<extensions>
+					<speed>0.6985276341438293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0101739601905" lon="-84.21323018962964">
+				<ele>958.7335392981768</ele>
+				<time>2017-10-02T18:13:15Z</time>
+				<extensions>
+					<speed>1.3653573989868164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010202258162968" lon="-84.2132158033168">
+				<ele>958.1789176454768</ele>
+				<time>2017-10-02T18:13:16Z</time>
+				<extensions>
+					<speed>2.2244088649749756</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010224743097123" lon="-84.21319225592448">
+				<ele>958.1119618080556</ele>
+				<time>2017-10-02T18:13:17Z</time>
+				<extensions>
+					<speed>2.844419002532959</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01025082145239" lon="-84.21317138015488">
+				<ele>957.9093023333699</ele>
+				<time>2017-10-02T18:13:18Z</time>
+				<extensions>
+					<speed>2.8745675086975098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010294056258754" lon="-84.21315921958488">
+				<ele>957.118159125559</ele>
+				<time>2017-10-02T18:13:19Z</time>
+				<extensions>
+					<speed>2.7510135173797607</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010312356800103" lon="-84.21314729168223">
+				<ele>956.3098159795627</ele>
+				<time>2017-10-02T18:13:20Z</time>
+				<extensions>
+					<speed>2.293247938156128</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010347866666198" lon="-84.2131367317187">
+				<ele>955.2341797603294</ele>
+				<time>2017-10-02T18:13:21Z</time>
+				<extensions>
+					<speed>2.025585412979126</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010360071470238" lon="-84.21312464626074">
+				<ele>953.8847180847079</ele>
+				<time>2017-10-02T18:13:22Z</time>
+				<extensions>
+					<speed>1.4359033107757568</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010356520655769" lon="-84.2131087703429">
+				<ele>952.5735109476373</ele>
+				<time>2017-10-02T18:13:23Z</time>
+				<extensions>
+					<speed>1.0647083520889282</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010344264186083" lon="-84.21309235732586">
+				<ele>951.7876106407493</ele>
+				<time>2017-10-02T18:13:24Z</time>
+				<extensions>
+					<speed>1.3034789562225342</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010323086981673" lon="-84.21307415757008">
+				<ele>951.8824282009155</ele>
+				<time>2017-10-02T18:13:25Z</time>
+				<extensions>
+					<speed>1.8836044073104858</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01032055003728" lon="-84.21305636809305">
+				<ele>951.7024668976665</ele>
+				<time>2017-10-02T18:13:26Z</time>
+				<extensions>
+					<speed>2.3200316429138184</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010320133803985" lon="-84.21303965602601">
+				<ele>951.7972323577851</ele>
+				<time>2017-10-02T18:13:27Z</time>
+				<extensions>
+					<speed>2.3261475563049316</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010311164700777" lon="-84.21302159124811">
+				<ele>952.2445745225996</ele>
+				<time>2017-10-02T18:13:28Z</time>
+				<extensions>
+					<speed>2.362560987472534</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010294617648317" lon="-84.21300816382691">
+				<ele>952.4302871944383</ele>
+				<time>2017-10-02T18:13:29Z</time>
+				<extensions>
+					<speed>2.3602311611175537</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010340205892772" lon="-84.21299865965403">
+				<ele>951.2620179736987</ele>
+				<time>2017-10-02T18:13:30Z</time>
+				<extensions>
+					<speed>2.4699344635009766</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010371637808325" lon="-84.21300075879267">
+				<ele>950.5131095163524</ele>
+				<time>2017-10-02T18:13:31Z</time>
+				<extensions>
+					<speed>2.252079725265503</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01039063244451" lon="-84.21300115657263">
+				<ele>950.0264349067584</ele>
+				<time>2017-10-02T18:13:32Z</time>
+				<extensions>
+					<speed>1.681111454963684</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010400223145767" lon="-84.21302655781558">
+				<ele>949.6267499485984</ele>
+				<time>2017-10-02T18:13:33Z</time>
+				<extensions>
+					<speed>0.4039463400840759</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:34Z</time>
+				<extensions>
+					<speed>0.21639400720596313</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010396950597917" lon="-84.21301448664852">
+				<ele>949.5147085245699</ele>
+				<time>2017-10-02T18:13:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010300844533177" lon="-84.21299711874848">
+				<ele>950.9428943293169</ele>
+				<time>2017-10-02T18:13:59Z</time>
+				<extensions>
+					<speed>1.160991907119751</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010233273588172" lon="-84.21298275305463">
+				<ele>951.572240518406</ele>
+				<time>2017-10-02T18:14:00Z</time>
+				<extensions>
+					<speed>1.7033989429473877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010179865027503" lon="-84.2129583142386">
+				<ele>952.0228024180979</ele>
+				<time>2017-10-02T18:14:01Z</time>
+				<extensions>
+					<speed>2.254304885864258</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010147912272528" lon="-84.21293208552345">
+				<ele>952.1615246068686</ele>
+				<time>2017-10-02T18:14:02Z</time>
+				<extensions>
+					<speed>2.6324126720428467</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010110237786325" lon="-84.21289806851985">
+				<ele>952.2465152898803</ele>
+				<time>2017-10-02T18:14:03Z</time>
+				<extensions>
+					<speed>3.3115296363830566</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01008043303418" lon="-84.2128719228253">
+				<ele>952.4120381772518</ele>
+				<time>2017-10-02T18:14:04Z</time>
+				<extensions>
+					<speed>3.419771909713745</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01005062452225" lon="-84.2128547001098">
+				<ele>952.4937978526577</ele>
+				<time>2017-10-02T18:14:05Z</time>
+				<extensions>
+					<speed>3.4375216960906982</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010011731110492" lon="-84.21283265797192">
+				<ele>952.6806882228702</ele>
+				<time>2017-10-02T18:14:06Z</time>
+				<extensions>
+					<speed>3.6947765350341797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009976392680326" lon="-84.21280932891463">
+				<ele>952.7636623494327</ele>
+				<time>2017-10-02T18:14:07Z</time>
+				<extensions>
+					<speed>4.007201671600342</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009931472140103" lon="-84.21276881554049">
+				<ele>952.8906561080366</ele>
+				<time>2017-10-02T18:14:08Z</time>
+				<extensions>
+					<speed>4.963682651519775</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00988287026028" lon="-84.21272699059337">
+				<ele>953.0847241412848</ele>
+				<time>2017-10-02T18:14:09Z</time>
+				<extensions>
+					<speed>6.011406421661377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00982691109124" lon="-84.21268598031315">
+				<ele>953.2327663069591</ele>
+				<time>2017-10-02T18:14:10Z</time>
+				<extensions>
+					<speed>6.72308349609375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009760703860449" lon="-84.2126402382773">
+				<ele>953.4079148545861</ele>
+				<time>2017-10-02T18:14:11Z</time>
+				<extensions>
+					<speed>7.487635135650635</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009686782405886" lon="-84.21258817177687">
+				<ele>953.7388070328161</ele>
+				<time>2017-10-02T18:14:12Z</time>
+				<extensions>
+					<speed>8.30164909362793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009613122087341" lon="-84.21252669876924">
+				<ele>954.0235224245116</ele>
+				<time>2017-10-02T18:14:13Z</time>
+				<extensions>
+					<speed>8.942349433898926</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009531795659036" lon="-84.21244841089624">
+				<ele>954.1334907868877</ele>
+				<time>2017-10-02T18:14:14Z</time>
+				<extensions>
+					<speed>10.375988006591797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00944927161792" lon="-84.21237450460848">
+				<ele>954.2093368638307</ele>
+				<time>2017-10-02T18:14:15Z</time>
+				<extensions>
+					<speed>11.286478996276855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00936225032215" lon="-84.21229711047492">
+				<ele>954.2897787233815</ele>
+				<time>2017-10-02T18:14:16Z</time>
+				<extensions>
+					<speed>11.683761596679688</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009275124291566" lon="-84.21222278432137">
+				<ele>954.447280459106</ele>
+				<time>2017-10-02T18:14:17Z</time>
+				<extensions>
+					<speed>11.902959823608398</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009189536852132" lon="-84.21215141426501">
+				<ele>954.903245748952</ele>
+				<time>2017-10-02T18:14:18Z</time>
+				<extensions>
+					<speed>11.947135925292969</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009111463681046" lon="-84.21207012116815">
+				<ele>955.3646931974217</ele>
+				<time>2017-10-02T18:14:19Z</time>
+				<extensions>
+					<speed>11.936116218566895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009034815858067" lon="-84.21198613131429">
+				<ele>955.7352203652263</ele>
+				<time>2017-10-02T18:14:20Z</time>
+				<extensions>
+					<speed>11.950495719909668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008954059390446" lon="-84.21190725828968">
+				<ele>956.29881439358</ele>
+				<time>2017-10-02T18:14:21Z</time>
+				<extensions>
+					<speed>11.912213325500488</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008880543439126" lon="-84.21183063166903">
+				<ele>956.7906549479812</ele>
+				<time>2017-10-02T18:14:22Z</time>
+				<extensions>
+					<speed>11.938600540161133</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008818070199348" lon="-84.21174456061486">
+				<ele>956.693455716595</ele>
+				<time>2017-10-02T18:14:23Z</time>
+				<extensions>
+					<speed>11.966564178466797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008756017212631" lon="-84.21164689759388">
+				<ele>956.8182299621403</ele>
+				<time>2017-10-02T18:14:24Z</time>
+				<extensions>
+					<speed>12.271675109863281</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008715418771008" lon="-84.21154466151995">
+				<ele>957.1264365734532</ele>
+				<time>2017-10-02T18:14:25Z</time>
+				<extensions>
+					<speed>12.553434371948242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008691114536406" lon="-84.21143557417773">
+				<ele>957.4190307892859</ele>
+				<time>2017-10-02T18:14:26Z</time>
+				<extensions>
+					<speed>12.657614707946777</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008668390619514" lon="-84.21130503632199">
+				<ele>957.2558259386569</ele>
+				<time>2017-10-02T18:14:27Z</time>
+				<extensions>
+					<speed>14.009583473205566</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008647617103508" lon="-84.21115898571922">
+				<ele>955.8514708206058</ele>
+				<time>2017-10-02T18:14:28Z</time>
+				<extensions>
+					<speed>14.192400932312012</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008634726132085" lon="-84.211017585587">
+				<ele>954.5136651080102</ele>
+				<time>2017-10-02T18:14:29Z</time>
+				<extensions>
+					<speed>13.849013328552246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008621133874032" lon="-84.21088822896783">
+				<ele>953.0143621191382</ele>
+				<time>2017-10-02T18:14:30Z</time>
+				<extensions>
+					<speed>13.24431037902832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008606240494705" lon="-84.21078131700015">
+				<ele>952.4004243649542</ele>
+				<time>2017-10-02T18:14:31Z</time>
+				<extensions>
+					<speed>12.496917724609375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008606469307786" lon="-84.21068300155679">
+				<ele>951.8386160740629</ele>
+				<time>2017-10-02T18:14:32Z</time>
+				<extensions>
+					<speed>11.403759002685547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008609140093919" lon="-84.21060956870411">
+				<ele>950.5509642772377</ele>
+				<time>2017-10-02T18:14:33Z</time>
+				<extensions>
+					<speed>8.757304191589355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008607725989053" lon="-84.21054651524454">
+				<ele>948.1917806258425</ele>
+				<time>2017-10-02T18:14:34Z</time>
+				<extensions>
+					<speed>5.789527416229248</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008608819577265" lon="-84.21050999399635">
+				<ele>946.3564199190587</ele>
+				<time>2017-10-02T18:14:35Z</time>
+				<extensions>
+					<speed>3.203530788421631</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008609752311093" lon="-84.2104915396439">
+				<ele>945.4278704077005</ele>
+				<time>2017-10-02T18:14:36Z</time>
+				<extensions>
+					<speed>1.3804042339324951</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00860671487793" lon="-84.21048713735067">
+				<ele>945.5362094156444</ele>
+				<time>2017-10-02T18:14:37Z</time>
+				<extensions>
+					<speed>0.21242640912532806</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008604838832328" lon="-84.21049775988295">
+				<ele>946.086901425384</ele>
+				<time>2017-10-02T18:14:38Z</time>
+				<extensions>
+					<speed>1.1523990631103516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008601521895027" lon="-84.21051490698838">
+				<ele>946.420126311481</ele>
+				<time>2017-10-02T18:14:39Z</time>
+				<extensions>
+					<speed>1.7390035390853882</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008600228801086" lon="-84.21053056364181">
+				<ele>946.3674151068553</ele>
+				<time>2017-10-02T18:14:40Z</time>
+				<extensions>
+					<speed>1.5434596538543701</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008600755073124" lon="-84.21053841698343">
+				<ele>946.0992346387357</ele>
+				<time>2017-10-02T18:14:41Z</time>
+				<extensions>
+					<speed>1.053633213043213</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00860409617681" lon="-84.21054374876938">
+				<ele>945.8708707941696</ele>
+				<time>2017-10-02T18:14:42Z</time>
+				<extensions>
+					<speed>0.7869457006454468</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00860409617681" lon="-84.21054374876938">
+				<ele>945.8708707941696</ele>
+				<time>2017-10-02T18:14:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008613519942738" lon="-84.21055056325133">
+				<ele>945.5062991641462</ele>
+				<time>2017-10-02T18:14:44Z</time>
+				<extensions>
+					<speed>0.38702788949012756</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008613519942738" lon="-84.21055056325133">
+				<ele>945.5062991641462</ele>
+				<time>2017-10-02T18:14:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008613519942738" lon="-84.21055056325133">
+				<ele>945.5062991641462</ele>
+				<time>2017-10-02T18:14:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008613519942738" lon="-84.21055056325133">
+				<ele>945.5062991641462</ele>
+				<time>2017-10-02T18:14:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008613519942738" lon="-84.21055056325133">
+				<ele>945.5062991641462</ele>
+				<time>2017-10-02T18:14:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008613519942738" lon="-84.21055056325133">
+				<ele>945.5062991641462</ele>
+				<time>2017-10-02T18:14:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008613519942738" lon="-84.21055056325133">
+				<ele>945.5062991641462</ele>
+				<time>2017-10-02T18:14:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008613519942738" lon="-84.21055056325133">
+				<ele>945.5062991641462</ele>
+				<time>2017-10-02T18:14:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008613519942738" lon="-84.21055056325133">
+				<ele>945.5062991641462</ele>
+				<time>2017-10-02T18:14:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008613925610122" lon="-84.21054896652703">
+				<ele>944.8057305058464</ele>
+				<time>2017-10-02T18:14:53Z</time>
+				<extensions>
+					<speed>0.632686972618103</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008613660765848" lon="-84.21054346334854">
+				<ele>943.8862623209134</ele>
+				<time>2017-10-02T18:14:54Z</time>
+				<extensions>
+					<speed>1.2117165327072144</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008613617796264" lon="-84.21053128507087">
+				<ele>943.72812556196</ele>
+				<time>2017-10-02T18:14:55Z</time>
+				<extensions>
+					<speed>1.394197702407837</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008614204445186" lon="-84.21051926428567">
+				<ele>943.7629294041544</ele>
+				<time>2017-10-02T18:14:56Z</time>
+				<extensions>
+					<speed>1.4186335802078247</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008616630927872" lon="-84.21049733709806">
+				<ele>943.7538984138519</ele>
+				<time>2017-10-02T18:14:57Z</time>
+				<extensions>
+					<speed>1.874790072441101</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00861842551004" lon="-84.21047416266946">
+				<ele>944.0637312838808</ele>
+				<time>2017-10-02T18:14:58Z</time>
+				<extensions>
+					<speed>2.0224852561950684</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008617773455901" lon="-84.2104551687431">
+				<ele>944.4601161805913</ele>
+				<time>2017-10-02T18:14:59Z</time>
+				<extensions>
+					<speed>1.958330750465393</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008614729595983" lon="-84.21043945969524">
+				<ele>944.978822610341</ele>
+				<time>2017-10-02T18:15:00Z</time>
+				<extensions>
+					<speed>1.622822642326355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008609787208298" lon="-84.21043020596854">
+				<ele>945.5348408538848</ele>
+				<time>2017-10-02T18:15:01Z</time>
+				<extensions>
+					<speed>1.0684983730316162</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008596147894602" lon="-84.21042609626113">
+				<ele>945.9323665332049</ele>
+				<time>2017-10-02T18:15:02Z</time>
+				<extensions>
+					<speed>0.3970687687397003</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008596147894602" lon="-84.21042609626113">
+				<ele>945.9323665332049</ele>
+				<time>2017-10-02T18:15:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008596147894602" lon="-84.21042609626113">
+				<ele>945.9323665332049</ele>
+				<time>2017-10-02T18:15:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008596147894602" lon="-84.21042609626113">
+				<ele>945.9323665332049</ele>
+				<time>2017-10-02T18:15:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008596147894602" lon="-84.21042609626113">
+				<ele>945.9323665332049</ele>
+				<time>2017-10-02T18:15:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008596147894602" lon="-84.21042609626113">
+				<ele>945.9323665332049</ele>
+				<time>2017-10-02T18:15:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008596147894602" lon="-84.21042609626113">
+				<ele>945.9323665332049</ele>
+				<time>2017-10-02T18:15:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008596147894602" lon="-84.21042609626113">
+				<ele>945.9323665332049</ele>
+				<time>2017-10-02T18:15:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008596147894602" lon="-84.21042609626113">
+				<ele>945.9323665332049</ele>
+				<time>2017-10-02T18:15:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008595123204927" lon="-84.21041087766406">
+				<ele>945.8603200381622</ele>
+				<time>2017-10-02T18:15:11Z</time>
+				<extensions>
+					<speed>1.1058318614959717</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008593364445483" lon="-84.2103892281755">
+				<ele>945.8296570032835</ele>
+				<time>2017-10-02T18:15:12Z</time>
+				<extensions>
+					<speed>1.7176308631896973</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00860065824836" lon="-84.21036357755861">
+				<ele>945.7728464789689</ele>
+				<time>2017-10-02T18:15:13Z</time>
+				<extensions>
+					<speed>2.183830738067627</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008610317919594" lon="-84.2103409471616">
+				<ele>945.9103456949815</ele>
+				<time>2017-10-02T18:15:14Z</time>
+				<extensions>
+					<speed>2.3651721477508545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008619691927422" lon="-84.21031076421527">
+				<ele>946.3167846370488</ele>
+				<time>2017-10-02T18:15:15Z</time>
+				<extensions>
+					<speed>2.4421865940093994</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008628283302622" lon="-84.2102894693276">
+				<ele>946.4160413593054</ele>
+				<time>2017-10-02T18:15:16Z</time>
+				<extensions>
+					<speed>2.2870559692382813</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008627008406375" lon="-84.21026733995816">
+				<ele>946.8248884221539</ele>
+				<time>2017-10-02T18:15:17Z</time>
+				<extensions>
+					<speed>2.044037103652954</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008618771759693" lon="-84.21024662692783">
+				<ele>947.2903054365888</ele>
+				<time>2017-10-02T18:15:18Z</time>
+				<extensions>
+					<speed>1.8797404766082764</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008613371006563" lon="-84.21023628585482">
+				<ele>947.728359490633</ele>
+				<time>2017-10-02T18:15:19Z</time>
+				<extensions>
+					<speed>1.3251186609268188</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008618365763507" lon="-84.21023397771692">
+				<ele>948.0512236664072</ele>
+				<time>2017-10-02T18:15:20Z</time>
+				<extensions>
+					<speed>0.6485722064971924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008625580868356" lon="-84.21023520110892">
+				<ele>948.2559356121346</ele>
+				<time>2017-10-02T18:15:21Z</time>
+				<extensions>
+					<speed>0.0638439804315567</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0086323071296" lon="-84.2102308290143">
+				<ele>948.3642238108441</ele>
+				<time>2017-10-02T18:15:22Z</time>
+				<extensions>
+					<speed>0.1715811938047409</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0086323071296" lon="-84.2102308290143">
+				<ele>948.3642238108441</ele>
+				<time>2017-10-02T18:15:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00863873200455" lon="-84.21023105634119">
+				<ele>948.4211718570441</ele>
+				<time>2017-10-02T18:15:24Z</time>
+				<extensions>
+					<speed>0.1341223120689392</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008641016404932" lon="-84.21023216234599">
+				<ele>948.4564946042374</ele>
+				<time>2017-10-02T18:15:25Z</time>
+				<extensions>
+					<speed>0.12135715782642365</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008644549923147" lon="-84.21023618211105">
+				<ele>948.4782231571153</ele>
+				<time>2017-10-02T18:15:26Z</time>
+				<extensions>
+					<speed>0.1830012947320938</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008647532480447" lon="-84.21023397503374">
+				<ele>948.2498756200075</ele>
+				<time>2017-10-02T18:15:27Z</time>
+				<extensions>
+					<speed>0.12110887467861176</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008647532480447" lon="-84.21023397503374">
+				<ele>948.2498756200075</ele>
+				<time>2017-10-02T18:15:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00864933881599" lon="-84.21024048744503">
+				<ele>948.121478763409</ele>
+				<time>2017-10-02T18:15:29Z</time>
+				<extensions>
+					<speed>0.2067037969827652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008650224449031" lon="-84.21024235315335">
+				<ele>948.1380828795955</ele>
+				<time>2017-10-02T18:15:30Z</time>
+				<extensions>
+					<speed>0.17867246270179749</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008648109104081" lon="-84.21024095361979">
+				<ele>948.1748717920855</ele>
+				<time>2017-10-02T18:15:31Z</time>
+				<extensions>
+					<speed>0.15714174509048462</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008645050435995" lon="-84.21022679209874">
+				<ele>948.2166776657104</ele>
+				<time>2017-10-02T18:15:32Z</time>
+				<extensions>
+					<speed>0.12867721915245056</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008644860176254" lon="-84.21020389329607">
+				<ele>948.2533279769123</ele>
+				<time>2017-10-02T18:15:33Z</time>
+				<extensions>
+					<speed>0.20832164585590363</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008639253286752" lon="-84.21017958366205">
+				<ele>948.2688117111102</ele>
+				<time>2017-10-02T18:15:34Z</time>
+				<extensions>
+					<speed>0.4188213646411896</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008635266209433" lon="-84.21016481411647">
+				<ele>948.2115208134055</ele>
+				<time>2017-10-02T18:15:35Z</time>
+				<extensions>
+					<speed>0.5552338361740112</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008625892954683" lon="-84.21010388118404">
+				<ele>947.9060353050008</ele>
+				<time>2017-10-02T18:15:36Z</time>
+				<extensions>
+					<speed>1.5316280126571655</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008617103428858" lon="-84.21004088860009">
+				<ele>947.5244431672618</ele>
+				<time>2017-10-02T18:15:37Z</time>
+				<extensions>
+					<speed>3.1770503520965576</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008613656409866" lon="-84.21001164939568">
+				<ele>947.3746620155871</ele>
+				<time>2017-10-02T18:15:38Z</time>
+				<extensions>
+					<speed>3.7370412349700928</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008606841452595" lon="-84.20997791946468">
+				<ele>947.2910891305655</ele>
+				<time>2017-10-02T18:15:39Z</time>
+				<extensions>
+					<speed>4.082773208618164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008597636612272" lon="-84.20994114249461">
+				<ele>947.1756749320775</ele>
+				<time>2017-10-02T18:15:40Z</time>
+				<extensions>
+					<speed>4.661625385284424</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008586708483442" lon="-84.20989587800162">
+				<ele>947.1116983378306</ele>
+				<time>2017-10-02T18:15:41Z</time>
+				<extensions>
+					<speed>5.178237438201904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008575230823917" lon="-84.20984524134794">
+				<ele>947.0184186454862</ele>
+				<time>2017-10-02T18:15:42Z</time>
+				<extensions>
+					<speed>5.927314281463623</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008571576921957" lon="-84.20978737370051">
+				<ele>947.0141057148576</ele>
+				<time>2017-10-02T18:15:43Z</time>
+				<extensions>
+					<speed>6.245956897735596</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008574022222" lon="-84.20974228578149">
+				<ele>947.0748988436535</ele>
+				<time>2017-10-02T18:15:44Z</time>
+				<extensions>
+					<speed>6.168858051300049</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008600825498515" lon="-84.20969644745412">
+				<ele>947.1411485746503</ele>
+				<time>2017-10-02T18:15:45Z</time>
+				<extensions>
+					<speed>6.15193510055542</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008605490525156" lon="-84.20963522149704">
+				<ele>947.1517979679629</ele>
+				<time>2017-10-02T18:15:46Z</time>
+				<extensions>
+					<speed>6.314041614532471</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008617110604275" lon="-84.20958023741336">
+				<ele>947.183730901219</ele>
+				<time>2017-10-02T18:15:47Z</time>
+				<extensions>
+					<speed>6.236690044403076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008627302606158" lon="-84.20953888519924">
+				<ele>947.2389251049608</ele>
+				<time>2017-10-02T18:15:48Z</time>
+				<extensions>
+					<speed>5.7212347984313965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008641940830875" lon="-84.20951041294579">
+				<ele>947.4222892820835</ele>
+				<time>2017-10-02T18:15:49Z</time>
+				<extensions>
+					<speed>5.215675354003906</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008650646233383" lon="-84.20947053375433">
+				<ele>947.6350895222276</ele>
+				<time>2017-10-02T18:15:50Z</time>
+				<extensions>
+					<speed>4.9667158126831055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008655038034771" lon="-84.2094514288735">
+				<ele>947.9363641105592</ele>
+				<time>2017-10-02T18:15:51Z</time>
+				<extensions>
+					<speed>3.855576515197754</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008656406570267" lon="-84.20945352996954">
+				<ele>948.4770320672542</ele>
+				<time>2017-10-02T18:15:52Z</time>
+				<extensions>
+					<speed>2.856788158416748</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008657929903128" lon="-84.20944051065032">
+				<ele>948.64589810092</ele>
+				<time>2017-10-02T18:15:53Z</time>
+				<extensions>
+					<speed>2.2034542560577393</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662842673301" lon="-84.20942017078363">
+				<ele>948.7309264317155</ele>
+				<time>2017-10-02T18:15:54Z</time>
+				<extensions>
+					<speed>2.0395891666412354</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662056221448" lon="-84.20939445030442">
+				<ele>948.7185710407794</ele>
+				<time>2017-10-02T18:15:55Z</time>
+				<extensions>
+					<speed>1.9109952449798584</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00865761778916" lon="-84.20936759628796">
+				<ele>948.7637624386698</ele>
+				<time>2017-10-02T18:15:56Z</time>
+				<extensions>
+					<speed>1.9543124437332153</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008655224222043" lon="-84.20933932366479">
+				<ele>948.8206061460078</ele>
+				<time>2017-10-02T18:15:57Z</time>
+				<extensions>
+					<speed>2.1534740924835205</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008652054695228" lon="-84.20932035737104">
+				<ele>948.9007164407521</ele>
+				<time>2017-10-02T18:15:58Z</time>
+				<extensions>
+					<speed>2.1310713291168213</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008650444601091" lon="-84.20930075009699">
+				<ele>948.9343680199236</ele>
+				<time>2017-10-02T18:15:59Z</time>
+				<extensions>
+					<speed>2.1390881538391113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008650447568572" lon="-84.20927459589396">
+				<ele>948.8726602355018</ele>
+				<time>2017-10-02T18:16:00Z</time>
+				<extensions>
+					<speed>2.2992043495178223</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00864919875985" lon="-84.20924470190923">
+				<ele>948.8518012613058</ele>
+				<time>2017-10-02T18:16:01Z</time>
+				<extensions>
+					<speed>2.449127674102783</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008647290829966" lon="-84.2092088464781">
+				<ele>948.799778174609</ele>
+				<time>2017-10-02T18:16:02Z</time>
+				<extensions>
+					<speed>2.6412034034729004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008645900669771" lon="-84.20915271250944">
+				<ele>948.6841066302732</ele>
+				<time>2017-10-02T18:16:03Z</time>
+				<extensions>
+					<speed>3.207015037536621</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008650858914685" lon="-84.20909573556149">
+				<ele>948.6286906218156</ele>
+				<time>2017-10-02T18:16:04Z</time>
+				<extensions>
+					<speed>3.912766218185425</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00866154662958" lon="-84.20905290208556">
+				<ele>948.598216233775</ele>
+				<time>2017-10-02T18:16:05Z</time>
+				<extensions>
+					<speed>4.299943447113037</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008680472106127" lon="-84.20900440062056">
+				<ele>948.5991605240852</ele>
+				<time>2017-10-02T18:16:06Z</time>
+				<extensions>
+					<speed>4.758427619934082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008695384788558" lon="-84.20894281824889">
+				<ele>948.5611873967573</ele>
+				<time>2017-10-02T18:16:07Z</time>
+				<extensions>
+					<speed>5.134274959564209</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00870298394798" lon="-84.20882228837718">
+				<ele>948.5204799044877</ele>
+				<time>2017-10-02T18:16:08Z</time>
+				<extensions>
+					<speed>6.7403883934021</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008704450262048" lon="-84.20869484584469">
+				<ele>948.4659364940599</ele>
+				<time>2017-10-02T18:16:09Z</time>
+				<extensions>
+					<speed>8.889232635498047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008685278468272" lon="-84.20856729522323">
+				<ele>948.1104109305888</ele>
+				<time>2017-10-02T18:16:10Z</time>
+				<extensions>
+					<speed>9.50462818145752</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008678128321588" lon="-84.20847357257192">
+				<ele>947.9125202186406</ele>
+				<time>2017-10-02T18:16:11Z</time>
+				<extensions>
+					<speed>8.908772468566895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008693816119383" lon="-84.20842023026641">
+				<ele>948.3396141119301</ele>
+				<time>2017-10-02T18:16:12Z</time>
+				<extensions>
+					<speed>7.9241862297058105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00868951289465" lon="-84.2083614634892">
+				<ele>947.9736505355686</ele>
+				<time>2017-10-02T18:16:13Z</time>
+				<extensions>
+					<speed>6.40557336807251</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008679494451608" lon="-84.20831047677362">
+				<ele>947.7724725892767</ele>
+				<time>2017-10-02T18:16:14Z</time>
+				<extensions>
+					<speed>4.75229024887085</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008669516654454" lon="-84.2082670162985">
+				<ele>947.5813517216593</ele>
+				<time>2017-10-02T18:16:15Z</time>
+				<extensions>
+					<speed>3.301264524459839</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008659131372871" lon="-84.20824348338076">
+				<ele>947.2055821660906</ele>
+				<time>2017-10-02T18:16:16Z</time>
+				<extensions>
+					<speed>2.01952862739563</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008649346097314" lon="-84.20822154593442">
+				<ele>946.7649738555774</ele>
+				<time>2017-10-02T18:16:17Z</time>
+				<extensions>
+					<speed>1.1042001247406006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008639743781151" lon="-84.20821223790567">
+				<ele>946.541119966656</ele>
+				<time>2017-10-02T18:16:18Z</time>
+				<extensions>
+					<speed>0.40855637192726135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008627797253478" lon="-84.20820677434972">
+				<ele>946.2267007147893</ele>
+				<time>2017-10-02T18:16:19Z</time>
+				<extensions>
+					<speed>0.15263471007347107</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008616114304623" lon="-84.2081913044211">
+				<ele>945.6552833551541</ele>
+				<time>2017-10-02T18:16:20Z</time>
+				<extensions>
+					<speed>0.196791872382164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008605338982521" lon="-84.20818324962998">
+				<ele>945.3587117893621</ele>
+				<time>2017-10-02T18:16:21Z</time>
+				<extensions>
+					<speed>0.15689684450626373</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00859536465512" lon="-84.20817139935617">
+				<ele>944.9654974220321</ele>
+				<time>2017-10-02T18:16:22Z</time>
+				<extensions>
+					<speed>0.07128972560167313</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00859536465512" lon="-84.20817139935617">
+				<ele>944.7054047482088</ele>
+				<time>2017-10-02T18:16:23Z</time>
+				<extensions>
+					<speed>0.31695425510406494</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00859536465512" lon="-84.20817139935617">
+				<ele>944.5039716344327</ele>
+				<time>2017-10-02T18:16:24Z</time>
+				<extensions>
+					<speed>0.4405841827392578</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008588249628012" lon="-84.2081446846289">
+				<ele>944.3738341312855</ele>
+				<time>2017-10-02T18:16:25Z</time>
+				<extensions>
+					<speed>0.4410373866558075</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008592228040428" lon="-84.20813380533394">
+				<ele>944.1484702350572</ele>
+				<time>2017-10-02T18:16:26Z</time>
+				<extensions>
+					<speed>0.5275943279266357</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008593122349545" lon="-84.20811529306125">
+				<ele>943.974701391533</ele>
+				<time>2017-10-02T18:16:27Z</time>
+				<extensions>
+					<speed>0.5816183686256409</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008589838923566" lon="-84.20810106942612">
+				<ele>943.9593335669488</ele>
+				<time>2017-10-02T18:16:28Z</time>
+				<extensions>
+					<speed>0.6121772527694702</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008580642194865" lon="-84.20807088014294">
+				<ele>940.3481379300356</ele>
+				<time>2017-10-02T18:16:29Z</time>
+				<extensions>
+					<speed>0.4472475051879883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008580642194865" lon="-84.20807088014294">
+				<ele>925.5654740436003</ele>
+				<time>2017-10-02T18:16:30Z</time>
+				<extensions>
+					<speed>0.5700592398643494</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0085461703453" lon="-84.20794611673664">
+				<ele>923.2088542636484</ele>
+				<time>2017-10-02T18:16:31Z</time>
+				<extensions>
+					<speed>0.25347036123275757</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0085461703453" lon="-84.20794611673664">
+				<ele>923.2088542636484</ele>
+				<time>2017-10-02T18:16:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0085461703453" lon="-84.20794611673664">
+				<ele>923.2088542636484</ele>
+				<time>2017-10-02T18:16:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0085461703453" lon="-84.20794611673664">
+				<ele>923.2088542636484</ele>
+				<time>2017-10-02T18:16:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0085461703453" lon="-84.20794611673664">
+				<ele>923.2088542636484</ele>
+				<time>2017-10-02T18:16:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0085461703453" lon="-84.20794611673664">
+				<ele>923.2088542636484</ele>
+				<time>2017-10-02T18:16:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008549360171894" lon="-84.20795893897208">
+				<ele>926.0145440595224</ele>
+				<time>2017-10-02T18:16:37Z</time>
+				<extensions>
+					<speed>0.7399649024009705</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008556785826858" lon="-84.20797591188153">
+				<ele>928.2356256311759</ele>
+				<time>2017-10-02T18:16:38Z</time>
+				<extensions>
+					<speed>0.7782678008079529</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008560033648441" lon="-84.20799245345324">
+				<ele>930.1966976961121</ele>
+				<time>2017-10-02T18:16:39Z</time>
+				<extensions>
+					<speed>0.5547968149185181</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008560793086067" lon="-84.20800904664375">
+				<ele>931.8461307957768</ele>
+				<time>2017-10-02T18:16:40Z</time>
+				<extensions>
+					<speed>0.19003337621688843</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008560793086067" lon="-84.20800904664375">
+				<ele>931.8461307957768</ele>
+				<time>2017-10-02T18:16:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008560793086067" lon="-84.20800904664375">
+				<ele>931.8461307957768</ele>
+				<time>2017-10-02T18:16:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008560793086067" lon="-84.20800904664375">
+				<ele>931.8461307957768</ele>
+				<time>2017-10-02T18:16:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008563698239223" lon="-84.20800531504538">
+				<ele>931.3057831767946</ele>
+				<time>2017-10-02T18:16:44Z</time>
+				<extensions>
+					<speed>1.0357670783996582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00856133768427" lon="-84.20800044120212">
+				<ele>930.9730148101225</ele>
+				<time>2017-10-02T18:16:45Z</time>
+				<extensions>
+					<speed>1.0935862064361572</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008554996105051" lon="-84.20799190083136">
+				<ele>931.1654810970649</ele>
+				<time>2017-10-02T18:16:46Z</time>
+				<extensions>
+					<speed>1.1414179801940918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008539493359363" lon="-84.20798317500655">
+				<ele>931.3405402777717</ele>
+				<time>2017-10-02T18:16:47Z</time>
+				<extensions>
+					<speed>1.389843225479126</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008523959163323" lon="-84.20797871680021">
+				<ele>931.1287693046033</ele>
+				<time>2017-10-02T18:16:48Z</time>
+				<extensions>
+					<speed>1.6050021648406982</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008510862640536" lon="-84.20796909237964">
+				<ele>931.0444953907281</ele>
+				<time>2017-10-02T18:16:49Z</time>
+				<extensions>
+					<speed>1.8099870681762695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008496374212532" lon="-84.2079425997442">
+				<ele>932.243552303873</ele>
+				<time>2017-10-02T18:16:50Z</time>
+				<extensions>
+					<speed>2.1653387546539307</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008477109458315" lon="-84.20791793120166">
+				<ele>933.4145306684077</ele>
+				<time>2017-10-02T18:16:51Z</time>
+				<extensions>
+					<speed>2.291314125061035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008466475394098" lon="-84.20789249534796">
+				<ele>934.4288824386895</ele>
+				<time>2017-10-02T18:16:52Z</time>
+				<extensions>
+					<speed>2.385612964630127</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008457746970116" lon="-84.20786107493986">
+				<ele>935.6212378842756</ele>
+				<time>2017-10-02T18:16:53Z</time>
+				<extensions>
+					<speed>2.3759467601776123</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00844559472961" lon="-84.20783040721659">
+				<ele>936.28461909201</ele>
+				<time>2017-10-02T18:16:54Z</time>
+				<extensions>
+					<speed>2.602567434310913</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008422426825518" lon="-84.20778972184196">
+				<ele>937.0262478338555</ele>
+				<time>2017-10-02T18:16:55Z</time>
+				<extensions>
+					<speed>3.2030816078186035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008397289683524" lon="-84.20776076118237">
+				<ele>937.5203848332167</ele>
+				<time>2017-10-02T18:16:56Z</time>
+				<extensions>
+					<speed>3.5654513835906982</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00836254959178" lon="-84.20773059376212">
+				<ele>937.8999731326476</ele>
+				<time>2017-10-02T18:16:57Z</time>
+				<extensions>
+					<speed>4.188122749328613</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008302684743333" lon="-84.20770602542736">
+				<ele>937.8758366880938</ele>
+				<time>2017-10-02T18:16:58Z</time>
+				<extensions>
+					<speed>5.708865165710449</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00824588569905" lon="-84.20766031215152">
+				<ele>938.4169866042212</ele>
+				<time>2017-10-02T18:16:59Z</time>
+				<extensions>
+					<speed>7.145405292510986</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008183203262272" lon="-84.20760705931261">
+				<ele>938.911738739349</ele>
+				<time>2017-10-02T18:17:00Z</time>
+				<extensions>
+					<speed>7.998851299285889</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008122054064641" lon="-84.20756714815707">
+				<ele>939.3518182253465</ele>
+				<time>2017-10-02T18:17:01Z</time>
+				<extensions>
+					<speed>8.259730339050293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008054272869987" lon="-84.20751755219668">
+				<ele>939.5163788972422</ele>
+				<time>2017-10-02T18:17:02Z</time>
+				<extensions>
+					<speed>8.803792953491211</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00798477874087" lon="-84.20747397561333">
+				<ele>939.6609898777679</ele>
+				<time>2017-10-02T18:17:03Z</time>
+				<extensions>
+					<speed>9.194825172424316</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007907060782385" lon="-84.20742495586752">
+				<ele>939.9155769823119</ele>
+				<time>2017-10-02T18:17:04Z</time>
+				<extensions>
+					<speed>9.555301666259766</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007822446065155" lon="-84.2073835751194">
+				<ele>939.6496291244403</ele>
+				<time>2017-10-02T18:17:05Z</time>
+				<extensions>
+					<speed>10.002363204956055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007734041245099" lon="-84.20733686775495">
+				<ele>939.3481361139566</ele>
+				<time>2017-10-02T18:17:06Z</time>
+				<extensions>
+					<speed>10.514270782470703</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00765391395532" lon="-84.20727512391693">
+				<ele>939.3045978136361</ele>
+				<time>2017-10-02T18:17:07Z</time>
+				<extensions>
+					<speed>11.015570640563965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00757160648757" lon="-84.20720615340935">
+				<ele>939.3869059914723</ele>
+				<time>2017-10-02T18:17:08Z</time>
+				<extensions>
+					<speed>11.263067245483398</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00748094100122" lon="-84.20710566587104">
+				<ele>939.6446139737964</ele>
+				<time>2017-10-02T18:17:09Z</time>
+				<extensions>
+					<speed>11.50524616241455</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007401065819312" lon="-84.20702565515319">
+				<ele>939.9927099552006</ele>
+				<time>2017-10-02T18:17:10Z</time>
+				<extensions>
+					<speed>11.552949905395508</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007317687427582" lon="-84.20691729068966">
+				<ele>941.2378820870072</ele>
+				<time>2017-10-02T18:17:11Z</time>
+				<extensions>
+					<speed>10.980387687683105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007248407089385" lon="-84.20684860218114">
+				<ele>942.0901824114844</ele>
+				<time>2017-10-02T18:17:12Z</time>
+				<extensions>
+					<speed>9.910545349121094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007180728529326" lon="-84.20678290273688">
+				<ele>942.3984667211771</ele>
+				<time>2017-10-02T18:17:13Z</time>
+				<extensions>
+					<speed>9.499503135681152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007135074770563" lon="-84.20670750604187">
+				<ele>942.5703936759382</ele>
+				<time>2017-10-02T18:17:14Z</time>
+				<extensions>
+					<speed>9.164681434631348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007086245536257" lon="-84.20663073871395">
+				<ele>942.6462014904246</ele>
+				<time>2017-10-02T18:17:15Z</time>
+				<extensions>
+					<speed>8.641640663146973</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007043266071708" lon="-84.20657672254569">
+				<ele>942.7507856357843</ele>
+				<time>2017-10-02T18:17:16Z</time>
+				<extensions>
+					<speed>8.209973335266113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007049499827469" lon="-84.20655817505842">
+				<ele>942.9152219193056</ele>
+				<time>2017-10-02T18:17:17Z</time>
+				<extensions>
+					<speed>6.404428005218506</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00705254406336" lon="-84.20652187434948">
+				<ele>942.9543120767921</ele>
+				<time>2017-10-02T18:17:18Z</time>
+				<extensions>
+					<speed>5.6007771492004395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007078241100915" lon="-84.20652956700174">
+				<ele>943.1967057958245</ele>
+				<time>2017-10-02T18:17:19Z</time>
+				<extensions>
+					<speed>3.6224050521850586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007116931845422" lon="-84.20652671717251">
+				<ele>943.3486066265032</ele>
+				<time>2017-10-02T18:17:20Z</time>
+				<extensions>
+					<speed>2.6789169311523438</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007166041514681" lon="-84.20654235418029">
+				<ele>943.5323570538312</ele>
+				<time>2017-10-02T18:17:21Z</time>
+				<extensions>
+					<speed>1.7819797992706299</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007182381893239" lon="-84.2065374355484">
+				<ele>943.6574379066005</ele>
+				<time>2017-10-02T18:17:22Z</time>
+				<extensions>
+					<speed>1.5731170177459717</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007233922741156" lon="-84.2065888010815">
+				<ele>944.0216417694464</ele>
+				<time>2017-10-02T18:17:23Z</time>
+				<extensions>
+					<speed>1.593701720237732</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007270518288424" lon="-84.20660437004803">
+				<ele>944.1482753278688</ele>
+				<time>2017-10-02T18:17:24Z</time>
+				<extensions>
+					<speed>1.650286078453064</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007290604693635" lon="-84.20661574453254">
+				<ele>944.2754345517606</ele>
+				<time>2017-10-02T18:17:25Z</time>
+				<extensions>
+					<speed>1.3456292152404785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00729966931844" lon="-84.20662796860124">
+				<ele>944.4320113370195</ele>
+				<time>2017-10-02T18:17:26Z</time>
+				<extensions>
+					<speed>0.9679014086723328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007296787405918" lon="-84.20664373310612">
+				<ele>944.5370712121949</ele>
+				<time>2017-10-02T18:17:27Z</time>
+				<extensions>
+					<speed>0.42331463098526</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007279519560129" lon="-84.2066439860844">
+				<ele>944.3226459706202</ele>
+				<time>2017-10-02T18:17:28Z</time>
+				<extensions>
+					<speed>0.18852785229682922</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007266100755041" lon="-84.2066445898079">
+				<ele>944.1772315353155</ele>
+				<time>2017-10-02T18:17:29Z</time>
+				<extensions>
+					<speed>0.3726832866668701</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007251395014212" lon="-84.20664526746862">
+				<ele>944.1464240001515</ele>
+				<time>2017-10-02T18:17:30Z</time>
+				<extensions>
+					<speed>0.42869892716407776</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007238378304868" lon="-84.20664201137497">
+				<ele>944.2705839406699</ele>
+				<time>2017-10-02T18:17:31Z</time>
+				<extensions>
+					<speed>0.43388158082962036</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00722644950249" lon="-84.20664182209717">
+				<ele>944.2285377904773</ele>
+				<time>2017-10-02T18:17:32Z</time>
+				<extensions>
+					<speed>0.4338662028312683</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007219788522727" lon="-84.20664704307131">
+				<ele>944.3263208726421</ele>
+				<time>2017-10-02T18:17:33Z</time>
+				<extensions>
+					<speed>0.4360312819480896</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007207373747974" lon="-84.20663907759361">
+				<ele>944.4279418680817</ele>
+				<time>2017-10-02T18:17:34Z</time>
+				<extensions>
+					<speed>0.5331154465675354</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007187041458186" lon="-84.20662149402811">
+				<ele>944.5213908972219</ele>
+				<time>2017-10-02T18:17:35Z</time>
+				<extensions>
+					<speed>0.895437479019165</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007154809155876" lon="-84.20660061541085">
+				<ele>944.5564614487812</ele>
+				<time>2017-10-02T18:17:36Z</time>
+				<extensions>
+					<speed>1.5640158653259277</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007120558881146" lon="-84.20657716440795">
+				<ele>944.5588002903387</ele>
+				<time>2017-10-02T18:17:37Z</time>
+				<extensions>
+					<speed>2.2761876583099365</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007068123747395" lon="-84.20654269962321">
+				<ele>944.4405666990206</ele>
+				<time>2017-10-02T18:17:38Z</time>
+				<extensions>
+					<speed>3.710630178451538</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007012998444662" lon="-84.20650157907787">
+				<ele>944.4924412798136</ele>
+				<time>2017-10-02T18:17:39Z</time>
+				<extensions>
+					<speed>5.652256011962891</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006968705735414" lon="-84.20646537299837">
+				<ele>944.661372163333</ele>
+				<time>2017-10-02T18:17:40Z</time>
+				<extensions>
+					<speed>6.968270778656006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00692255118481" lon="-84.20642088743301">
+				<ele>944.7123909927905</ele>
+				<time>2017-10-02T18:17:41Z</time>
+				<extensions>
+					<speed>7.090685844421387</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006871732828873" lon="-84.20637595353455">
+				<ele>944.7151038730517</ele>
+				<time>2017-10-02T18:17:42Z</time>
+				<extensions>
+					<speed>7.367000102996826</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006796993341792" lon="-84.20632409500652">
+				<ele>943.4745948994532</ele>
+				<time>2017-10-02T18:17:43Z</time>
+				<extensions>
+					<speed>7.910810470581055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006730404973649" lon="-84.20626973660416">
+				<ele>943.4481185832992</ele>
+				<time>2017-10-02T18:17:44Z</time>
+				<extensions>
+					<speed>8.513916969299316</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006674672901557" lon="-84.20623442682465">
+				<ele>944.0595091283321</ele>
+				<time>2017-10-02T18:17:45Z</time>
+				<extensions>
+					<speed>8.557598114013672</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006613224743356" lon="-84.20619006027539">
+				<ele>944.6125309215859</ele>
+				<time>2017-10-02T18:17:46Z</time>
+				<extensions>
+					<speed>8.952401161193848</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00654286400479" lon="-84.20614403313236">
+				<ele>944.6414789697155</ele>
+				<time>2017-10-02T18:17:47Z</time>
+				<extensions>
+					<speed>8.979534149169922</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006473653229902" lon="-84.206102005641">
+				<ele>944.3299154890701</ele>
+				<time>2017-10-02T18:17:48Z</time>
+				<extensions>
+					<speed>8.857290267944336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006406386436513" lon="-84.2060515864301">
+				<ele>943.9726535594091</ele>
+				<time>2017-10-02T18:17:49Z</time>
+				<extensions>
+					<speed>8.795348167419434</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006341047495233" lon="-84.20599357704836">
+				<ele>943.9529602685943</ele>
+				<time>2017-10-02T18:17:50Z</time>
+				<extensions>
+					<speed>8.824503898620605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006279715069951" lon="-84.20593976572144">
+				<ele>943.9125915607437</ele>
+				<time>2017-10-02T18:17:51Z</time>
+				<extensions>
+					<speed>8.785935401916504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006212809257502" lon="-84.20589084641111">
+				<ele>943.8854981968179</ele>
+				<time>2017-10-02T18:17:52Z</time>
+				<extensions>
+					<speed>8.726749420166016</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006144290662348" lon="-84.20585486378292">
+				<ele>943.3735337136313</ele>
+				<time>2017-10-02T18:17:53Z</time>
+				<extensions>
+					<speed>8.576186180114746</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00608474491607" lon="-84.20582222502215">
+				<ele>943.0690847495571</ele>
+				<time>2017-10-02T18:17:54Z</time>
+				<extensions>
+					<speed>8.143095016479492</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00602971358092" lon="-84.20578777208326">
+				<ele>942.9116699350998</ele>
+				<time>2017-10-02T18:17:55Z</time>
+				<extensions>
+					<speed>7.70258092880249</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00598166079731" lon="-84.2057528083217">
+				<ele>942.9552439181134</ele>
+				<time>2017-10-02T18:17:56Z</time>
+				<extensions>
+					<speed>7.135828495025635</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00594425579852" lon="-84.20574055934382">
+				<ele>943.0408140458167</ele>
+				<time>2017-10-02T18:17:57Z</time>
+				<extensions>
+					<speed>5.863247394561768</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005922846156507" lon="-84.2057552073899">
+				<ele>943.1453682789579</ele>
+				<time>2017-10-02T18:17:58Z</time>
+				<extensions>
+					<speed>3.7249441146850586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005893967939379" lon="-84.20577105861432">
+				<ele>942.684119601734</ele>
+				<time>2017-10-02T18:17:59Z</time>
+				<extensions>
+					<speed>3.6928563117980957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005881242845788" lon="-84.20578015812457">
+				<ele>941.2431196672842</ele>
+				<time>2017-10-02T18:18:00Z</time>
+				<extensions>
+					<speed>4.364933013916016</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005863897691553" lon="-84.20581513212684">
+				<ele>940.0982903167605</ele>
+				<time>2017-10-02T18:18:01Z</time>
+				<extensions>
+					<speed>5.43183708190918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005852465249262" lon="-84.20585926851997">
+				<ele>938.5726002529263</ele>
+				<time>2017-10-02T18:18:02Z</time>
+				<extensions>
+					<speed>6.603001117706299</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005802223796266" lon="-84.20588710823644">
+				<ele>938.6554888701066</ele>
+				<time>2017-10-02T18:18:03Z</time>
+				<extensions>
+					<speed>6.0439066886901855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00577971458111" lon="-84.20592125726174">
+				<ele>937.6709755863994</ele>
+				<time>2017-10-02T18:18:04Z</time>
+				<extensions>
+					<speed>5.230131149291992</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005765765244936" lon="-84.20595384437559">
+				<ele>936.9136994834989</ele>
+				<time>2017-10-02T18:18:05Z</time>
+				<extensions>
+					<speed>4.0122528076171875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005751655401223" lon="-84.20597742339713">
+				<ele>936.3011721242219</ele>
+				<time>2017-10-02T18:18:06Z</time>
+				<extensions>
+					<speed>2.5812199115753174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005748377952054" lon="-84.20598425136845">
+				<ele>935.4693219764158</ele>
+				<time>2017-10-02T18:18:07Z</time>
+				<extensions>
+					<speed>0.07524414360523224</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005754939845014" lon="-84.2059753139368">
+				<ele>934.5554715460166</ele>
+				<time>2017-10-02T18:18:08Z</time>
+				<extensions>
+					<speed>0.9683392643928528</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005761304209209" lon="-84.2059666863198">
+				<ele>934.1288420092314</ele>
+				<time>2017-10-02T18:18:09Z</time>
+				<extensions>
+					<speed>1.0822627544403076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005765531674864" lon="-84.20596148435453">
+				<ele>933.4343489045277</ele>
+				<time>2017-10-02T18:18:10Z</time>
+				<extensions>
+					<speed>0.7855280041694641</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00576503048972" lon="-84.20595368573044">
+				<ele>931.889544794336</ele>
+				<time>2017-10-02T18:18:11Z</time>
+				<extensions>
+					<speed>0.652414858341217</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005758759524262" lon="-84.2059433193158">
+				<ele>930.3851516908035</ele>
+				<time>2017-10-02T18:18:12Z</time>
+				<extensions>
+					<speed>0.5207476019859314</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005756526718079" lon="-84.20593839180015">
+				<ele>929.6884708981961</ele>
+				<time>2017-10-02T18:18:13Z</time>
+				<extensions>
+					<speed>0.3764541745185852</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005756332302429" lon="-84.20593868744223">
+				<ele>928.5045864470303</ele>
+				<time>2017-10-02T18:18:14Z</time>
+				<extensions>
+					<speed>0.06701843440532684</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005757323040795" lon="-84.2059369147378">
+				<ele>927.4698717044666</ele>
+				<time>2017-10-02T18:18:15Z</time>
+				<extensions>
+					<speed>0.02476612478494644</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005758455779485" lon="-84.20593528123908">
+				<ele>926.8806641027331</ele>
+				<time>2017-10-02T18:18:16Z</time>
+				<extensions>
+					<speed>0.02573092095553875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005756948634458" lon="-84.2059349635374">
+				<ele>926.0254652360454</ele>
+				<time>2017-10-02T18:18:17Z</time>
+				<extensions>
+					<speed>0.010587927885353565</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005756948634458" lon="-84.2059349635374">
+				<ele>925.0353751620278</ele>
+				<time>2017-10-02T18:18:18Z</time>
+				<extensions>
+					<speed>0.027310023084282875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005758748572553" lon="-84.20593336469308">
+				<ele>924.3640536526218</ele>
+				<time>2017-10-02T18:18:19Z</time>
+				<extensions>
+					<speed>0.041890330612659454</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005758341708537" lon="-84.20593247323929">
+				<ele>924.2041506310925</ele>
+				<time>2017-10-02T18:18:20Z</time>
+				<extensions>
+					<speed>0.01756919175386429</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005758599954643" lon="-84.20593086102733">
+				<ele>924.6856101602316</ele>
+				<time>2017-10-02T18:18:21Z</time>
+				<extensions>
+					<speed>0.026156524196267128</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005758599954643" lon="-84.20593086102733">
+				<ele>924.440053450875</ele>
+				<time>2017-10-02T18:18:22Z</time>
+				<extensions>
+					<speed>0.03911999613046646</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005759991579112" lon="-84.20593919598676">
+				<ele>924.6203072145581</ele>
+				<time>2017-10-02T18:18:23Z</time>
+				<extensions>
+					<speed>0.21344436705112457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005756165961344" lon="-84.20596523369744">
+				<ele>925.0868242383003</ele>
+				<time>2017-10-02T18:18:24Z</time>
+				<extensions>
+					<speed>0.6104049682617188</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005744443103842" lon="-84.20598663777301">
+				<ele>925.5544818425551</ele>
+				<time>2017-10-02T18:18:25Z</time>
+				<extensions>
+					<speed>2.0542385578155518</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005714751606758" lon="-84.20602110387625">
+				<ele>925.2029535248876</ele>
+				<time>2017-10-02T18:18:26Z</time>
+				<extensions>
+					<speed>5.150390625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005676489239892" lon="-84.20606817014232">
+				<ele>924.7042219899595</ele>
+				<time>2017-10-02T18:18:27Z</time>
+				<extensions>
+					<speed>6.238105773925781</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005635280831191" lon="-84.20611989401614">
+				<ele>924.6596215181053</ele>
+				<time>2017-10-02T18:18:28Z</time>
+				<extensions>
+					<speed>6.940636157989502</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005596257224463" lon="-84.20618438781831">
+				<ele>924.6351317921653</ele>
+				<time>2017-10-02T18:18:29Z</time>
+				<extensions>
+					<speed>7.711188316345215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005552890424699" lon="-84.20625344945853">
+				<ele>924.377035769634</ele>
+				<time>2017-10-02T18:18:30Z</time>
+				<extensions>
+					<speed>8.482489585876465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005500880215616" lon="-84.20631963821157">
+				<ele>924.0868595382199</ele>
+				<time>2017-10-02T18:18:31Z</time>
+				<extensions>
+					<speed>9.003880500793457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00543794302021" lon="-84.20638492236536">
+				<ele>923.7100594555959</ele>
+				<time>2017-10-02T18:18:32Z</time>
+				<extensions>
+					<speed>9.489649772644043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005367650179863" lon="-84.20644610631328">
+				<ele>922.9490449018776</ele>
+				<time>2017-10-02T18:18:33Z</time>
+				<extensions>
+					<speed>9.373329162597656</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005303589509554" lon="-84.20650658337175">
+				<ele>922.6143471291289</ele>
+				<time>2017-10-02T18:18:34Z</time>
+				<extensions>
+					<speed>9.301249504089355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005238025462345" lon="-84.20656600533528">
+				<ele>922.3241206519306</ele>
+				<time>2017-10-02T18:18:35Z</time>
+				<extensions>
+					<speed>9.253719329833984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00517290977305" lon="-84.20662740775236">
+				<ele>921.8978574266657</ele>
+				<time>2017-10-02T18:18:36Z</time>
+				<extensions>
+					<speed>8.9320068359375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005116309208688" lon="-84.2066847251685">
+				<ele>921.8395863613114</ele>
+				<time>2017-10-02T18:18:37Z</time>
+				<extensions>
+					<speed>8.15519905090332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00507099078245" lon="-84.20673956421544">
+				<ele>921.5878503127024</ele>
+				<time>2017-10-02T18:18:38Z</time>
+				<extensions>
+					<speed>6.959186553955078</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005029724457218" lon="-84.2067827733711">
+				<ele>921.5538232959807</ele>
+				<time>2017-10-02T18:18:39Z</time>
+				<extensions>
+					<speed>5.805636405944824</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00499110460833" lon="-84.20681471570394">
+				<ele>921.458373432979</ele>
+				<time>2017-10-02T18:18:40Z</time>
+				<extensions>
+					<speed>5.131721019744873</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00493706424719" lon="-84.20682181236323">
+				<ele>921.3376130517572</ele>
+				<time>2017-10-02T18:18:41Z</time>
+				<extensions>
+					<speed>4.72683572769165</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004895007818206" lon="-84.20681802010074">
+				<ele>920.9660456161946</ele>
+				<time>2017-10-02T18:18:42Z</time>
+				<extensions>
+					<speed>4.491399765014648</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00485850452716" lon="-84.20680442233638">
+				<ele>920.6356253093109</ele>
+				<time>2017-10-02T18:18:43Z</time>
+				<extensions>
+					<speed>4.3737664222717285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004825473812595" lon="-84.206782034784">
+				<ele>920.4606166183949</ele>
+				<time>2017-10-02T18:18:44Z</time>
+				<extensions>
+					<speed>4.2868828773498535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004793131976724" lon="-84.20675146222133">
+				<ele>920.6302786655724</ele>
+				<time>2017-10-02T18:18:45Z</time>
+				<extensions>
+					<speed>4.3824896812438965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004763717072183" lon="-84.20670598809576">
+				<ele>921.3639660263434</ele>
+				<time>2017-10-02T18:18:46Z</time>
+				<extensions>
+					<speed>4.394721984863281</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00473505083782" lon="-84.2066723970382">
+				<ele>922.6703937482089</ele>
+				<time>2017-10-02T18:18:47Z</time>
+				<extensions>
+					<speed>3.871054172515869</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004711164485267" lon="-84.20665399873845">
+				<ele>924.0262635201216</ele>
+				<time>2017-10-02T18:18:48Z</time>
+				<extensions>
+					<speed>3.0213301181793213</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004687704007086" lon="-84.20661960778142">
+				<ele>925.0751313213259</ele>
+				<time>2017-10-02T18:18:49Z</time>
+				<extensions>
+					<speed>2.986934185028076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004672223976756" lon="-84.20659846840154">
+				<ele>926.229149828665</ele>
+				<time>2017-10-02T18:18:50Z</time>
+				<extensions>
+					<speed>2.4969322681427</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004660935123438" lon="-84.20657557014374">
+				<ele>927.1525580855086</ele>
+				<time>2017-10-02T18:18:51Z</time>
+				<extensions>
+					<speed>2.133330821990967</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0046696226854" lon="-84.20657112400478">
+				<ele>927.6356473583728</ele>
+				<time>2017-10-02T18:18:52Z</time>
+				<extensions>
+					<speed>1.447487711906433</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004679144291083" lon="-84.20657438377694">
+				<ele>928.169125886634</ele>
+				<time>2017-10-02T18:18:53Z</time>
+				<extensions>
+					<speed>0.8044775724411011</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004701633233298" lon="-84.20658743480048">
+				<ele>928.7012244053185</ele>
+				<time>2017-10-02T18:18:54Z</time>
+				<extensions>
+					<speed>0.5896439552307129</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004711297628845" lon="-84.20659313235208">
+				<ele>928.9076124504209</ele>
+				<time>2017-10-02T18:18:55Z</time>
+				<extensions>
+					<speed>0.6898227334022522</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004717388356779" lon="-84.20659745428537">
+				<ele>929.1639561634511</ele>
+				<time>2017-10-02T18:18:56Z</time>
+				<extensions>
+					<speed>0.702913224697113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004731654904477" lon="-84.20658202819556">
+				<ele>929.186830220744</ele>
+				<time>2017-10-02T18:18:57Z</time>
+				<extensions>
+					<speed>0.7484674453735352</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004742844987984" lon="-84.2065834850819">
+				<ele>929.228857695125</ele>
+				<time>2017-10-02T18:18:58Z</time>
+				<extensions>
+					<speed>0.601179301738739</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004754894697015" lon="-84.20657173945625">
+				<ele>929.2630513515323</ele>
+				<time>2017-10-02T18:18:59Z</time>
+				<extensions>
+					<speed>0.557855486869812</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00475857073607" lon="-84.20656859165072">
+				<ele>929.2204525722191</ele>
+				<time>2017-10-02T18:19:00Z</time>
+				<extensions>
+					<speed>0.46368175745010376</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00475764279063" lon="-84.20655646590033">
+				<ele>929.0716883698478</ele>
+				<time>2017-10-02T18:19:01Z</time>
+				<extensions>
+					<speed>0.3945375978946686</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00475832504185" lon="-84.20654469006767">
+				<ele>928.5477214436978</ele>
+				<time>2017-10-02T18:19:02Z</time>
+				<extensions>
+					<speed>0.6571023464202881</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004763060409772" lon="-84.20651074482498">
+				<ele>928.2750316215679</ele>
+				<time>2017-10-02T18:19:03Z</time>
+				<extensions>
+					<speed>1.2041937112808228</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004764578475243" lon="-84.20646885040391">
+				<ele>928.1091150417924</ele>
+				<time>2017-10-02T18:19:04Z</time>
+				<extensions>
+					<speed>1.4658386707305908</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00475931196653" lon="-84.20643403725549">
+				<ele>927.9138646628708</ele>
+				<time>2017-10-02T18:19:05Z</time>
+				<extensions>
+					<speed>1.713355302810669</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004718256813698" lon="-84.20638218559007">
+				<ele>927.6660999916494</ele>
+				<time>2017-10-02T18:19:06Z</time>
+				<extensions>
+					<speed>2.2261815071105957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00468506289512" lon="-84.20632625948937">
+				<ele>927.7629396775737</ele>
+				<time>2017-10-02T18:19:07Z</time>
+				<extensions>
+					<speed>2.6134719848632813</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004663370734031" lon="-84.20628021943818">
+				<ele>927.9133769934997</ele>
+				<time>2017-10-02T18:19:08Z</time>
+				<extensions>
+					<speed>2.792151927947998</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004609866125655" lon="-84.20626732560586">
+				<ele>927.7752149663866</ele>
+				<time>2017-10-02T18:19:09Z</time>
+				<extensions>
+					<speed>2.854262590408325</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004567759121539" lon="-84.20627455020826">
+				<ele>926.6227652942762</ele>
+				<time>2017-10-02T18:19:10Z</time>
+				<extensions>
+					<speed>3.063890218734741</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004561472319564" lon="-84.2062505929641">
+				<ele>926.5592201203108</ele>
+				<time>2017-10-02T18:19:11Z</time>
+				<extensions>
+					<speed>2.926572322845459</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004545883621834" lon="-84.20621146142176">
+				<ele>926.3431509817019</ele>
+				<time>2017-10-02T18:19:12Z</time>
+				<extensions>
+					<speed>3.827907085418701</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00453930705325" lon="-84.2061717144431">
+				<ele>926.1383097907528</ele>
+				<time>2017-10-02T18:19:13Z</time>
+				<extensions>
+					<speed>4.553477764129639</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004559247471475" lon="-84.20613650179715">
+				<ele>926.1727466341108</ele>
+				<time>2017-10-02T18:19:14Z</time>
+				<extensions>
+					<speed>4.733730316162109</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004590030073876" lon="-84.20610315214516">
+				<ele>926.54905850254</ele>
+				<time>2017-10-02T18:19:15Z</time>
+				<extensions>
+					<speed>5.535141468048096</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004623789570001" lon="-84.2059988100022">
+				<ele>925.3116558585316</ele>
+				<time>2017-10-02T18:19:16Z</time>
+				<extensions>
+					<speed>6.348428726196289</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004671517061196" lon="-84.20593138929833">
+				<ele>924.6059279004112</ele>
+				<time>2017-10-02T18:19:17Z</time>
+				<extensions>
+					<speed>6.66586446762085</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004714094614679" lon="-84.20593592022789">
+				<ele>925.5642349710688</ele>
+				<time>2017-10-02T18:19:18Z</time>
+				<extensions>
+					<speed>6.276228427886963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004751143390655" lon="-84.20588442782166">
+				<ele>925.3006899273023</ele>
+				<time>2017-10-02T18:19:19Z</time>
+				<extensions>
+					<speed>6.4296722412109375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004790424263208" lon="-84.20583911915271">
+				<ele>925.350731219165</ele>
+				<time>2017-10-02T18:19:20Z</time>
+				<extensions>
+					<speed>6.62152099609375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004827263131396" lon="-84.20577663087467">
+				<ele>924.8524466836825</ele>
+				<time>2017-10-02T18:19:21Z</time>
+				<extensions>
+					<speed>6.877574443817139</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004865328066488" lon="-84.20572680258896">
+				<ele>924.7199583239853</ele>
+				<time>2017-10-02T18:19:22Z</time>
+				<extensions>
+					<speed>6.944079399108887</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004902729262659" lon="-84.20567163611125">
+				<ele>924.511537223123</ele>
+				<time>2017-10-02T18:19:23Z</time>
+				<extensions>
+					<speed>6.944600582122803</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004940052436263" lon="-84.20562100925694">
+				<ele>924.4624357661232</ele>
+				<time>2017-10-02T18:19:24Z</time>
+				<extensions>
+					<speed>7.0699462890625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004982800790868" lon="-84.20555698902083">
+				<ele>924.2587884059176</ele>
+				<time>2017-10-02T18:19:25Z</time>
+				<extensions>
+					<speed>7.349661350250244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005021840986023" lon="-84.20549058853031">
+				<ele>923.9982542442158</ele>
+				<time>2017-10-02T18:19:26Z</time>
+				<extensions>
+					<speed>7.362294673919678</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005060530819959" lon="-84.2054293764071">
+				<ele>924.0646918127313</ele>
+				<time>2017-10-02T18:19:27Z</time>
+				<extensions>
+					<speed>7.377700328826904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00509365446256" lon="-84.20537272863021">
+				<ele>924.078318009153</ele>
+				<time>2017-10-02T18:19:28Z</time>
+				<extensions>
+					<speed>7.239271640777588</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005117159035787" lon="-84.20531415990607">
+				<ele>924.0555262295529</ele>
+				<time>2017-10-02T18:19:29Z</time>
+				<extensions>
+					<speed>6.940130233764648</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005137657163838" lon="-84.20526774030601">
+				<ele>924.0053030829877</ele>
+				<time>2017-10-02T18:19:30Z</time>
+				<extensions>
+					<speed>6.505407333374023</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005158343379213" lon="-84.2052198750723">
+				<ele>924.1882418897003</ele>
+				<time>2017-10-02T18:19:31Z</time>
+				<extensions>
+					<speed>6.259627342224121</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005179014313242" lon="-84.20517161153195">
+				<ele>924.1715037738904</ele>
+				<time>2017-10-02T18:19:32Z</time>
+				<extensions>
+					<speed>6.131048679351807</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005207628229735" lon="-84.20512928837287">
+				<ele>924.2650391999632</ele>
+				<time>2017-10-02T18:19:33Z</time>
+				<extensions>
+					<speed>6.0248942375183105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005238420384698" lon="-84.20511048033245">
+				<ele>924.6176789933816</ele>
+				<time>2017-10-02T18:19:34Z</time>
+				<extensions>
+					<speed>5.30460786819458</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005245278703715" lon="-84.2050980938558">
+				<ele>924.8339050728828</ele>
+				<time>2017-10-02T18:19:35Z</time>
+				<extensions>
+					<speed>3.6462366580963135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005250733381391" lon="-84.20508444975279">
+				<ele>925.1503908401355</ele>
+				<time>2017-10-02T18:19:36Z</time>
+				<extensions>
+					<speed>2.320345878601074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005251597456432" lon="-84.20508015054025">
+				<ele>925.3420887961984</ele>
+				<time>2017-10-02T18:19:37Z</time>
+				<extensions>
+					<speed>0.9235496520996094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005242738756408" lon="-84.20508637271114">
+				<ele>925.1566762356088</ele>
+				<time>2017-10-02T18:19:38Z</time>
+				<extensions>
+					<speed>0.5819656252861023</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005230586854983" lon="-84.2051021274493">
+				<ele>925.2748879846185</ele>
+				<time>2017-10-02T18:19:39Z</time>
+				<extensions>
+					<speed>1.1164261102676392</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00521988106609" lon="-84.20511887104398">
+				<ele>925.3726664222777</ele>
+				<time>2017-10-02T18:19:40Z</time>
+				<extensions>
+					<speed>1.4164483547210693</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005212955831809" lon="-84.20513228691937">
+				<ele>925.277883249335</ele>
+				<time>2017-10-02T18:19:41Z</time>
+				<extensions>
+					<speed>1.208011269569397</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005208024487636" lon="-84.20514709494094">
+				<ele>925.3940470516682</ele>
+				<time>2017-10-02T18:19:42Z</time>
+				<extensions>
+					<speed>1.004052996635437</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005205110552867" lon="-84.20515733228362">
+				<ele>925.332183376886</ele>
+				<time>2017-10-02T18:19:43Z</time>
+				<extensions>
+					<speed>0.7716980576515198</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005206759288232" lon="-84.20516598905202">
+				<ele>925.2872904594988</ele>
+				<time>2017-10-02T18:19:44Z</time>
+				<extensions>
+					<speed>0.5897998809814453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00520714580182" lon="-84.20516164152642">
+				<ele>925.4262181548402</ele>
+				<time>2017-10-02T18:19:45Z</time>
+				<extensions>
+					<speed>0.17339998483657837</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00521032172272" lon="-84.205148743445">
+				<ele>924.7382045071572</ele>
+				<time>2017-10-02T18:19:46Z</time>
+				<extensions>
+					<speed>0.4180033504962921</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00521032172272" lon="-84.205148743445">
+				<ele>924.7382045071572</ele>
+				<time>2017-10-02T18:19:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005208585746173" lon="-84.20513139335611">
+				<ele>923.2724079191685</ele>
+				<time>2017-10-02T18:19:48Z</time>
+				<extensions>
+					<speed>0.5269237160682678</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005208585746173" lon="-84.20513139335611">
+				<ele>923.2724079191685</ele>
+				<time>2017-10-02T18:19:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005203787480978" lon="-84.20512025923318">
+				<ele>922.2950724642724</ele>
+				<time>2017-10-02T18:19:50Z</time>
+				<extensions>
+					<speed>0.3867698311805725</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005203787480978" lon="-84.20512025923318">
+				<ele>922.2950724642724</ele>
+				<time>2017-10-02T18:19:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005203787480978" lon="-84.20512025923318">
+				<ele>922.2950724642724</ele>
+				<time>2017-10-02T18:19:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005203889216176" lon="-84.20511995753539">
+				<ele>922.6823994396254</ele>
+				<time>2017-10-02T18:19:53Z</time>
+				<extensions>
+					<speed>0.017885109409689903</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005203889216176" lon="-84.20511995753539">
+				<ele>923.2311182040721</ele>
+				<time>2017-10-02T18:19:54Z</time>
+				<extensions>
+					<speed>0.1682421863079071</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005203889216176" lon="-84.20511995753539">
+				<ele>924.1172243729234</ele>
+				<time>2017-10-02T18:19:55Z</time>
+				<extensions>
+					<speed>0.36241960525512695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005203889216176" lon="-84.20511995753539">
+				<ele>924.6643174961209</ele>
+				<time>2017-10-02T18:19:56Z</time>
+				<extensions>
+					<speed>0.4886522591114044</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00524468758942" lon="-84.20511407752308">
+				<ele>925.0036110579967</ele>
+				<time>2017-10-02T18:19:57Z</time>
+				<extensions>
+					<speed>0.6787720322608948</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005271673692302" lon="-84.20512404290736">
+				<ele>925.37091069296</ele>
+				<time>2017-10-02T18:19:58Z</time>
+				<extensions>
+					<speed>0.7468404173851013</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00529371669051" lon="-84.20512905199998">
+				<ele>925.6490939091891</ele>
+				<time>2017-10-02T18:19:59Z</time>
+				<extensions>
+					<speed>0.8611541390419006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005301306971068" lon="-84.20512222196146">
+				<ele>926.0785197298974</ele>
+				<time>2017-10-02T18:20:00Z</time>
+				<extensions>
+					<speed>1.2188736200332642</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005303530524882" lon="-84.20511073569722">
+				<ele>926.3867104547098</ele>
+				<time>2017-10-02T18:20:01Z</time>
+				<extensions>
+					<speed>1.4044770002365112</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005315492598472" lon="-84.20510074776826">
+				<ele>926.6756348889321</ele>
+				<time>2017-10-02T18:20:02Z</time>
+				<extensions>
+					<speed>1.5938355922698975</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005328338183862" lon="-84.20508079049546">
+				<ele>927.0633861646056</ele>
+				<time>2017-10-02T18:20:03Z</time>
+				<extensions>
+					<speed>2.1363742351531982</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005337499452818" lon="-84.20506680772941">
+				<ele>927.0228894939646</ele>
+				<time>2017-10-02T18:20:04Z</time>
+				<extensions>
+					<speed>2.13708758354187</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005345997892244" lon="-84.2050568233959">
+				<ele>926.9724457329139</ele>
+				<time>2017-10-02T18:20:05Z</time>
+				<extensions>
+					<speed>1.9543514251708984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00535848277656" lon="-84.2050482992042">
+				<ele>927.2278785966337</ele>
+				<time>2017-10-02T18:20:06Z</time>
+				<extensions>
+					<speed>1.914697527885437</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005371433031629" lon="-84.20503817098567">
+				<ele>927.4681169474497</ele>
+				<time>2017-10-02T18:20:07Z</time>
+				<extensions>
+					<speed>1.8768595457077026</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005388295657236" lon="-84.20502298999777">
+				<ele>927.6136389961466</ele>
+				<time>2017-10-02T18:20:08Z</time>
+				<extensions>
+					<speed>2.0419042110443115</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005411621415716" lon="-84.20500013008659">
+				<ele>927.0866671400145</ele>
+				<time>2017-10-02T18:20:09Z</time>
+				<extensions>
+					<speed>2.356665849685669</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005436058731073" lon="-84.20498980079293">
+				<ele>931.2478248970583</ele>
+				<time>2017-10-02T18:20:10Z</time>
+				<extensions>
+					<speed>2.460358142852783</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005457065137177" lon="-84.2049904169831">
+				<ele>936.8670797711238</ele>
+				<time>2017-10-02T18:20:11Z</time>
+				<extensions>
+					<speed>2.4242706298828125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005472161483524" lon="-84.20496406773795">
+				<ele>936.3511061118916</ele>
+				<time>2017-10-02T18:20:12Z</time>
+				<extensions>
+					<speed>2.4335031509399414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00548535242225" lon="-84.20493940853545">
+				<ele>935.9421893022954</ele>
+				<time>2017-10-02T18:20:13Z</time>
+				<extensions>
+					<speed>2.476950168609619</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005496814085488" lon="-84.2049186305884">
+				<ele>936.1094565046951</ele>
+				<time>2017-10-02T18:20:14Z</time>
+				<extensions>
+					<speed>2.2756972312927246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005513545754123" lon="-84.204894530244">
+				<ele>935.899146550335</ele>
+				<time>2017-10-02T18:20:15Z</time>
+				<extensions>
+					<speed>2.337273120880127</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005534636457021" lon="-84.20486658430244">
+				<ele>935.784712084569</ele>
+				<time>2017-10-02T18:20:16Z</time>
+				<extensions>
+					<speed>2.6959400177001953</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005557525404054" lon="-84.20483684325463">
+				<ele>935.62154128775</ele>
+				<time>2017-10-02T18:20:17Z</time>
+				<extensions>
+					<speed>3.1870651245117188</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00558184707145" lon="-84.20480559736008">
+				<ele>935.5331809734926</ele>
+				<time>2017-10-02T18:20:18Z</time>
+				<extensions>
+					<speed>3.6861605644226074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005610542539227" lon="-84.20475553277016">
+				<ele>934.319510362111</ele>
+				<time>2017-10-02T18:20:19Z</time>
+				<extensions>
+					<speed>4.122499942779541</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005634425429868" lon="-84.20472884250309">
+				<ele>933.9233572082594</ele>
+				<time>2017-10-02T18:20:20Z</time>
+				<extensions>
+					<speed>4.098960876464844</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005658312508231" lon="-84.20469674965553">
+				<ele>933.0906208269298</ele>
+				<time>2017-10-02T18:20:21Z</time>
+				<extensions>
+					<speed>4.285645961761475</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00568849891484" lon="-84.20466263592391">
+				<ele>932.3982803355902</ele>
+				<time>2017-10-02T18:20:22Z</time>
+				<extensions>
+					<speed>4.33946418762207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005718985125878" lon="-84.20462813938346">
+				<ele>931.779096105136</ele>
+				<time>2017-10-02T18:20:23Z</time>
+				<extensions>
+					<speed>4.292510509490967</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005745560216887" lon="-84.20459422022525">
+				<ele>931.0793032767251</ele>
+				<time>2017-10-02T18:20:24Z</time>
+				<extensions>
+					<speed>4.275782585144043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005768348896671" lon="-84.20455947415456">
+				<ele>930.6293520079926</ele>
+				<time>2017-10-02T18:20:25Z</time>
+				<extensions>
+					<speed>4.292043685913086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005794223199993" lon="-84.20452481890413">
+				<ele>930.3918567253277</ele>
+				<time>2017-10-02T18:20:26Z</time>
+				<extensions>
+					<speed>4.287394046783447</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005825093610186" lon="-84.20449252028536">
+				<ele>930.1824821420014</ele>
+				<time>2017-10-02T18:20:27Z</time>
+				<extensions>
+					<speed>4.495084285736084</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005852201874708" lon="-84.2044518437444">
+				<ele>930.0075633944944</ele>
+				<time>2017-10-02T18:20:28Z</time>
+				<extensions>
+					<speed>4.926953315734863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005885816152965" lon="-84.20440946663187">
+				<ele>930.0784293496981</ele>
+				<time>2017-10-02T18:20:29Z</time>
+				<extensions>
+					<speed>5.497595310211182</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005920703529306" lon="-84.20436653015612">
+				<ele>929.8306237822399</ele>
+				<time>2017-10-02T18:20:30Z</time>
+				<extensions>
+					<speed>5.711662292480469</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00595361698733" lon="-84.2043275806728">
+				<ele>929.6629449129105</ele>
+				<time>2017-10-02T18:20:31Z</time>
+				<extensions>
+					<speed>5.604979038238525</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005983107538592" lon="-84.20430231957508">
+				<ele>929.8416760386899</ele>
+				<time>2017-10-02T18:20:32Z</time>
+				<extensions>
+					<speed>4.8761491775512695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006005479465003" lon="-84.20427872638358">
+				<ele>930.1805077083409</ele>
+				<time>2017-10-02T18:20:33Z</time>
+				<extensions>
+					<speed>3.7779107093811035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006017273850889" lon="-84.20426359433993">
+				<ele>930.5789271965623</ele>
+				<time>2017-10-02T18:20:34Z</time>
+				<extensions>
+					<speed>1.9872465133666992</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006017575620408" lon="-84.20425342123926">
+				<ele>930.5555101456121</ele>
+				<time>2017-10-02T18:20:35Z</time>
+				<extensions>
+					<speed>1.124894618988037</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00601088706714" lon="-84.20424607106496">
+				<ele>930.5386009952053</ele>
+				<time>2017-10-02T18:20:36Z</time>
+				<extensions>
+					<speed>0.8817420601844788</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00601088706714" lon="-84.20424607106496">
+				<ele>930.5386009952053</ele>
+				<time>2017-10-02T18:20:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005994245805654" lon="-84.20425065655454">
+				<ele>930.4201832348481</ele>
+				<time>2017-10-02T18:20:38Z</time>
+				<extensions>
+					<speed>1.0303418636322021</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00597878576489" lon="-84.20425158065457">
+				<ele>930.1573925754055</ele>
+				<time>2017-10-02T18:20:39Z</time>
+				<extensions>
+					<speed>1.0358712673187256</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005966696371395" lon="-84.20425524774207">
+				<ele>930.2641796506941</ele>
+				<time>2017-10-02T18:20:40Z</time>
+				<extensions>
+					<speed>0.8979925513267517</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005966696371395" lon="-84.20425524774207">
+				<ele>930.2641796506941</ele>
+				<time>2017-10-02T18:20:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005957643403042" lon="-84.20426143411409">
+				<ele>929.5598334120587</ele>
+				<time>2017-10-02T18:20:42Z</time>
+				<extensions>
+					<speed>0.6464297771453857</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005957643403042" lon="-84.20426143411409">
+				<ele>929.5598334120587</ele>
+				<time>2017-10-02T18:20:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005948258417027" lon="-84.2042657604966">
+				<ele>928.7531893579289</ele>
+				<time>2017-10-02T18:20:44Z</time>
+				<extensions>
+					<speed>0.25058913230895996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005948258417027" lon="-84.2042657604966">
+				<ele>928.7531893579289</ele>
+				<time>2017-10-02T18:20:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005948258417027" lon="-84.2042657604966">
+				<ele>928.7531893579289</ele>
+				<time>2017-10-02T18:20:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005948258417027" lon="-84.2042657604966">
+				<ele>928.7531893579289</ele>
+				<time>2017-10-02T18:20:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005948182501326" lon="-84.20423453279788">
+				<ele>928.3455594684929</ele>
+				<time>2017-10-02T18:20:48Z</time>
+				<extensions>
+					<speed>1.0937799215316772</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005954408239454" lon="-84.20420815399811">
+				<ele>928.2392886951566</ele>
+				<time>2017-10-02T18:20:49Z</time>
+				<extensions>
+					<speed>1.7699006795883179</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00596406458353" lon="-84.20417818760535">
+				<ele>928.5546088647097</ele>
+				<time>2017-10-02T18:20:50Z</time>
+				<extensions>
+					<speed>2.293020486831665</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005976698509926" lon="-84.20414407961196">
+				<ele>929.0768986344337</ele>
+				<time>2017-10-02T18:20:51Z</time>
+				<extensions>
+					<speed>2.7391517162323</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006001457696568" lon="-84.20410210676228">
+				<ele>929.3285528486595</ele>
+				<time>2017-10-02T18:20:52Z</time>
+				<extensions>
+					<speed>3.721954345703125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00602575517777" lon="-84.20406868023795">
+				<ele>929.4370663827285</ele>
+				<time>2017-10-02T18:20:53Z</time>
+				<extensions>
+					<speed>4.067986011505127</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006058453688299" lon="-84.20402901951974">
+				<ele>929.6524391118437</ele>
+				<time>2017-10-02T18:20:54Z</time>
+				<extensions>
+					<speed>4.518649101257324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006108610095078" lon="-84.20399544387718">
+				<ele>930.0313658863306</ele>
+				<time>2017-10-02T18:20:55Z</time>
+				<extensions>
+					<speed>4.871901035308838</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00615764583874" lon="-84.20396521999612">
+				<ele>930.0639510983601</ele>
+				<time>2017-10-02T18:20:56Z</time>
+				<extensions>
+					<speed>5.044241905212402</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006204559667617" lon="-84.20391939506148">
+				<ele>929.8031109832227</ele>
+				<time>2017-10-02T18:20:57Z</time>
+				<extensions>
+					<speed>5.321692943572998</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006248088846057" lon="-84.20389010525453">
+				<ele>929.8538981387392</ele>
+				<time>2017-10-02T18:20:58Z</time>
+				<extensions>
+					<speed>5.127027988433838</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006294841377464" lon="-84.20386943744946">
+				<ele>930.0712859723717</ele>
+				<time>2017-10-02T18:20:59Z</time>
+				<extensions>
+					<speed>5.029938697814941</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006340420136068" lon="-84.20385508075209">
+				<ele>929.9015415245667</ele>
+				<time>2017-10-02T18:21:00Z</time>
+				<extensions>
+					<speed>4.638926029205322</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006396805371017" lon="-84.20381695455525">
+				<ele>928.6853759512305</ele>
+				<time>2017-10-02T18:21:01Z</time>
+				<extensions>
+					<speed>3.8422598838806152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006441121396982" lon="-84.20379689908297">
+				<ele>929.0173374414444</ele>
+				<time>2017-10-02T18:21:02Z</time>
+				<extensions>
+					<speed>3.7177491188049316</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006532330797585" lon="-84.20390081764636">
+				<ele>930.8346222536638</ele>
+				<time>2017-10-02T18:21:03Z</time>
+				<extensions>
+					<speed>4.244096279144287</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006574374719419" lon="-84.2039805340559">
+				<ele>930.823732836172</ele>
+				<time>2017-10-02T18:21:04Z</time>
+				<extensions>
+					<speed>7.608433723449707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006654715982254" lon="-84.20407714797369">
+				<ele>932.5362481670454</ele>
+				<time>2017-10-02T18:21:05Z</time>
+				<extensions>
+					<speed>8.054391860961914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006703954734741" lon="-84.20414355961381">
+				<ele>932.9620206737891</ele>
+				<time>2017-10-02T18:21:06Z</time>
+				<extensions>
+					<speed>8.110228538513184</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006761030283664" lon="-84.20421826609865">
+				<ele>933.821946577169</ele>
+				<time>2017-10-02T18:21:07Z</time>
+				<extensions>
+					<speed>8.202452659606934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006838262469188" lon="-84.20429753919677">
+				<ele>935.2385823046789</ele>
+				<time>2017-10-02T18:21:08Z</time>
+				<extensions>
+					<speed>8.338233947753906</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006883901165917" lon="-84.20437170476588">
+				<ele>935.1825084593147</ele>
+				<time>2017-10-02T18:21:09Z</time>
+				<extensions>
+					<speed>8.6275053024292</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006925020000576" lon="-84.2044230437258">
+				<ele>935.2650406342</ele>
+				<time>2017-10-02T18:21:10Z</time>
+				<extensions>
+					<speed>8.583786010742188</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006968234814378" lon="-84.20446911424268">
+				<ele>935.4973737215623</ele>
+				<time>2017-10-02T18:21:11Z</time>
+				<extensions>
+					<speed>8.628952980041504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007008306139134" lon="-84.20451563220044">
+				<ele>935.0606852509081</ele>
+				<time>2017-10-02T18:21:12Z</time>
+				<extensions>
+					<speed>8.484781265258789</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007049382073125" lon="-84.20456589548992">
+				<ele>934.8158793235198</ele>
+				<time>2017-10-02T18:21:13Z</time>
+				<extensions>
+					<speed>8.288819313049316</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007093202446887" lon="-84.20461470641331">
+				<ele>934.8594558974728</ele>
+				<time>2017-10-02T18:21:14Z</time>
+				<extensions>
+					<speed>7.834134101867676</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007118439677658" lon="-84.20466862310995">
+				<ele>934.5903204297647</ele>
+				<time>2017-10-02T18:21:15Z</time>
+				<extensions>
+					<speed>7.349984169006348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007138893536618" lon="-84.20470853490096">
+				<ele>933.3246946092695</ele>
+				<time>2017-10-02T18:21:16Z</time>
+				<extensions>
+					<speed>6.460140228271484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007152105716344" lon="-84.20474550934959">
+				<ele>931.8114334568381</ele>
+				<time>2017-10-02T18:21:17Z</time>
+				<extensions>
+					<speed>5.509927749633789</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007171336600827" lon="-84.20476835803449">
+				<ele>930.7411157321185</ele>
+				<time>2017-10-02T18:21:18Z</time>
+				<extensions>
+					<speed>4.7341132164001465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00719047435995" lon="-84.20477479981872">
+				<ele>929.9980118218809</ele>
+				<time>2017-10-02T18:21:19Z</time>
+				<extensions>
+					<speed>3.5405972003936768</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007196857121633" lon="-84.20475984901769">
+				<ele>929.6054889950901</ele>
+				<time>2017-10-02T18:21:20Z</time>
+				<extensions>
+					<speed>1.562495470046997</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007193481963311" lon="-84.20474212627784">
+				<ele>929.9569843122736</ele>
+				<time>2017-10-02T18:21:21Z</time>
+				<extensions>
+					<speed>0.38993072509765625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00718566035057" lon="-84.20471376727942">
+				<ele>930.6823803326115</ele>
+				<time>2017-10-02T18:21:22Z</time>
+				<extensions>
+					<speed>1.1539864540100098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007162483042977" lon="-84.20470275094506">
+				<ele>929.7967485673726</ele>
+				<time>2017-10-02T18:21:23Z</time>
+				<extensions>
+					<speed>1.2713282108306885</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007148491538134" lon="-84.2046856428932">
+				<ele>930.2369704293087</ele>
+				<time>2017-10-02T18:21:24Z</time>
+				<extensions>
+					<speed>1.1275715827941895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007142766501964" lon="-84.20466671278412">
+				<ele>932.3388350093737</ele>
+				<time>2017-10-02T18:21:25Z</time>
+				<extensions>
+					<speed>0.9114581942558289</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007142766501964" lon="-84.20466671278412">
+				<ele>932.3388350093737</ele>
+				<time>2017-10-02T18:21:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007139681601434" lon="-84.20466648250878">
+				<ele>932.3357504969463</ele>
+				<time>2017-10-02T18:21:27Z</time>
+				<extensions>
+					<speed>0.2297380417585373</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007139681601434" lon="-84.20466648250878">
+				<ele>932.3357504969463</ele>
+				<time>2017-10-02T18:21:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007149332418468" lon="-84.20467041668763">
+				<ele>933.0516001116484</ele>
+				<time>2017-10-02T18:21:29Z</time>
+				<extensions>
+					<speed>1.6428115367889404</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007171097617581" lon="-84.20467186322709">
+				<ele>932.6321355598047</ele>
+				<time>2017-10-02T18:21:30Z</time>
+				<extensions>
+					<speed>2.50411057472229</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007204783347758" lon="-84.2046538731538">
+				<ele>930.7658317498863</ele>
+				<time>2017-10-02T18:21:31Z</time>
+				<extensions>
+					<speed>3.553982973098755</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007237127251146" lon="-84.20464334241619">
+				<ele>929.9323871191591</ele>
+				<time>2017-10-02T18:21:32Z</time>
+				<extensions>
+					<speed>4.045030117034912</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007265105428216" lon="-84.20463013293848">
+				<ele>929.579959240742</ele>
+				<time>2017-10-02T18:21:33Z</time>
+				<extensions>
+					<speed>3.949022054672241</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007291299751179" lon="-84.20460948818233">
+				<ele>929.5027943653986</ele>
+				<time>2017-10-02T18:21:34Z</time>
+				<extensions>
+					<speed>4.000326156616211</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007315397739704" lon="-84.20458017466126">
+				<ele>929.6055509224534</ele>
+				<time>2017-10-02T18:21:35Z</time>
+				<extensions>
+					<speed>4.230727195739746</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007321854789973" lon="-84.20454743164444">
+				<ele>929.5607676273212</ele>
+				<time>2017-10-02T18:21:36Z</time>
+				<extensions>
+					<speed>3.581137180328369</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00732425507923" lon="-84.20452882652384">
+				<ele>929.3039782000706</ele>
+				<time>2017-10-02T18:21:37Z</time>
+				<extensions>
+					<speed>2.194983959197998</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007323961605133" lon="-84.2045095756617">
+				<ele>929.3471352243796</ele>
+				<time>2017-10-02T18:21:38Z</time>
+				<extensions>
+					<speed>1.1310276985168457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0073074090806" lon="-84.20449381101234">
+				<ele>928.9401467293501</ele>
+				<time>2017-10-02T18:21:39Z</time>
+				<extensions>
+					<speed>0.6927840113639832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0073074090806" lon="-84.20449381101234">
+				<ele>928.9401467293501</ele>
+				<time>2017-10-02T18:21:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00730288901762" lon="-84.20449125937952">
+				<ele>928.279000217095</ele>
+				<time>2017-10-02T18:21:41Z</time>
+				<extensions>
+					<speed>0.6749498248100281</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00730288901762" lon="-84.20449125937952">
+				<ele>928.279000217095</ele>
+				<time>2017-10-02T18:21:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007296423195564" lon="-84.20448807658025">
+				<ele>927.5022842427716</ele>
+				<time>2017-10-02T18:21:43Z</time>
+				<extensions>
+					<speed>0.4041963219642639</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007296423195564" lon="-84.20448807658025">
+				<ele>927.5022842427716</ele>
+				<time>2017-10-02T18:21:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00729030663445" lon="-84.2044833264275">
+				<ele>926.1984261162579</ele>
+				<time>2017-10-02T18:21:45Z</time>
+				<extensions>
+					<speed>0.2939733862876892</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00729030663445" lon="-84.2044833264275">
+				<ele>926.1984261162579</ele>
+				<time>2017-10-02T18:21:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00729030663445" lon="-84.2044833264275">
+				<ele>926.1984261162579</ele>
+				<time>2017-10-02T18:21:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00729030663445" lon="-84.2044833264275">
+				<ele>926.1984261162579</ele>
+				<time>2017-10-02T18:21:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00729030663445" lon="-84.2044833264275">
+				<ele>926.1984261162579</ele>
+				<time>2017-10-02T18:21:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00729030663445" lon="-84.2044833264275">
+				<ele>926.1984261162579</ele>
+				<time>2017-10-02T18:21:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007293850563624" lon="-84.20446718754279">
+				<ele>927.0984893878922</ele>
+				<time>2017-10-02T18:21:51Z</time>
+				<extensions>
+					<speed>1.3020371198654175</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00730439117357" lon="-84.20444756188125">
+				<ele>928.1618866790086</ele>
+				<time>2017-10-02T18:21:52Z</time>
+				<extensions>
+					<speed>2.212035894393921</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007322511933836" lon="-84.20442603695163">
+				<ele>928.8663145527244</ele>
+				<time>2017-10-02T18:21:53Z</time>
+				<extensions>
+					<speed>2.9263224601745605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007346807736676" lon="-84.20440282578664">
+				<ele>929.3386359270662</ele>
+				<time>2017-10-02T18:21:54Z</time>
+				<extensions>
+					<speed>3.4927561283111572</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007378303832526" lon="-84.20437286757407">
+				<ele>929.777068991214</ele>
+				<time>2017-10-02T18:21:55Z</time>
+				<extensions>
+					<speed>4.0701446533203125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007417920195989" lon="-84.20433596052204">
+				<ele>929.9756637020037</ele>
+				<time>2017-10-02T18:21:56Z</time>
+				<extensions>
+					<speed>4.804993152618408</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007465946661085" lon="-84.20429869252942">
+				<ele>929.6736868144944</ele>
+				<time>2017-10-02T18:21:57Z</time>
+				<extensions>
+					<speed>5.6276774406433105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007516491808333" lon="-84.20425955597148">
+				<ele>929.9255189662799</ele>
+				<time>2017-10-02T18:21:58Z</time>
+				<extensions>
+					<speed>6.1421098709106445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007568923561262" lon="-84.20421732570836">
+				<ele>930.1211163140833</ele>
+				<time>2017-10-02T18:21:59Z</time>
+				<extensions>
+					<speed>6.54758358001709</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007623336500135" lon="-84.20417555070651">
+				<ele>930.3635121313855</ele>
+				<time>2017-10-02T18:22:00Z</time>
+				<extensions>
+					<speed>6.796960353851318</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00767953982842" lon="-84.20413031787791">
+				<ele>930.4806307312101</ele>
+				<time>2017-10-02T18:22:01Z</time>
+				<extensions>
+					<speed>7.2282514572143555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007745131849484" lon="-84.20408945276678">
+				<ele>931.0478738090023</ele>
+				<time>2017-10-02T18:22:02Z</time>
+				<extensions>
+					<speed>7.529022216796875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00780137661253" lon="-84.20404489483805">
+				<ele>931.1361991381273</ele>
+				<time>2017-10-02T18:22:03Z</time>
+				<extensions>
+					<speed>7.504207134246826</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007858021183647" lon="-84.20399725365175">
+				<ele>931.5500953858718</ele>
+				<time>2017-10-02T18:22:04Z</time>
+				<extensions>
+					<speed>7.558743476867676</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007910228700501" lon="-84.20394779158309">
+				<ele>931.5899966051802</ele>
+				<time>2017-10-02T18:22:05Z</time>
+				<extensions>
+					<speed>7.50782585144043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007960389041715" lon="-84.2039036725137">
+				<ele>931.883408033289</ele>
+				<time>2017-10-02T18:22:06Z</time>
+				<extensions>
+					<speed>7.44545841217041</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008011110519718" lon="-84.20386320967818">
+				<ele>932.405134761706</ele>
+				<time>2017-10-02T18:22:07Z</time>
+				<extensions>
+					<speed>7.3637189865112305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008068557191683" lon="-84.20381659459413">
+				<ele>932.751894406043</ele>
+				<time>2017-10-02T18:22:08Z</time>
+				<extensions>
+					<speed>7.4841694831848145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008129018728013" lon="-84.20377466007388">
+				<ele>932.6948435688391</ele>
+				<time>2017-10-02T18:22:09Z</time>
+				<extensions>
+					<speed>7.539882659912109</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008189909141173" lon="-84.20373662603566">
+				<ele>932.3393993284553</ele>
+				<time>2017-10-02T18:22:10Z</time>
+				<extensions>
+					<speed>7.411046981811523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008243620964024" lon="-84.20370575409527">
+				<ele>932.487514205277</ele>
+				<time>2017-10-02T18:22:11Z</time>
+				<extensions>
+					<speed>7.2926859855651855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008300777277906" lon="-84.20365771948595">
+				<ele>932.7733091013506</ele>
+				<time>2017-10-02T18:22:12Z</time>
+				<extensions>
+					<speed>7.335457801818848</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008350068511847" lon="-84.20361927185878">
+				<ele>933.0394932618365</ele>
+				<time>2017-10-02T18:22:13Z</time>
+				<extensions>
+					<speed>7.170987129211426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008395890001136" lon="-84.20357962258856">
+				<ele>932.8783006565645</ele>
+				<time>2017-10-02T18:22:14Z</time>
+				<extensions>
+					<speed>6.691789150238037</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00844048008243" lon="-84.20354270607498">
+				<ele>932.7392220972106</ele>
+				<time>2017-10-02T18:22:15Z</time>
+				<extensions>
+					<speed>6.26033878326416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008474709033527" lon="-84.20351706599075">
+				<ele>932.554768897593</ele>
+				<time>2017-10-02T18:22:16Z</time>
+				<extensions>
+					<speed>5.273286819458008</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008491211126259" lon="-84.20350119207924">
+				<ele>932.4659420112148</ele>
+				<time>2017-10-02T18:22:17Z</time>
+				<extensions>
+					<speed>4.072235107421875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008494179367963" lon="-84.20349739512038">
+				<ele>932.1279694382101</ele>
+				<time>2017-10-02T18:22:18Z</time>
+				<extensions>
+					<speed>2.43156099319458</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008490442855122" lon="-84.20350122544484">
+				<ele>931.9254343714565</ele>
+				<time>2017-10-02T18:22:19Z</time>
+				<extensions>
+					<speed>1.092680811882019</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008484295801546" lon="-84.20350428266539">
+				<ele>931.5796417882666</ele>
+				<time>2017-10-02T18:22:20Z</time>
+				<extensions>
+					<speed>1.0782103538513184</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008482859794894" lon="-84.20350317963931">
+				<ele>931.2641696343198</ele>
+				<time>2017-10-02T18:22:21Z</time>
+				<extensions>
+					<speed>1.1556469202041626</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00847975002147" lon="-84.20350197284053">
+				<ele>930.9336507264525</ele>
+				<time>2017-10-02T18:22:22Z</time>
+				<extensions>
+					<speed>1.0836092233657837</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008484984594403" lon="-84.20349500356048">
+				<ele>930.8965654708445</ele>
+				<time>2017-10-02T18:22:23Z</time>
+				<extensions>
+					<speed>1.3410624265670776</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008487075356877" lon="-84.20349392656833">
+				<ele>930.5014791879803</ele>
+				<time>2017-10-02T18:22:24Z</time>
+				<extensions>
+					<speed>1.2613588571548462</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008500877721968" lon="-84.20349070418864">
+				<ele>930.2170302225277</ele>
+				<time>2017-10-02T18:22:25Z</time>
+				<extensions>
+					<speed>1.6611770391464233</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008519310157842" lon="-84.20348259983595">
+				<ele>929.8866105172783</ele>
+				<time>2017-10-02T18:22:26Z</time>
+				<extensions>
+					<speed>2.1843414306640625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008540415590074" lon="-84.20346580483914">
+				<ele>929.6676184907556</ele>
+				<time>2017-10-02T18:22:27Z</time>
+				<extensions>
+					<speed>2.664517402648926</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008570767620247" lon="-84.20344770552484">
+				<ele>929.5260561546311</ele>
+				<time>2017-10-02T18:22:28Z</time>
+				<extensions>
+					<speed>3.284653902053833</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008616174475394" lon="-84.20342123614226">
+				<ele>929.7112463153899</ele>
+				<time>2017-10-02T18:22:29Z</time>
+				<extensions>
+					<speed>3.95926570892334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008656079411484" lon="-84.20339712956698">
+				<ele>929.0399261070415</ele>
+				<time>2017-10-02T18:22:30Z</time>
+				<extensions>
+					<speed>4.265433311462402</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008707242089825" lon="-84.20334021776351">
+				<ele>928.8426129510626</ele>
+				<time>2017-10-02T18:22:31Z</time>
+				<extensions>
+					<speed>5.008464336395264</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008739801966259" lon="-84.20330348036285">
+				<ele>927.482758903876</ele>
+				<time>2017-10-02T18:22:32Z</time>
+				<extensions>
+					<speed>3.7878623008728027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008769138030342" lon="-84.2032813680443">
+				<ele>927.3283801469952</ele>
+				<time>2017-10-02T18:22:33Z</time>
+				<extensions>
+					<speed>2.3275814056396484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008778913264454" lon="-84.20327261699018">
+				<ele>926.7372082313523</ele>
+				<time>2017-10-02T18:22:34Z</time>
+				<extensions>
+					<speed>0.3832600712776184</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008771765685358" lon="-84.20327708376274">
+				<ele>925.582749241963</ele>
+				<time>2017-10-02T18:22:35Z</time>
+				<extensions>
+					<speed>0.6112004518508911</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008771765685358" lon="-84.20327708376274">
+				<ele>925.582749241963</ele>
+				<time>2017-10-02T18:22:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008770072495615" lon="-84.20328767840094">
+				<ele>926.0312797604129</ele>
+				<time>2017-10-02T18:22:37Z</time>
+				<extensions>
+					<speed>1.0722216367721558</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008766706552397" lon="-84.20329436919842">
+				<ele>927.0170086035505</ele>
+				<time>2017-10-02T18:22:38Z</time>
+				<extensions>
+					<speed>1.1443573236465454</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00876385437729" lon="-84.20329385482071">
+				<ele>928.468583855778</ele>
+				<time>2017-10-02T18:22:39Z</time>
+				<extensions>
+					<speed>0.9527761936187744</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00876385437729" lon="-84.20329385482071">
+				<ele>928.468583855778</ele>
+				<time>2017-10-02T18:22:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008778909375303" lon="-84.20329446734152">
+				<ele>933.3255778243765</ele>
+				<time>2017-10-02T18:22:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008778909375303" lon="-84.20329446734152">
+				<ele>933.3255778243765</ele>
+				<time>2017-10-02T18:22:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008778909375303" lon="-84.20329446734152">
+				<ele>933.3255778243765</ele>
+				<time>2017-10-02T18:22:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008778909375303" lon="-84.20329446734152">
+				<ele>933.3255778243765</ele>
+				<time>2017-10-02T18:22:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008778909375303" lon="-84.20329446734152">
+				<ele>933.3255778243765</ele>
+				<time>2017-10-02T18:22:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008778909375303" lon="-84.20329446734152">
+				<ele>933.3255778243765</ele>
+				<time>2017-10-02T18:22:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008796743206592" lon="-84.20328546559674">
+				<ele>935.8037635283545</ele>
+				<time>2017-10-02T18:22:47Z</time>
+				<extensions>
+					<speed>1.169953465461731</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008826268625848" lon="-84.20325549021521">
+				<ele>937.8948656972498</ele>
+				<time>2017-10-02T18:22:48Z</time>
+				<extensions>
+					<speed>3.181363821029663</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008875137173222" lon="-84.20322146873478">
+				<ele>940.6653006523848</ele>
+				<time>2017-10-02T18:22:49Z</time>
+				<extensions>
+					<speed>4.067880630493164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008924919362402" lon="-84.20318807136782">
+				<ele>942.8796473788098</ele>
+				<time>2017-10-02T18:22:50Z</time>
+				<extensions>
+					<speed>5.089691638946533</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008974046846113" lon="-84.20315387090857">
+				<ele>944.5917228274047</ele>
+				<time>2017-10-02T18:22:51Z</time>
+				<extensions>
+					<speed>5.436334133148193</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009022631370078" lon="-84.20312304863609">
+				<ele>946.4750709803775</ele>
+				<time>2017-10-02T18:22:52Z</time>
+				<extensions>
+					<speed>5.200424671173096</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00906448425572" lon="-84.20309301428878">
+				<ele>948.1011092858389</ele>
+				<time>2017-10-02T18:22:53Z</time>
+				<extensions>
+					<speed>4.874195098876953</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009102242629398" lon="-84.20307076799044">
+				<ele>949.4249151330441</ele>
+				<time>2017-10-02T18:22:54Z</time>
+				<extensions>
+					<speed>4.306325435638428</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009136339629405" lon="-84.20305002687778">
+				<ele>951.5095931496471</ele>
+				<time>2017-10-02T18:22:55Z</time>
+				<extensions>
+					<speed>3.5099079608917236</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009159570960573" lon="-84.20303231031855">
+				<ele>952.6717973314226</ele>
+				<time>2017-10-02T18:22:56Z</time>
+				<extensions>
+					<speed>2.5499002933502197</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009174873933725" lon="-84.2030201200145">
+				<ele>953.6783357271925</ele>
+				<time>2017-10-02T18:22:57Z</time>
+				<extensions>
+					<speed>1.7531651258468628</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009186148139051" lon="-84.20300856796192">
+				<ele>954.6760129611939</ele>
+				<time>2017-10-02T18:22:58Z</time>
+				<extensions>
+					<speed>1.4079469442367554</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009195707175088" lon="-84.2029953019094">
+				<ele>955.7409092402086</ele>
+				<time>2017-10-02T18:22:59Z</time>
+				<extensions>
+					<speed>1.5690168142318726</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009209015955392" lon="-84.20298111999114">
+				<ele>956.7393083535135</ele>
+				<time>2017-10-02T18:23:00Z</time>
+				<extensions>
+					<speed>1.9216499328613281</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009225747905273" lon="-84.20296436503122">
+				<ele>957.6455565048382</ele>
+				<time>2017-10-02T18:23:01Z</time>
+				<extensions>
+					<speed>2.453578472137451</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009247478047419" lon="-84.2029466812045">
+				<ele>958.4445121958852</ele>
+				<time>2017-10-02T18:23:02Z</time>
+				<extensions>
+					<speed>2.9258556365966797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009271370160688" lon="-84.20292872872902">
+				<ele>959.0529327234253</ele>
+				<time>2017-10-02T18:23:03Z</time>
+				<extensions>
+					<speed>3.1857192516326904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009301186594207" lon="-84.20290980582182">
+				<ele>959.8366201203316</ele>
+				<time>2017-10-02T18:23:04Z</time>
+				<extensions>
+					<speed>3.608564853668213</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009336691804029" lon="-84.20288147615955">
+				<ele>960.0313403327018</ele>
+				<time>2017-10-02T18:23:05Z</time>
+				<extensions>
+					<speed>4.799263000488281</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009378974090573" lon="-84.2028480502196">
+				<ele>960.2918105395511</ele>
+				<time>2017-10-02T18:23:06Z</time>
+				<extensions>
+					<speed>6.055882930755615</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009427637241279" lon="-84.20280344412302">
+				<ele>960.7737840600312</ele>
+				<time>2017-10-02T18:23:07Z</time>
+				<extensions>
+					<speed>7.297327995300293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00948491924645" lon="-84.20275141034072">
+				<ele>961.1860608337447</ele>
+				<time>2017-10-02T18:23:08Z</time>
+				<extensions>
+					<speed>8.613505363464355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00954117666989" lon="-84.2026998578711">
+				<ele>961.1986344512552</ele>
+				<time>2017-10-02T18:23:09Z</time>
+				<extensions>
+					<speed>8.011842727661133</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009596429175042" lon="-84.20265689973554">
+				<ele>961.0700622564182</ele>
+				<time>2017-10-02T18:23:10Z</time>
+				<extensions>
+					<speed>7.613009452819824</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009651269751659" lon="-84.20261476988667">
+				<ele>961.1838047513738</ele>
+				<time>2017-10-02T18:23:11Z</time>
+				<extensions>
+					<speed>7.582207202911377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009705045296935" lon="-84.20256683355211">
+				<ele>960.8544170083478</ele>
+				<time>2017-10-02T18:23:12Z</time>
+				<extensions>
+					<speed>7.627411842346191</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0097620540483" lon="-84.20251808038373">
+				<ele>960.7546878587455</ele>
+				<time>2017-10-02T18:23:13Z</time>
+				<extensions>
+					<speed>7.810566425323486</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009821166950235" lon="-84.20246271592106">
+				<ele>960.7234701095149</ele>
+				<time>2017-10-02T18:23:14Z</time>
+				<extensions>
+					<speed>8.051078796386719</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009868808181091" lon="-84.20240681708434">
+				<ele>959.9177487669513</ele>
+				<time>2017-10-02T18:23:15Z</time>
+				<extensions>
+					<speed>8.11637020111084</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009921706028258" lon="-84.2023439493915">
+				<ele>959.4855602029711</ele>
+				<time>2017-10-02T18:23:16Z</time>
+				<extensions>
+					<speed>8.311579704284668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009978043297185" lon="-84.20229015853069">
+				<ele>959.2482323134318</ele>
+				<time>2017-10-02T18:23:17Z</time>
+				<extensions>
+					<speed>8.266335487365723</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010036000563641" lon="-84.2022480188282">
+				<ele>959.3644914412871</ele>
+				<time>2017-10-02T18:23:18Z</time>
+				<extensions>
+					<speed>8.064593315124512</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010090641165295" lon="-84.20220811325885">
+				<ele>959.6170535217971</ele>
+				<time>2017-10-02T18:23:19Z</time>
+				<extensions>
+					<speed>7.587944507598877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01013473917115" lon="-84.20217480480609">
+				<ele>960.0186947481707</ele>
+				<time>2017-10-02T18:23:20Z</time>
+				<extensions>
+					<speed>6.456469535827637</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01016638593996" lon="-84.20215186333472">
+				<ele>960.6396149331704</ele>
+				<time>2017-10-02T18:23:21Z</time>
+				<extensions>
+					<speed>4.112011909484863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010193727675611" lon="-84.20213773384378">
+				<ele>961.681893276982</ele>
+				<time>2017-10-02T18:23:22Z</time>
+				<extensions>
+					<speed>2.7889246940612793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01021106252717" lon="-84.20212071597012">
+				<ele>962.473676671274</ele>
+				<time>2017-10-02T18:23:23Z</time>
+				<extensions>
+					<speed>2.574321985244751</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010209478080704" lon="-84.2021184019233">
+				<ele>963.4061851035804</ele>
+				<time>2017-10-02T18:23:24Z</time>
+				<extensions>
+					<speed>0.08264459669589996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010201246979733" lon="-84.2021179198018">
+				<ele>963.8007448762655</ele>
+				<time>2017-10-02T18:23:25Z</time>
+				<extensions>
+					<speed>1.5715035200119019</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010198950162607" lon="-84.20211592119733">
+				<ele>964.734472242184</ele>
+				<time>2017-10-02T18:23:26Z</time>
+				<extensions>
+					<speed>1.2448341846466064</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01019820239624" lon="-84.20211930260959">
+				<ele>965.7326185172424</ele>
+				<time>2017-10-02T18:23:27Z</time>
+				<extensions>
+					<speed>1.2280362844467163</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010198826207061" lon="-84.20212104922457">
+				<ele>966.9237670525908</ele>
+				<time>2017-10-02T18:23:28Z</time>
+				<extensions>
+					<speed>1.1532089710235596</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010191107755654" lon="-84.20212629692767">
+				<ele>967.5967762256041</ele>
+				<time>2017-10-02T18:23:29Z</time>
+				<extensions>
+					<speed>0.845760703086853</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010191107755654" lon="-84.20212629692767">
+				<ele>967.5967762256041</ele>
+				<time>2017-10-02T18:23:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01016717350889" lon="-84.20212054140794">
+				<ele>962.172545154579</ele>
+				<time>2017-10-02T18:23:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01016717350889" lon="-84.20212054140794">
+				<ele>962.172545154579</ele>
+				<time>2017-10-02T18:23:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01016717350889" lon="-84.20212054140794">
+				<ele>962.172545154579</ele>
+				<time>2017-10-02T18:23:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010184298983239" lon="-84.20211590085879">
+				<ele>962.6593143669888</ele>
+				<time>2017-10-02T18:23:34Z</time>
+				<extensions>
+					<speed>1.2213525772094727</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010200343264117" lon="-84.20210456728847">
+				<ele>963.1276274826378</ele>
+				<time>2017-10-02T18:23:35Z</time>
+				<extensions>
+					<speed>1.9844776391983032</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010221348663089" lon="-84.20208854925578">
+				<ele>964.0153715610504</ele>
+				<time>2017-10-02T18:23:36Z</time>
+				<extensions>
+					<speed>2.51503324508667</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010244814597531" lon="-84.20206874497157">
+				<ele>964.4608999313787</ele>
+				<time>2017-10-02T18:23:37Z</time>
+				<extensions>
+					<speed>3.049642324447632</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010273305714513" lon="-84.2020475177782">
+				<ele>964.6954226316884</ele>
+				<time>2017-10-02T18:23:38Z</time>
+				<extensions>
+					<speed>3.444153070449829</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010326419009276" lon="-84.20201289820703">
+				<ele>964.7948964992538</ele>
+				<time>2017-10-02T18:23:39Z</time>
+				<extensions>
+					<speed>4.731875419616699</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010375626732683" lon="-84.20198007445529">
+				<ele>965.068441693671</ele>
+				<time>2017-10-02T18:23:40Z</time>
+				<extensions>
+					<speed>5.525431156158447</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010428783524683" lon="-84.20194895700901">
+				<ele>965.0321456277743</ele>
+				<time>2017-10-02T18:23:41Z</time>
+				<extensions>
+					<speed>5.912290573120117</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0104814719404" lon="-84.2019194303303">
+				<ele>964.8938332665712</ele>
+				<time>2017-10-02T18:23:42Z</time>
+				<extensions>
+					<speed>6.095035076141357</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01053509311001" lon="-84.20189197942939">
+				<ele>964.9404891189188</ele>
+				<time>2017-10-02T18:23:43Z</time>
+				<extensions>
+					<speed>6.321796894073486</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010598278858435" lon="-84.20185956368464">
+				<ele>964.9729562178254</ele>
+				<time>2017-10-02T18:23:44Z</time>
+				<extensions>
+					<speed>6.938895225524902</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010665124651764" lon="-84.20181799667112">
+				<ele>965.001479418017</ele>
+				<time>2017-10-02T18:23:45Z</time>
+				<extensions>
+					<speed>7.190576076507568</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01073250555532" lon="-84.201775818747">
+				<ele>964.9828692553565</ele>
+				<time>2017-10-02T18:23:46Z</time>
+				<extensions>
+					<speed>7.406322479248047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010796371497952" lon="-84.20173513151443">
+				<ele>965.1346205119044</ele>
+				<time>2017-10-02T18:23:47Z</time>
+				<extensions>
+					<speed>7.431608200073242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010857592938814" lon="-84.20169103800784">
+				<ele>965.2137065436691</ele>
+				<time>2017-10-02T18:23:48Z</time>
+				<extensions>
+					<speed>7.160315036773682</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010911495029445" lon="-84.20165507400289">
+				<ele>965.2629867624491</ele>
+				<time>2017-10-02T18:23:49Z</time>
+				<extensions>
+					<speed>6.639894485473633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01095538315725" lon="-84.20161770001243">
+				<ele>965.4870782513171</ele>
+				<time>2017-10-02T18:23:50Z</time>
+				<extensions>
+					<speed>5.761364936828613</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010990699917404" lon="-84.20159161819731">
+				<ele>965.6825318690389</ele>
+				<time>2017-10-02T18:23:51Z</time>
+				<extensions>
+					<speed>4.500943183898926</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011016862332404" lon="-84.20157625006198">
+				<ele>965.8576186355203</ele>
+				<time>2017-10-02T18:23:52Z</time>
+				<extensions>
+					<speed>2.8765361309051514</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011032354143879" lon="-84.20156827861862">
+				<ele>966.2274987166747</ele>
+				<time>2017-10-02T18:23:53Z</time>
+				<extensions>
+					<speed>1.739733099937439</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011041702827331" lon="-84.20156527888881">
+				<ele>966.4260115865618</ele>
+				<time>2017-10-02T18:23:54Z</time>
+				<extensions>
+					<speed>1.4026086330413818</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011048988935562" lon="-84.20156235574039">
+				<ele>966.7876944001764</ele>
+				<time>2017-10-02T18:23:55Z</time>
+				<extensions>
+					<speed>1.2882534265518188</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01105816566408" lon="-84.2015576285721">
+				<ele>967.0969759160653</ele>
+				<time>2017-10-02T18:23:56Z</time>
+				<extensions>
+					<speed>1.5288255214691162</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011072130882809" lon="-84.20155310768854">
+				<ele>967.2185177505016</ele>
+				<time>2017-10-02T18:23:57Z</time>
+				<extensions>
+					<speed>2.293748617172241</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011092278290974" lon="-84.20154197882262">
+				<ele>967.3005144698545</ele>
+				<time>2017-10-02T18:23:58Z</time>
+				<extensions>
+					<speed>3.2201173305511475</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011115713945095" lon="-84.20152200170878">
+				<ele>967.4356639133766</ele>
+				<time>2017-10-02T18:23:59Z</time>
+				<extensions>
+					<speed>3.942288398742676</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011140505784804" lon="-84.20149622666291">
+				<ele>967.3891263725236</ele>
+				<time>2017-10-02T18:24:00Z</time>
+				<extensions>
+					<speed>4.480780124664307</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011167871350914" lon="-84.20147301315676">
+				<ele>966.6355883590877</ele>
+				<time>2017-10-02T18:24:01Z</time>
+				<extensions>
+					<speed>4.842576503753662</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011201767081287" lon="-84.20145819636261">
+				<ele>966.6711210878566</ele>
+				<time>2017-10-02T18:24:02Z</time>
+				<extensions>
+					<speed>4.371519088745117</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011235379396066" lon="-84.20145162225062">
+				<ele>966.0273190988228</ele>
+				<time>2017-10-02T18:24:03Z</time>
+				<extensions>
+					<speed>3.739198684692383</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011267713666157" lon="-84.20144487226776">
+				<ele>965.8826283523813</ele>
+				<time>2017-10-02T18:24:04Z</time>
+				<extensions>
+					<speed>3.5466880798339844</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011294485166106" lon="-84.20144447556996">
+				<ele>965.8119533276185</ele>
+				<time>2017-10-02T18:24:05Z</time>
+				<extensions>
+					<speed>2.622835874557495</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011312465429468" lon="-84.2014491384676">
+				<ele>965.6474928678945</ele>
+				<time>2017-10-02T18:24:06Z</time>
+				<extensions>
+					<speed>1.075167179107666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011320456805036" lon="-84.2014540918685">
+				<ele>965.5956028383225</ele>
+				<time>2017-10-02T18:24:07Z</time>
+				<extensions>
+					<speed>0.9596604108810425</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011321372915798" lon="-84.20146316614748">
+				<ele>965.8490270050243</ele>
+				<time>2017-10-02T18:24:08Z</time>
+				<extensions>
+					<speed>1.0115711688995361</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011320105790013" lon="-84.20146647236493">
+				<ele>966.2160178152844</ele>
+				<time>2017-10-02T18:24:09Z</time>
+				<extensions>
+					<speed>0.655386745929718</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011320105790013" lon="-84.20146647236493">
+				<ele>966.2160178152844</ele>
+				<time>2017-10-02T18:24:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01131918163156" lon="-84.20147086371104">
+				<ele>966.2593602743</ele>
+				<time>2017-10-02T18:24:11Z</time>
+				<extensions>
+					<speed>0.80120450258255</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01131918163156" lon="-84.20147086371104">
+				<ele>966.2593602743</ele>
+				<time>2017-10-02T18:24:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011318989276326" lon="-84.20147110535625">
+				<ele>965.9263844033703</ele>
+				<time>2017-10-02T18:24:13Z</time>
+				<extensions>
+					<speed>0.5394155383110046</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011318989276326" lon="-84.20147110535625">
+				<ele>965.9263844033703</ele>
+				<time>2017-10-02T18:24:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:15Z</time>
+				<extensions>
+					<speed>0.18418379127979279</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011326511071193" lon="-84.20147477562102">
+				<ele>966.139118263498</ele>
+				<time>2017-10-02T18:24:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011332169030021" lon="-84.20147090419073">
+				<ele>965.9705444807187</ele>
+				<time>2017-10-02T18:24:36Z</time>
+				<extensions>
+					<speed>1.089443325996399</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01134898095025" lon="-84.20145997687669">
+				<ele>965.8140422897413</ele>
+				<time>2017-10-02T18:24:37Z</time>
+				<extensions>
+					<speed>2.512754201889038</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011375206857608" lon="-84.20144488815168">
+				<ele>965.5786597263068</ele>
+				<time>2017-10-02T18:24:38Z</time>
+				<extensions>
+					<speed>3.4067912101745605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01140682929087" lon="-84.2014280826858">
+				<ele>965.4302783627063</ele>
+				<time>2017-10-02T18:24:39Z</time>
+				<extensions>
+					<speed>3.759735345840454</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011442227936698" lon="-84.201412767871">
+				<ele>965.4276328794658</ele>
+				<time>2017-10-02T18:24:40Z</time>
+				<extensions>
+					<speed>3.9563772678375244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011479256860518" lon="-84.20139544469843">
+				<ele>965.6110689239576</ele>
+				<time>2017-10-02T18:24:41Z</time>
+				<extensions>
+					<speed>4.155378818511963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01152628575168" lon="-84.20137596551731">
+				<ele>965.7458677804098</ele>
+				<time>2017-10-02T18:24:42Z</time>
+				<extensions>
+					<speed>5.010507106781006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011576815757953" lon="-84.20135816017806">
+				<ele>966.1831704117358</ele>
+				<time>2017-10-02T18:24:43Z</time>
+				<extensions>
+					<speed>5.974985599517822</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01163761697267" lon="-84.20133177122686">
+				<ele>966.2999666109681</ele>
+				<time>2017-10-02T18:24:44Z</time>
+				<extensions>
+					<speed>7.540097236633301</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01170777388788" lon="-84.20129558447492">
+				<ele>966.2569580441341</ele>
+				<time>2017-10-02T18:24:45Z</time>
+				<extensions>
+					<speed>8.53502082824707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011781226799044" lon="-84.20125830760595">
+				<ele>966.3800363810733</ele>
+				<time>2017-10-02T18:24:46Z</time>
+				<extensions>
+					<speed>9.056889533996582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011857759830724" lon="-84.20121555929258">
+				<ele>966.3677909234539</ele>
+				<time>2017-10-02T18:24:47Z</time>
+				<extensions>
+					<speed>9.56700611114502</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01193815950308" lon="-84.20117371232718">
+				<ele>966.5571609931067</ele>
+				<time>2017-10-02T18:24:48Z</time>
+				<extensions>
+					<speed>9.636612892150879</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01201719714986" lon="-84.20113406325419">
+				<ele>966.6638771668077</ele>
+				<time>2017-10-02T18:24:49Z</time>
+				<extensions>
+					<speed>9.312040328979492</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012087812739964" lon="-84.20109671307762">
+				<ele>966.7184285931289</ele>
+				<time>2017-10-02T18:24:50Z</time>
+				<extensions>
+					<speed>8.27074909210205</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012146443972401" lon="-84.20106330280173">
+				<ele>966.7491394849494</ele>
+				<time>2017-10-02T18:24:51Z</time>
+				<extensions>
+					<speed>6.58136510848999</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012188621624643" lon="-84.20103782382012">
+				<ele>966.7540950579569</ele>
+				<time>2017-10-02T18:24:52Z</time>
+				<extensions>
+					<speed>3.851116895675659</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012212214361567" lon="-84.20102235971414">
+				<ele>966.7744467034936</ele>
+				<time>2017-10-02T18:24:53Z</time>
+				<extensions>
+					<speed>2.033574342727661</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012227269701079" lon="-84.20101500787474">
+				<ele>967.0132377780974</ele>
+				<time>2017-10-02T18:24:54Z</time>
+				<extensions>
+					<speed>1.1930298805236816</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012235178950153" lon="-84.20101018550862">
+				<ele>967.1496693715453</ele>
+				<time>2017-10-02T18:24:55Z</time>
+				<extensions>
+					<speed>0.6588101983070374</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012235178950153" lon="-84.20101018550862">
+				<ele>967.1496693715453</ele>
+				<time>2017-10-02T18:24:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012242223309357" lon="-84.2010042210285">
+				<ele>966.887403161265</ele>
+				<time>2017-10-02T18:24:57Z</time>
+				<extensions>
+					<speed>1.3921180963516235</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01225797404662" lon="-84.20099297515692">
+				<ele>966.5915444036946</ele>
+				<time>2017-10-02T18:24:58Z</time>
+				<extensions>
+					<speed>2.7882373332977295</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012283429541133" lon="-84.20097598783792">
+				<ele>965.860967695713</ele>
+				<time>2017-10-02T18:24:59Z</time>
+				<extensions>
+					<speed>3.9647440910339355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012325159954846" lon="-84.20095164351072">
+				<ele>966.1755932178348</ele>
+				<time>2017-10-02T18:25:00Z</time>
+				<extensions>
+					<speed>5.470836639404297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012374550624543" lon="-84.20092674345725">
+				<ele>966.0164392311126</ele>
+				<time>2017-10-02T18:25:01Z</time>
+				<extensions>
+					<speed>6.563039302825928</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012432553774985" lon="-84.2008962664712">
+				<ele>965.7200052123517</ele>
+				<time>2017-10-02T18:25:02Z</time>
+				<extensions>
+					<speed>7.4864091873168945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01249700946402" lon="-84.20086541426544">
+				<ele>965.5366317220032</ele>
+				<time>2017-10-02T18:25:03Z</time>
+				<extensions>
+					<speed>8.009183883666992</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01256495026233" lon="-84.20083285232344">
+				<ele>965.2324158316478</ele>
+				<time>2017-10-02T18:25:04Z</time>
+				<extensions>
+					<speed>8.23175048828125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012634180480402" lon="-84.20079927770101">
+				<ele>964.9231390468776</ele>
+				<time>2017-10-02T18:25:05Z</time>
+				<extensions>
+					<speed>8.460733413696289</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01270392715862" lon="-84.20076723355021">
+				<ele>964.6996757360175</ele>
+				<time>2017-10-02T18:25:06Z</time>
+				<extensions>
+					<speed>8.444134712219238</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012771243932013" lon="-84.20073491652934">
+				<ele>964.6193003896624</ele>
+				<time>2017-10-02T18:25:07Z</time>
+				<extensions>
+					<speed>8.295767784118652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012835443937428" lon="-84.20070413047391">
+				<ele>964.618163658306</ele>
+				<time>2017-10-02T18:25:08Z</time>
+				<extensions>
+					<speed>7.737634658813477</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012882029094138" lon="-84.2006800039121">
+				<ele>964.3530787853524</ele>
+				<time>2017-10-02T18:25:09Z</time>
+				<extensions>
+					<speed>6.011346340179443</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012920830563404" lon="-84.20066032214778">
+				<ele>963.909896443598</ele>
+				<time>2017-10-02T18:25:10Z</time>
+				<extensions>
+					<speed>4.738790512084961</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012959245383461" lon="-84.20064773032287">
+				<ele>963.6819134922698</ele>
+				<time>2017-10-02T18:25:11Z</time>
+				<extensions>
+					<speed>4.775113582611084</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013002563915844" lon="-84.20065067061965">
+				<ele>963.6366205075756</ele>
+				<time>2017-10-02T18:25:12Z</time>
+				<extensions>
+					<speed>4.773447036743164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01304162281974" lon="-84.20067320238702">
+				<ele>963.8089913344011</ele>
+				<time>2017-10-02T18:25:13Z</time>
+				<extensions>
+					<speed>4.7324347496032715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013080555450168" lon="-84.20071828341295">
+				<ele>964.1856803968549</ele>
+				<time>2017-10-02T18:25:14Z</time>
+				<extensions>
+					<speed>6.516304016113281</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013120151207145" lon="-84.20077764472047">
+				<ele>964.3241074373946</ele>
+				<time>2017-10-02T18:25:15Z</time>
+				<extensions>
+					<speed>7.411167621612549</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013157778763341" lon="-84.20083627379805">
+				<ele>964.5438336152583</ele>
+				<time>2017-10-02T18:25:16Z</time>
+				<extensions>
+					<speed>7.094946384429932</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013191154199657" lon="-84.2008886170188">
+				<ele>964.9577745720744</ele>
+				<time>2017-10-02T18:25:17Z</time>
+				<extensions>
+					<speed>5.679238319396973</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013212265953342" lon="-84.20093233499016">
+				<ele>965.1284324638546</ele>
+				<time>2017-10-02T18:25:18Z</time>
+				<extensions>
+					<speed>4.74710750579834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013225781855594" lon="-84.20096639912265">
+				<ele>965.3181588994339</ele>
+				<time>2017-10-02T18:25:19Z</time>
+				<extensions>
+					<speed>3.6009700298309326</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01323017177132" lon="-84.20098923698485">
+				<ele>965.4077163934708</ele>
+				<time>2017-10-02T18:25:20Z</time>
+				<extensions>
+					<speed>2.002772808074951</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013225822846122" lon="-84.20099689907137">
+				<ele>965.3342782938853</ele>
+				<time>2017-10-02T18:25:21Z</time>
+				<extensions>
+					<speed>0.6269474625587463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013219768726923" lon="-84.20099532689497">
+				<ele>965.1689423546195</ele>
+				<time>2017-10-02T18:25:22Z</time>
+				<extensions>
+					<speed>0.916935384273529</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013219768726923" lon="-84.20099532689497">
+				<ele>965.1689423546195</ele>
+				<time>2017-10-02T18:25:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013212897911968" lon="-84.2009937750296">
+				<ele>964.5830120556056</ele>
+				<time>2017-10-02T18:25:24Z</time>
+				<extensions>
+					<speed>0.5262426733970642</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013212897911968" lon="-84.2009937750296">
+				<ele>964.5830120556056</ele>
+				<time>2017-10-02T18:25:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013210954099554" lon="-84.20099447384507">
+				<ele>964.3389883190393</ele>
+				<time>2017-10-02T18:25:26Z</time>
+				<extensions>
+					<speed>0.0745769664645195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013210954099554" lon="-84.20099447384507">
+				<ele>964.3389883190393</ele>
+				<time>2017-10-02T18:25:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013210954099554" lon="-84.20099447384507">
+				<ele>964.3389883190393</ele>
+				<time>2017-10-02T18:25:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013210954099554" lon="-84.20099447384507">
+				<ele>964.3389883190393</ele>
+				<time>2017-10-02T18:25:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013210954099554" lon="-84.20099447384507">
+				<ele>964.3389883190393</ele>
+				<time>2017-10-02T18:25:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013210954099554" lon="-84.20099447384507">
+				<ele>964.3389883190393</ele>
+				<time>2017-10-02T18:25:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013210954099554" lon="-84.20099447384507">
+				<ele>964.3389883190393</ele>
+				<time>2017-10-02T18:25:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013210954099554" lon="-84.20099447384507">
+				<ele>964.3389883190393</ele>
+				<time>2017-10-02T18:25:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013210954099554" lon="-84.20099447384507">
+				<ele>964.3389883190393</ele>
+				<time>2017-10-02T18:25:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01322215777436" lon="-84.20101739585337">
+				<ele>964.225693533197</ele>
+				<time>2017-10-02T18:25:35Z</time>
+				<extensions>
+					<speed>0.6139062643051147</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013237716699598" lon="-84.20104415502605">
+				<ele>964.0462974235415</ele>
+				<time>2017-10-02T18:25:36Z</time>
+				<extensions>
+					<speed>1.2653626203536987</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013264678648545" lon="-84.20108818722441">
+				<ele>964.0299809705466</ele>
+				<time>2017-10-02T18:25:37Z</time>
+				<extensions>
+					<speed>2.5871832370758057</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01329055352747" lon="-84.20112051086784">
+				<ele>963.977780890651</ele>
+				<time>2017-10-02T18:25:38Z</time>
+				<extensions>
+					<speed>4.123708248138428</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013327861321349" lon="-84.20116528937254">
+				<ele>964.0854422161356</ele>
+				<time>2017-10-02T18:25:39Z</time>
+				<extensions>
+					<speed>5.513418197631836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013369210523143" lon="-84.20121385062669">
+				<ele>964.320320202969</ele>
+				<time>2017-10-02T18:25:40Z</time>
+				<extensions>
+					<speed>6.72792911529541</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01341082254763" lon="-84.20126095406302">
+				<ele>964.488558950834</ele>
+				<time>2017-10-02T18:25:41Z</time>
+				<extensions>
+					<speed>7.340751647949219</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013455346277661" lon="-84.20130719058665">
+				<ele>964.442407223396</ele>
+				<time>2017-10-02T18:25:42Z</time>
+				<extensions>
+					<speed>7.668299198150635</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01350190950873" lon="-84.20135933289308">
+				<ele>964.2702483898029</ele>
+				<time>2017-10-02T18:25:43Z</time>
+				<extensions>
+					<speed>7.984671592712402</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013553693000167" lon="-84.2014060912992">
+				<ele>964.0863190395758</ele>
+				<time>2017-10-02T18:25:44Z</time>
+				<extensions>
+					<speed>8.149836540222168</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013604684235714" lon="-84.20145293874441">
+				<ele>963.8184590451419</ele>
+				<time>2017-10-02T18:25:45Z</time>
+				<extensions>
+					<speed>8.256168365478516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013663443866559" lon="-84.20150209573528">
+				<ele>963.7825908614323</ele>
+				<time>2017-10-02T18:25:46Z</time>
+				<extensions>
+					<speed>8.406551361083984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013720778101451" lon="-84.2015592362771">
+				<ele>963.6169390128925</ele>
+				<time>2017-10-02T18:25:47Z</time>
+				<extensions>
+					<speed>8.711535453796387</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013778860855782" lon="-84.2016172688148">
+				<ele>963.4653838044032</ele>
+				<time>2017-10-02T18:25:48Z</time>
+				<extensions>
+					<speed>9.06214427947998</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013840248433715" lon="-84.20167505610907">
+				<ele>963.526350621134</ele>
+				<time>2017-10-02T18:25:49Z</time>
+				<extensions>
+					<speed>9.105032920837402</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01389914927912" lon="-84.2017424987291">
+				<ele>963.4985732920468</ele>
+				<time>2017-10-02T18:25:50Z</time>
+				<extensions>
+					<speed>9.730541229248047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013960472850405" lon="-84.20181494730586">
+				<ele>963.4754718318582</ele>
+				<time>2017-10-02T18:25:51Z</time>
+				<extensions>
+					<speed>10.415319442749023</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014014342059598" lon="-84.20188866159685">
+				<ele>963.4670207798481</ele>
+				<time>2017-10-02T18:25:52Z</time>
+				<extensions>
+					<speed>10.166479110717773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014064635597048" lon="-84.2019549241471">
+				<ele>963.3453522557393</ele>
+				<time>2017-10-02T18:25:53Z</time>
+				<extensions>
+					<speed>9.57381820678711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014105497463193" lon="-84.2020247930621">
+				<ele>963.3280074633658</ele>
+				<time>2017-10-02T18:25:54Z</time>
+				<extensions>
+					<speed>9.0514497756958</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014138041990943" lon="-84.20209502885837">
+				<ele>963.3825568500906</ele>
+				<time>2017-10-02T18:25:55Z</time>
+				<extensions>
+					<speed>8.682543754577637</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014169717238419" lon="-84.20216170879837">
+				<ele>963.406959457323</ele>
+				<time>2017-10-02T18:25:56Z</time>
+				<extensions>
+					<speed>8.074700355529785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0141961963489" lon="-84.20222273354285">
+				<ele>963.480394215323</ele>
+				<time>2017-10-02T18:25:57Z</time>
+				<extensions>
+					<speed>6.827513694763184</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014216277650037" lon="-84.2022666484723">
+				<ele>963.3691677609459</ele>
+				<time>2017-10-02T18:25:58Z</time>
+				<extensions>
+					<speed>4.688637733459473</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229293359225" lon="-84.20229462650008">
+				<ele>963.4543421892449</ele>
+				<time>2017-10-02T18:25:59Z</time>
+				<extensions>
+					<speed>2.188425064086914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014233160952891" lon="-84.20230917535976">
+				<ele>963.4240584643558</ele>
+				<time>2017-10-02T18:26:00Z</time>
+				<extensions>
+					<speed>0.8017454147338867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014224873337831" lon="-84.20231001688724">
+				<ele>963.823330597952</ele>
+				<time>2017-10-02T18:26:01Z</time>
+				<extensions>
+					<speed>0.5386578440666199</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014196364332687" lon="-84.20229737612675">
+				<ele>958.6662378096953</ele>
+				<time>2017-10-02T18:26:02Z</time>
+				<extensions>
+					<speed>1.1468979120254517</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01417947558338" lon="-84.20228253797397">
+				<ele>955.6676371470094</ele>
+				<time>2017-10-02T18:26:03Z</time>
+				<extensions>
+					<speed>0.9211215972900391</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014163536768997" lon="-84.20226913111803">
+				<ele>951.8635240355507</ele>
+				<time>2017-10-02T18:26:04Z</time>
+				<extensions>
+					<speed>1.0225801467895508</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014165806023849" lon="-84.20225734023356">
+				<ele>951.1588817695156</ele>
+				<time>2017-10-02T18:26:05Z</time>
+				<extensions>
+					<speed>0.5993956327438354</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014165806023849" lon="-84.20225734023356">
+				<ele>951.1588817695156</ele>
+				<time>2017-10-02T18:26:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014166457079664" lon="-84.20225544372468">
+				<ele>950.6881702477112</ele>
+				<time>2017-10-02T18:26:07Z</time>
+				<extensions>
+					<speed>0.3697437644004822</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014166457079664" lon="-84.20225544372468">
+				<ele>950.6881702477112</ele>
+				<time>2017-10-02T18:26:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014166457079664" lon="-84.20225544372468">
+				<ele>950.6881702477112</ele>
+				<time>2017-10-02T18:26:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014166457079664" lon="-84.20225544372468">
+				<ele>950.6881702477112</ele>
+				<time>2017-10-02T18:26:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014166457079664" lon="-84.20225544372468">
+				<ele>950.6881702477112</ele>
+				<time>2017-10-02T18:26:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01417344104568" lon="-84.20226194684524">
+				<ele>950.4048275072128</ele>
+				<time>2017-10-02T18:26:12Z</time>
+				<extensions>
+					<speed>0.6807602643966675</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014166457079664" lon="-84.20225544372468">
+				<ele>950.6881702477112</ele>
+				<time>2017-10-02T18:26:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014166457079664" lon="-84.20225544372468">
+				<ele>950.6881702477112</ele>
+				<time>2017-10-02T18:26:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014170620074525" lon="-84.2022615706638">
+				<ele>950.0773491868749</ele>
+				<time>2017-10-02T18:26:15Z</time>
+				<extensions>
+					<speed>0.6042500138282776</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014177639742297" lon="-84.20227089061893">
+				<ele>949.6205840362236</ele>
+				<time>2017-10-02T18:26:16Z</time>
+				<extensions>
+					<speed>1.5942505598068237</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014188265423012" lon="-84.20228844854819">
+				<ele>949.4339570682496</ele>
+				<time>2017-10-02T18:26:17Z</time>
+				<extensions>
+					<speed>2.9147322177886963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014204569256101" lon="-84.20231907939376">
+				<ele>949.0979824280366</ele>
+				<time>2017-10-02T18:26:18Z</time>
+				<extensions>
+					<speed>4.215420722961426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014223874584331" lon="-84.20235390690898">
+				<ele>949.072834758088</ele>
+				<time>2017-10-02T18:26:19Z</time>
+				<extensions>
+					<speed>4.114435195922852</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014246837453616" lon="-84.20238941774844">
+				<ele>949.2086369544268</ele>
+				<time>2017-10-02T18:26:20Z</time>
+				<extensions>
+					<speed>4.4377288818359375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014274210969171" lon="-84.20241538763587">
+				<ele>948.8242311030626</ele>
+				<time>2017-10-02T18:26:21Z</time>
+				<extensions>
+					<speed>3.9704885482788086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014309003486948" lon="-84.20242513601927">
+				<ele>948.4735459377989</ele>
+				<time>2017-10-02T18:26:22Z</time>
+				<extensions>
+					<speed>4.267055988311768</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014349572047104" lon="-84.20242351945092">
+				<ele>947.5403724936768</ele>
+				<time>2017-10-02T18:26:23Z</time>
+				<extensions>
+					<speed>4.91620397567749</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014393973192789" lon="-84.20241030294956">
+				<ele>947.1664245072752</ele>
+				<time>2017-10-02T18:26:24Z</time>
+				<extensions>
+					<speed>5.3386640548706055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014443693583866" lon="-84.2023869836263">
+				<ele>946.5978929148987</ele>
+				<time>2017-10-02T18:26:25Z</time>
+				<extensions>
+					<speed>6.802708625793457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014499181776385" lon="-84.20235338537763">
+				<ele>946.5534397056326</ele>
+				<time>2017-10-02T18:26:26Z</time>
+				<extensions>
+					<speed>7.276879787445068</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014557172145409" lon="-84.20231559951607">
+				<ele>946.7098580989987</ele>
+				<time>2017-10-02T18:26:27Z</time>
+				<extensions>
+					<speed>7.6452436447143555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014618612394225" lon="-84.20227416949926">
+				<ele>947.0170585922897</ele>
+				<time>2017-10-02T18:26:28Z</time>
+				<extensions>
+					<speed>7.915725231170654</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014679849415478" lon="-84.20223415329092">
+				<ele>947.9941943474114</ele>
+				<time>2017-10-02T18:26:29Z</time>
+				<extensions>
+					<speed>7.910496711730957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014744827814482" lon="-84.20219484590115">
+				<ele>948.4980347305536</ele>
+				<time>2017-10-02T18:26:30Z</time>
+				<extensions>
+					<speed>8.401897430419922</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014812219787146" lon="-84.2021572660427">
+				<ele>949.3140136739239</ele>
+				<time>2017-10-02T18:26:31Z</time>
+				<extensions>
+					<speed>8.416044235229492</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014875971117537" lon="-84.2021185116846">
+				<ele>950.2165127508342</ele>
+				<time>2017-10-02T18:26:32Z</time>
+				<extensions>
+					<speed>8.052902221679688</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014938768528445" lon="-84.20207611914562">
+				<ele>950.3130579171702</ele>
+				<time>2017-10-02T18:26:33Z</time>
+				<extensions>
+					<speed>8.218714714050293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014999641504255" lon="-84.20203094939852">
+				<ele>950.204194681719</ele>
+				<time>2017-10-02T18:26:34Z</time>
+				<extensions>
+					<speed>8.152647972106934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015059545045922" lon="-84.20198710138408">
+				<ele>949.9430073220283</ele>
+				<time>2017-10-02T18:26:35Z</time>
+				<extensions>
+					<speed>8.176546096801758</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015120416189117" lon="-84.2019429691631">
+				<ele>949.9637232841924</ele>
+				<time>2017-10-02T18:26:36Z</time>
+				<extensions>
+					<speed>8.142498970031738</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01518147396916" lon="-84.2019026283805">
+				<ele>949.8869171803817</ele>
+				<time>2017-10-02T18:26:37Z</time>
+				<extensions>
+					<speed>8.044668197631836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015234822410369" lon="-84.2018640129442">
+				<ele>949.9914804650471</ele>
+				<time>2017-10-02T18:26:38Z</time>
+				<extensions>
+					<speed>7.509096145629883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015276697530373" lon="-84.20182884252752">
+				<ele>950.1167696807534</ele>
+				<time>2017-10-02T18:26:39Z</time>
+				<extensions>
+					<speed>6.2129669189453125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015305964824478" lon="-84.20179957420596">
+				<ele>950.2193951178342</ele>
+				<time>2017-10-02T18:26:40Z</time>
+				<extensions>
+					<speed>4.444240093231201</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015325509189484" lon="-84.20177957497405">
+				<ele>950.2561168922111</ele>
+				<time>2017-10-02T18:26:41Z</time>
+				<extensions>
+					<speed>3.138646125793457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015323222143298" lon="-84.20177036988946">
+				<ele>950.4884751234204</ele>
+				<time>2017-10-02T18:26:42Z</time>
+				<extensions>
+					<speed>1.4663397073745728</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015317276058585" lon="-84.20178004231288">
+				<ele>950.4195875087753</ele>
+				<time>2017-10-02T18:26:43Z</time>
+				<extensions>
+					<speed>0.6514171957969666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015307771433053" lon="-84.20179309130965">
+				<ele>950.4839250072837</ele>
+				<time>2017-10-02T18:26:44Z</time>
+				<extensions>
+					<speed>1.3399922847747803</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015290952302493" lon="-84.20181126247441">
+				<ele>950.8267000429332</ele>
+				<time>2017-10-02T18:26:45Z</time>
+				<extensions>
+					<speed>1.7013986110687256</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01526830811955" lon="-84.2018396726355">
+				<ele>950.961426217109</ele>
+				<time>2017-10-02T18:26:46Z</time>
+				<extensions>
+					<speed>2.2621490955352783</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015244326174457" lon="-84.20186970318109">
+				<ele>950.4009072072804</ele>
+				<time>2017-10-02T18:26:47Z</time>
+				<extensions>
+					<speed>2.2118194103240967</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238574203645" lon="-84.20189092323135">
+				<ele>950.2693727239966</ele>
+				<time>2017-10-02T18:26:48Z</time>
+				<extensions>
+					<speed>1.795109748840332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015240195788946" lon="-84.20190021298605">
+				<ele>950.3721056794748</ele>
+				<time>2017-10-02T18:26:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015250586197485" lon="-84.2019025240911">
+				<ele>950.4997275387868</ele>
+				<time>2017-10-02T18:26:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015250586197485" lon="-84.2019025240911">
+				<ele>950.4997275387868</ele>
+				<time>2017-10-02T18:26:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015250586197485" lon="-84.2019025240911">
+				<ele>950.4997275387868</ele>
+				<time>2017-10-02T18:26:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015250586197485" lon="-84.2019025240911">
+				<ele>950.4997275387868</ele>
+				<time>2017-10-02T18:26:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015250586197485" lon="-84.2019025240911">
+				<ele>950.4997275387868</ele>
+				<time>2017-10-02T18:26:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015250586197485" lon="-84.2019025240911">
+				<ele>950.4997275387868</ele>
+				<time>2017-10-02T18:26:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015250586197485" lon="-84.2019025240911">
+				<ele>950.4997275387868</ele>
+				<time>2017-10-02T18:26:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015250586197485" lon="-84.2019025240911">
+				<ele>950.4997275387868</ele>
+				<time>2017-10-02T18:26:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015250586197485" lon="-84.2019025240911">
+				<ele>950.4997275387868</ele>
+				<time>2017-10-02T18:26:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015250586197485" lon="-84.2019025240911">
+				<ele>950.4997275387868</ele>
+				<time>2017-10-02T18:26:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015250586197485" lon="-84.2019025240911">
+				<ele>950.4997275387868</ele>
+				<time>2017-10-02T18:27:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015257183089398" lon="-84.20189049369519">
+				<ele>950.6764823151752</ele>
+				<time>2017-10-02T18:27:01Z</time>
+				<extensions>
+					<speed>0.7895162105560303</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015268629184108" lon="-84.20187609687625">
+				<ele>950.748466912657</ele>
+				<time>2017-10-02T18:27:02Z</time>
+				<extensions>
+					<speed>1.4167670011520386</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015281516049345" lon="-84.2018622713453">
+				<ele>950.8637358918786</ele>
+				<time>2017-10-02T18:27:03Z</time>
+				<extensions>
+					<speed>1.6713855266571045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01529759578026" lon="-84.20183288827167">
+				<ele>950.8314445605502</ele>
+				<time>2017-10-02T18:27:04Z</time>
+				<extensions>
+					<speed>2.0673201084136963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015315893432374" lon="-84.20180866406886">
+				<ele>950.7295030495152</ele>
+				<time>2017-10-02T18:27:05Z</time>
+				<extensions>
+					<speed>2.1697962284088135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015333174303349" lon="-84.20179373368758">
+				<ele>950.2676549237221</ele>
+				<time>2017-10-02T18:27:06Z</time>
+				<extensions>
+					<speed>2.218517303466797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015351776866229" lon="-84.20177348663918">
+				<ele>949.315194606781</ele>
+				<time>2017-10-02T18:27:07Z</time>
+				<extensions>
+					<speed>2.272138833999634</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015367860135601" lon="-84.20175622033535">
+				<ele>948.0479834740981</ele>
+				<time>2017-10-02T18:27:08Z</time>
+				<extensions>
+					<speed>1.9343955516815186</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015386442090863" lon="-84.20174403074854">
+				<ele>947.3815971240401</ele>
+				<time>2017-10-02T18:27:09Z</time>
+				<extensions>
+					<speed>1.704882025718689</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015399072160523" lon="-84.20174288313058">
+				<ele>947.3170259566978</ele>
+				<time>2017-10-02T18:27:10Z</time>
+				<extensions>
+					<speed>1.2375783920288086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015404295154433" lon="-84.2017438411921">
+				<ele>947.2708840016276</ele>
+				<time>2017-10-02T18:27:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015403154979888" lon="-84.20174434692024">
+				<ele>947.5834806039929</ele>
+				<time>2017-10-02T18:27:12Z</time>
+				<extensions>
+					<speed>0.6130977869033813</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015397356938289" lon="-84.20174517437984">
+				<ele>947.9095785850659</ele>
+				<time>2017-10-02T18:27:13Z</time>
+				<extensions>
+					<speed>0.9078542590141296</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015390519613128" lon="-84.20175235879766">
+				<ele>947.8134531397372</ele>
+				<time>2017-10-02T18:27:14Z</time>
+				<extensions>
+					<speed>1.2734780311584473</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01537757937798" lon="-84.20175787062">
+				<ele>947.5708836372942</ele>
+				<time>2017-10-02T18:27:15Z</time>
+				<extensions>
+					<speed>1.6055127382278442</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015359870373503" lon="-84.20176507392439">
+				<ele>946.983961885795</ele>
+				<time>2017-10-02T18:27:16Z</time>
+				<extensions>
+					<speed>2.1443700790405273</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015347666972486" lon="-84.20176533667926">
+				<ele>946.54701753892</ele>
+				<time>2017-10-02T18:27:17Z</time>
+				<extensions>
+					<speed>2.0579657554626465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015335439165872" lon="-84.20175781355127">
+				<ele>946.182067594491</ele>
+				<time>2017-10-02T18:27:18Z</time>
+				<extensions>
+					<speed>1.9586116075515747</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015319977792961" lon="-84.20175248680401">
+				<ele>946.1628505615517</ele>
+				<time>2017-10-02T18:27:19Z</time>
+				<extensions>
+					<speed>1.7075964212417603</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015309751587871" lon="-84.20174895440405">
+				<ele>946.2759172143415</ele>
+				<time>2017-10-02T18:27:20Z</time>
+				<extensions>
+					<speed>1.2488019466400146</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015299214864648" lon="-84.20174737126905">
+				<ele>946.3926718290895</ele>
+				<time>2017-10-02T18:27:21Z</time>
+				<extensions>
+					<speed>1.0196243524551392</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015291473425899" lon="-84.20174876103884">
+				<ele>946.3298950176686</ele>
+				<time>2017-10-02T18:27:22Z</time>
+				<extensions>
+					<speed>0.9320672750473022</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015287916381526" lon="-84.20175281821008">
+				<ele>946.286524974741</ele>
+				<time>2017-10-02T18:27:23Z</time>
+				<extensions>
+					<speed>0.5372726917266846</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015290087531085" lon="-84.20175704654612">
+				<ele>946.4710513846949</ele>
+				<time>2017-10-02T18:27:24Z</time>
+				<extensions>
+					<speed>0.3214074373245239</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015290087531085" lon="-84.20175704654612">
+				<ele>946.4710513846949</ele>
+				<time>2017-10-02T18:27:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015290087531085" lon="-84.20175704654612">
+				<ele>946.4710513846949</ele>
+				<time>2017-10-02T18:27:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015303576360273" lon="-84.20177282179934">
+				<ele>946.760288962163</ele>
+				<time>2017-10-02T18:27:27Z</time>
+				<extensions>
+					<speed>0.8920403718948364</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015320398376138" lon="-84.20179275407247">
+				<ele>947.5588842341676</ele>
+				<time>2017-10-02T18:27:28Z</time>
+				<extensions>
+					<speed>1.4715780019760132</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01534248128722" lon="-84.20182025403163">
+				<ele>948.4400564720854</ele>
+				<time>2017-10-02T18:27:29Z</time>
+				<extensions>
+					<speed>2.3474881649017334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015357416922344" lon="-84.20184476597112">
+				<ele>948.945691135712</ele>
+				<time>2017-10-02T18:27:30Z</time>
+				<extensions>
+					<speed>2.9655659198760986</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0153639567906" lon="-84.20187549912659">
+				<ele>949.4406602177769</ele>
+				<time>2017-10-02T18:27:31Z</time>
+				<extensions>
+					<speed>3.3326656818389893</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015359286109698" lon="-84.20191379356768">
+				<ele>949.6945893531665</ele>
+				<time>2017-10-02T18:27:32Z</time>
+				<extensions>
+					<speed>4.035470008850098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015340848625561" lon="-84.20195939295056">
+				<ele>949.5989806083962</ele>
+				<time>2017-10-02T18:27:33Z</time>
+				<extensions>
+					<speed>5.204287528991699</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01530873977226" lon="-84.20200406615773">
+				<ele>949.7255359971896</ele>
+				<time>2017-10-02T18:27:34Z</time>
+				<extensions>
+					<speed>6.160919189453125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525083562846" lon="-84.20205253373351">
+				<ele>949.6395440362394</ele>
+				<time>2017-10-02T18:27:35Z</time>
+				<extensions>
+					<speed>8.101085662841797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01517979092348" lon="-84.20210036192918">
+				<ele>949.785182626918</ele>
+				<time>2017-10-02T18:27:36Z</time>
+				<extensions>
+					<speed>9.705645561218262</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015096800026738" lon="-84.20214898839424">
+				<ele>950.5299913724884</ele>
+				<time>2017-10-02T18:27:37Z</time>
+				<extensions>
+					<speed>10.443653106689453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015000451491813" lon="-84.20220047322273">
+				<ele>950.0348516646773</ele>
+				<time>2017-10-02T18:27:38Z</time>
+				<extensions>
+					<speed>10.882233619689941</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014905795146392" lon="-84.2022506176933">
+				<ele>949.5008825045079</ele>
+				<time>2017-10-02T18:27:39Z</time>
+				<extensions>
+					<speed>10.659972190856934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014818029858798" lon="-84.20230099788618">
+				<ele>950.4155734581873</ele>
+				<time>2017-10-02T18:27:40Z</time>
+				<extensions>
+					<speed>10.795633316040039</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014725821428236" lon="-84.20233272564745">
+				<ele>949.599302072078</ele>
+				<time>2017-10-02T18:27:41Z</time>
+				<extensions>
+					<speed>10.345725059509277</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01463878585334" lon="-84.20236959818914">
+				<ele>949.0345422914252</ele>
+				<time>2017-10-02T18:27:42Z</time>
+				<extensions>
+					<speed>10.093109130859375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014556201278982" lon="-84.20240562822626">
+				<ele>948.50599949155</ele>
+				<time>2017-10-02T18:27:43Z</time>
+				<extensions>
+					<speed>9.588937759399414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0144814533862" lon="-84.20244155051633">
+				<ele>948.2558836461976</ele>
+				<time>2017-10-02T18:27:44Z</time>
+				<extensions>
+					<speed>8.77462387084961</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014418486189284" lon="-84.2024719382578">
+				<ele>947.9404389020056</ele>
+				<time>2017-10-02T18:27:45Z</time>
+				<extensions>
+					<speed>7.315514087677002</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014367729451223" lon="-84.20249661700119">
+				<ele>947.3791333204135</ele>
+				<time>2017-10-02T18:27:46Z</time>
+				<extensions>
+					<speed>5.492661476135254</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014332853093043" lon="-84.20251524947052">
+				<ele>947.0223321663216</ele>
+				<time>2017-10-02T18:27:47Z</time>
+				<extensions>
+					<speed>3.63240909576416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313325080192" lon="-84.20252366129779">
+				<ele>946.7908555343747</ele>
+				<time>2017-10-02T18:27:48Z</time>
+				<extensions>
+					<speed>1.8984603881835938</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014303653752071" lon="-84.20253002105599">
+				<ele>947.1319637941197</ele>
+				<time>2017-10-02T18:27:49Z</time>
+				<extensions>
+					<speed>0.8180254697799683</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014302304944007" lon="-84.20253400640816">
+				<ele>947.6723985401914</ele>
+				<time>2017-10-02T18:27:50Z</time>
+				<extensions>
+					<speed>0.03827784210443497</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014302304944007" lon="-84.20253400640816">
+				<ele>947.6723985401914</ele>
+				<time>2017-10-02T18:27:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014297314973604" lon="-84.20252865537044">
+				<ele>945.9599318196997</ele>
+				<time>2017-10-02T18:27:52Z</time>
+				<extensions>
+					<speed>1.0018556118011475</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014283999158627" lon="-84.20252353895243">
+				<ele>944.9382516806945</ele>
+				<time>2017-10-02T18:27:53Z</time>
+				<extensions>
+					<speed>2.0440924167633057</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014261327852145" lon="-84.20251070479016">
+				<ele>944.6136638587341</ele>
+				<time>2017-10-02T18:27:54Z</time>
+				<extensions>
+					<speed>3.52040433883667</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014232248030908" lon="-84.20248869059247">
+				<ele>944.9259240115061</ele>
+				<time>2017-10-02T18:27:55Z</time>
+				<extensions>
+					<speed>3.928537607192993</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014198205133628" lon="-84.20245039758201">
+				<ele>945.479105219245</ele>
+				<time>2017-10-02T18:27:56Z</time>
+				<extensions>
+					<speed>4.919511318206787</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014164075311978" lon="-84.20240545462184">
+				<ele>946.1102022640407</ele>
+				<time>2017-10-02T18:27:57Z</time>
+				<extensions>
+					<speed>5.675992488861084</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01412278181089" lon="-84.20233759077097">
+				<ele>946.6665981048718</ele>
+				<time>2017-10-02T18:27:58Z</time>
+				<extensions>
+					<speed>7.246942043304443</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014080380549066" lon="-84.20225450715199">
+				<ele>947.3327429350466</ele>
+				<time>2017-10-02T18:27:59Z</time>
+				<extensions>
+					<speed>8.995237350463867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014036189354204" lon="-84.20216905114495">
+				<ele>948.0860135601833</ele>
+				<time>2017-10-02T18:28:00Z</time>
+				<extensions>
+					<speed>9.921260833740234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013991394878712" lon="-84.20208136552263">
+				<ele>948.8685510372743</ele>
+				<time>2017-10-02T18:28:01Z</time>
+				<extensions>
+					<speed>10.350424766540527</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013955251111604" lon="-84.20200651009735">
+				<ele>948.9184714229777</ele>
+				<time>2017-10-02T18:28:02Z</time>
+				<extensions>
+					<speed>9.685685157775879</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01391722746594" lon="-84.20193003988615">
+				<ele>948.9404714629054</ele>
+				<time>2017-10-02T18:28:03Z</time>
+				<extensions>
+					<speed>9.555123329162598</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01388306385207" lon="-84.20185981628177">
+				<ele>949.1749599045143</ele>
+				<time>2017-10-02T18:28:04Z</time>
+				<extensions>
+					<speed>9.056180000305176</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013846079184702" lon="-84.20181238774195">
+				<ele>948.703596169129</ele>
+				<time>2017-10-02T18:28:05Z</time>
+				<extensions>
+					<speed>7.340941905975342</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013809714334403" lon="-84.2017523652094">
+				<ele>948.9819580689073</ele>
+				<time>2017-10-02T18:28:06Z</time>
+				<extensions>
+					<speed>7.179646015167236</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013773489060965" lon="-84.20169453569446">
+				<ele>949.0681108692661</ele>
+				<time>2017-10-02T18:28:07Z</time>
+				<extensions>
+					<speed>7.016583442687988</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013731632312046" lon="-84.2016420152913">
+				<ele>948.7200009031221</ele>
+				<time>2017-10-02T18:28:08Z</time>
+				<extensions>
+					<speed>6.909464359283447</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013687423967827" lon="-84.20159857919091">
+				<ele>948.5195626234636</ele>
+				<time>2017-10-02T18:28:09Z</time>
+				<extensions>
+					<speed>7.0306901931762695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013645481190585" lon="-84.20155726271004">
+				<ele>948.247272323817</ele>
+				<time>2017-10-02T18:28:10Z</time>
+				<extensions>
+					<speed>6.767163276672363</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013604244661224" lon="-84.20151754688074">
+				<ele>948.0369033468887</ele>
+				<time>2017-10-02T18:28:11Z</time>
+				<extensions>
+					<speed>6.691470623016357</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013561359776697" lon="-84.2014748413597">
+				<ele>948.2927871448919</ele>
+				<time>2017-10-02T18:28:12Z</time>
+				<extensions>
+					<speed>6.715793132781982</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013518812670757" lon="-84.20143314447218">
+				<ele>948.2151005724445</ele>
+				<time>2017-10-02T18:28:13Z</time>
+				<extensions>
+					<speed>6.769695281982422</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013477335278216" lon="-84.20139282631453">
+				<ele>948.0574000757188</ele>
+				<time>2017-10-02T18:28:14Z</time>
+				<extensions>
+					<speed>6.65779972076416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0134370122267" lon="-84.20135224445768">
+				<ele>947.4743844838813</ele>
+				<time>2017-10-02T18:28:15Z</time>
+				<extensions>
+					<speed>6.526902675628662</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013395674139774" lon="-84.2013167107983">
+				<ele>947.3779868669808</ele>
+				<time>2017-10-02T18:28:16Z</time>
+				<extensions>
+					<speed>6.320954322814941</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013359411730512" lon="-84.20128880236793">
+				<ele>947.8675610171631</ele>
+				<time>2017-10-02T18:28:17Z</time>
+				<extensions>
+					<speed>5.983953475952148</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013324516328348" lon="-84.20124894696693">
+				<ele>948.0310277948156</ele>
+				<time>2017-10-02T18:28:18Z</time>
+				<extensions>
+					<speed>6.042353630065918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013291168972787" lon="-84.20120400344904">
+				<ele>948.311513312161</ele>
+				<time>2017-10-02T18:28:19Z</time>
+				<extensions>
+					<speed>6.199649810791016</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013256211806638" lon="-84.2011493858437">
+				<ele>949.470521369949</ele>
+				<time>2017-10-02T18:28:20Z</time>
+				<extensions>
+					<speed>6.4898481369018555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013226239572784" lon="-84.20109671479018">
+				<ele>949.7955816909671</ele>
+				<time>2017-10-02T18:28:21Z</time>
+				<extensions>
+					<speed>6.506555557250977</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013194897886294" lon="-84.20104778466496">
+				<ele>950.0017637228593</ele>
+				<time>2017-10-02T18:28:22Z</time>
+				<extensions>
+					<speed>6.431530952453613</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013162675914757" lon="-84.20099633656366">
+				<ele>950.6474515795708</ele>
+				<time>2017-10-02T18:28:23Z</time>
+				<extensions>
+					<speed>6.231694221496582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013135350148582" lon="-84.20095398130466">
+				<ele>951.3860260471702</ele>
+				<time>2017-10-02T18:28:24Z</time>
+				<extensions>
+					<speed>5.687535762786865</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013114616084492" lon="-84.20091993712839">
+				<ele>952.0474777398631</ele>
+				<time>2017-10-02T18:28:25Z</time>
+				<extensions>
+					<speed>4.740947723388672</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0130976125825" lon="-84.20087862602284">
+				<ele>952.4854637784883</ele>
+				<time>2017-10-02T18:28:26Z</time>
+				<extensions>
+					<speed>4.119807243347168</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013084477042254" lon="-84.2008445197377">
+				<ele>952.6186231086031</ele>
+				<time>2017-10-02T18:28:27Z</time>
+				<extensions>
+					<speed>3.5127511024475098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013073799905225" lon="-84.20081976110022">
+				<ele>952.9027837496251</ele>
+				<time>2017-10-02T18:28:28Z</time>
+				<extensions>
+					<speed>2.946861982345581</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013071380467007" lon="-84.2008125668093">
+				<ele>952.8487892718986</ele>
+				<time>2017-10-02T18:28:29Z</time>
+				<extensions>
+					<speed>1.7107841968536377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013073147097428" lon="-84.20081077532363">
+				<ele>952.6615536687896</ele>
+				<time>2017-10-02T18:28:30Z</time>
+				<extensions>
+					<speed>0.9359106421470642</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01307708172049" lon="-84.2008117342449">
+				<ele>952.5478910859674</ele>
+				<time>2017-10-02T18:28:31Z</time>
+				<extensions>
+					<speed>0.6003193855285645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013077696357929" lon="-84.20080820120653">
+				<ele>952.4222001181915</ele>
+				<time>2017-10-02T18:28:32Z</time>
+				<extensions>
+					<speed>0.7394844889640808</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013073583360107" lon="-84.20080173063343">
+				<ele>952.3057709177956</ele>
+				<time>2017-10-02T18:28:33Z</time>
+				<extensions>
+					<speed>0.7482362985610962</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013068841146067" lon="-84.20079240262675">
+				<ele>952.187834398821</ele>
+				<time>2017-10-02T18:28:34Z</time>
+				<extensions>
+					<speed>0.785695493221283</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013065455507325" lon="-84.20078702061332">
+				<ele>952.507517516613</ele>
+				<time>2017-10-02T18:28:35Z</time>
+				<extensions>
+					<speed>0.7122263312339783</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01305808082826" lon="-84.2007808499069">
+				<ele>953.1270710602403</ele>
+				<time>2017-10-02T18:28:36Z</time>
+				<extensions>
+					<speed>1.0341811180114746</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013047859002334" lon="-84.20076368594235">
+				<ele>953.3677878929302</ele>
+				<time>2017-10-02T18:28:37Z</time>
+				<extensions>
+					<speed>1.6347103118896484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013032868915968" lon="-84.20074754331844">
+				<ele>953.6486681867391</ele>
+				<time>2017-10-02T18:28:38Z</time>
+				<extensions>
+					<speed>1.9835435152053833</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013014270231205" lon="-84.20073065906539">
+				<ele>954.376014309004</ele>
+				<time>2017-10-02T18:28:39Z</time>
+				<extensions>
+					<speed>1.9227677583694458</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012995360199117" lon="-84.2007137015024">
+				<ele>954.3942388854921</ele>
+				<time>2017-10-02T18:28:40Z</time>
+				<extensions>
+					<speed>1.982946753501892</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012985684073188" lon="-84.20068803914089">
+				<ele>953.8542057937011</ele>
+				<time>2017-10-02T18:28:41Z</time>
+				<extensions>
+					<speed>2.2329299449920654</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012988196975641" lon="-84.20065632392138">
+				<ele>953.8652743604034</ele>
+				<time>2017-10-02T18:28:42Z</time>
+				<extensions>
+					<speed>3.0077526569366455</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01299908989229" lon="-84.20061751961528">
+				<ele>953.8067593276501</ele>
+				<time>2017-10-02T18:28:43Z</time>
+				<extensions>
+					<speed>3.894221544265747</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013025179303174" lon="-84.20057875982444">
+				<ele>953.6636498169973</ele>
+				<time>2017-10-02T18:28:44Z</time>
+				<extensions>
+					<speed>4.840137481689453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01306032802361" lon="-84.20052680487447">
+				<ele>952.1882140692323</ele>
+				<time>2017-10-02T18:28:45Z</time>
+				<extensions>
+					<speed>5.6903839111328125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013108446322148" lon="-84.20048670235575">
+				<ele>951.7776277288795</ele>
+				<time>2017-10-02T18:28:46Z</time>
+				<extensions>
+					<speed>6.287796497344971</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013163707284749" lon="-84.20045607930923">
+				<ele>951.4236427284777</ele>
+				<time>2017-10-02T18:28:47Z</time>
+				<extensions>
+					<speed>6.821608543395996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013218333361683" lon="-84.200416442004">
+				<ele>951.0569762289524</ele>
+				<time>2017-10-02T18:28:48Z</time>
+				<extensions>
+					<speed>6.9142279624938965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013274284918118" lon="-84.20037356659475">
+				<ele>951.0291222883388</ele>
+				<time>2017-10-02T18:28:49Z</time>
+				<extensions>
+					<speed>7.1180620193481445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013326162827065" lon="-84.20033434058834">
+				<ele>951.5424616597593</ele>
+				<time>2017-10-02T18:28:50Z</time>
+				<extensions>
+					<speed>6.864413738250732</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013371018958617" lon="-84.2002942185987">
+				<ele>952.2965840063989</ele>
+				<time>2017-10-02T18:28:51Z</time>
+				<extensions>
+					<speed>6.4552202224731445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013417876026715" lon="-84.20026232517449">
+				<ele>952.8232098594308</ele>
+				<time>2017-10-02T18:28:52Z</time>
+				<extensions>
+					<speed>6.182636260986328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013465610661449" lon="-84.20023294467306">
+				<ele>953.1474463166669</ele>
+				<time>2017-10-02T18:28:53Z</time>
+				<extensions>
+					<speed>6.210984706878662</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01351294902039" lon="-84.2002043461347">
+				<ele>953.2372519215569</ele>
+				<time>2017-10-02T18:28:54Z</time>
+				<extensions>
+					<speed>6.054152965545654</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013565486377958" lon="-84.20017921007351">
+				<ele>953.4655761988834</ele>
+				<time>2017-10-02T18:28:55Z</time>
+				<extensions>
+					<speed>6.132566928863525</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013612082341563" lon="-84.20014602479161">
+				<ele>954.277691129595</ele>
+				<time>2017-10-02T18:28:56Z</time>
+				<extensions>
+					<speed>6.125531196594238</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013668996684258" lon="-84.2001081550724">
+				<ele>954.0330470921472</ele>
+				<time>2017-10-02T18:28:57Z</time>
+				<extensions>
+					<speed>6.555563449859619</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013727357093224" lon="-84.20007375825105">
+				<ele>954.7341256588697</ele>
+				<time>2017-10-02T18:28:58Z</time>
+				<extensions>
+					<speed>7.038050651550293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01378623780498" lon="-84.20002798518327">
+				<ele>954.8443238586187</ele>
+				<time>2017-10-02T18:28:59Z</time>
+				<extensions>
+					<speed>7.7911248207092285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013849899474705" lon="-84.19998559851591">
+				<ele>955.470448593609</ele>
+				<time>2017-10-02T18:29:00Z</time>
+				<extensions>
+					<speed>8.149014472961426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01390148736217" lon="-84.19994179844919">
+				<ele>955.7355307098478</ele>
+				<time>2017-10-02T18:29:01Z</time>
+				<extensions>
+					<speed>8.141444206237793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013949959733337" lon="-84.19988890482125">
+				<ele>955.5894453292713</ele>
+				<time>2017-10-02T18:29:02Z</time>
+				<extensions>
+					<speed>8.144991874694824</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013997284130754" lon="-84.19983159493418">
+				<ele>955.4582997830585</ele>
+				<time>2017-10-02T18:29:03Z</time>
+				<extensions>
+					<speed>8.307028770446777</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014046593718604" lon="-84.19977374815832">
+				<ele>955.5437608184293</ele>
+				<time>2017-10-02T18:29:04Z</time>
+				<extensions>
+					<speed>8.151145935058594</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014097083864206" lon="-84.19972171368116">
+				<ele>955.8529143705964</ele>
+				<time>2017-10-02T18:29:05Z</time>
+				<extensions>
+					<speed>8.036402702331543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014145876819033" lon="-84.19967257724838">
+				<ele>955.4490610389039</ele>
+				<time>2017-10-02T18:29:06Z</time>
+				<extensions>
+					<speed>7.865042686462402</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01419491064392" lon="-84.19962098750587">
+				<ele>955.2668920066208</ele>
+				<time>2017-10-02T18:29:07Z</time>
+				<extensions>
+					<speed>7.7951154708862305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014242879596276" lon="-84.19956735436175">
+				<ele>955.4589540334418</ele>
+				<time>2017-10-02T18:29:08Z</time>
+				<extensions>
+					<speed>7.500718116760254</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014293502761909" lon="-84.19951531936321">
+				<ele>955.7356853932142</ele>
+				<time>2017-10-02T18:29:09Z</time>
+				<extensions>
+					<speed>7.690726280212402</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014347778037914" lon="-84.1994694833663">
+				<ele>955.6914366427809</ele>
+				<time>2017-10-02T18:29:10Z</time>
+				<extensions>
+					<speed>7.793118953704834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014408073605741" lon="-84.19942977123111">
+				<ele>956.3240119451657</ele>
+				<time>2017-10-02T18:29:11Z</time>
+				<extensions>
+					<speed>7.892550468444824</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014470612572765" lon="-84.19939252259965">
+				<ele>957.1315465345979</ele>
+				<time>2017-10-02T18:29:12Z</time>
+				<extensions>
+					<speed>7.895289421081543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014529968412182" lon="-84.19935358641166">
+				<ele>957.8645042590797</ele>
+				<time>2017-10-02T18:29:13Z</time>
+				<extensions>
+					<speed>7.733819007873535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014584528568989" lon="-84.199309516401">
+				<ele>958.1614206954837</ele>
+				<time>2017-10-02T18:29:14Z</time>
+				<extensions>
+					<speed>7.619121551513672</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014636469383111" lon="-84.19926983070452">
+				<ele>958.4924750225618</ele>
+				<time>2017-10-02T18:29:15Z</time>
+				<extensions>
+					<speed>7.383471965789795</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014687170656089" lon="-84.19923545660113">
+				<ele>958.4539420614019</ele>
+				<time>2017-10-02T18:29:16Z</time>
+				<extensions>
+					<speed>7.0047736167907715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014739682860549" lon="-84.1992004700342">
+				<ele>958.020649514161</ele>
+				<time>2017-10-02T18:29:17Z</time>
+				<extensions>
+					<speed>6.890700817108154</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014794292587696" lon="-84.19916153206356">
+				<ele>958.5254391478375</ele>
+				<time>2017-10-02T18:29:18Z</time>
+				<extensions>
+					<speed>7.232163906097412</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014846924470882" lon="-84.19911673121669">
+				<ele>958.4249587357044</ele>
+				<time>2017-10-02T18:29:19Z</time>
+				<extensions>
+					<speed>7.311680316925049</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014899067349981" lon="-84.19907108667789">
+				<ele>958.5099159954116</ele>
+				<time>2017-10-02T18:29:20Z</time>
+				<extensions>
+					<speed>7.200293064117432</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014951079047593" lon="-84.1990275659817">
+				<ele>959.322345437482</ele>
+				<time>2017-10-02T18:29:21Z</time>
+				<extensions>
+					<speed>7.3384108543396</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0150005419877" lon="-84.1989846055471">
+				<ele>960.0743731185794</ele>
+				<time>2017-10-02T18:29:22Z</time>
+				<extensions>
+					<speed>6.971733093261719</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015046261359783" lon="-84.19894204012787">
+				<ele>960.8029767218977</ele>
+				<time>2017-10-02T18:29:23Z</time>
+				<extensions>
+					<speed>7.003259181976318</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015092103166191" lon="-84.19889885576923">
+				<ele>961.3062351755798</ele>
+				<time>2017-10-02T18:29:24Z</time>
+				<extensions>
+					<speed>6.818586826324463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01513642786234" lon="-84.19885661210071">
+				<ele>962.2266876110807</ele>
+				<time>2017-10-02T18:29:25Z</time>
+				<extensions>
+					<speed>6.805481910705566</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015184398456155" lon="-84.19881148659361">
+				<ele>963.6838812949136</ele>
+				<time>2017-10-02T18:29:26Z</time>
+				<extensions>
+					<speed>7.246542453765869</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015236417313814" lon="-84.19876585318315">
+				<ele>965.334006935358</ele>
+				<time>2017-10-02T18:29:27Z</time>
+				<extensions>
+					<speed>7.640201568603516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01528746626985" lon="-84.19871699160187">
+				<ele>965.7615385865793</ele>
+				<time>2017-10-02T18:29:28Z</time>
+				<extensions>
+					<speed>7.710564136505127</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015337923938622" lon="-84.1986666679452">
+				<ele>966.2070776242763</ele>
+				<time>2017-10-02T18:29:29Z</time>
+				<extensions>
+					<speed>7.617281913757324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015385790816186" lon="-84.19861439813197">
+				<ele>966.3480016048998</ele>
+				<time>2017-10-02T18:29:30Z</time>
+				<extensions>
+					<speed>7.899824619293213</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015426490577163" lon="-84.19855418843548">
+				<ele>966.5095168594271</ele>
+				<time>2017-10-02T18:29:31Z</time>
+				<extensions>
+					<speed>8.109044075012207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015461697678846" lon="-84.1984892834788">
+				<ele>966.7449649274349</ele>
+				<time>2017-10-02T18:29:32Z</time>
+				<extensions>
+					<speed>8.32308292388916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0154923013795" lon="-84.19841987425761">
+				<ele>966.76636334043</ele>
+				<time>2017-10-02T18:29:33Z</time>
+				<extensions>
+					<speed>8.490592956542969</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015522354117845" lon="-84.19834680712799">
+				<ele>966.9267792878672</ele>
+				<time>2017-10-02T18:29:34Z</time>
+				<extensions>
+					<speed>8.708874702453613</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015546485315346" lon="-84.19827517368289">
+				<ele>966.9427829096094</ele>
+				<time>2017-10-02T18:29:35Z</time>
+				<extensions>
+					<speed>8.571892738342285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015565746283894" lon="-84.19819989348194">
+				<ele>967.6314606936648</ele>
+				<time>2017-10-02T18:29:36Z</time>
+				<extensions>
+					<speed>9.112530708312988</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015589989304434" lon="-84.19812383270458">
+				<ele>968.7974842488766</ele>
+				<time>2017-10-02T18:29:37Z</time>
+				<extensions>
+					<speed>9.230813980102539</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015614569171404" lon="-84.19803950707937">
+				<ele>969.1485907174647</ele>
+				<time>2017-10-02T18:29:38Z</time>
+				<extensions>
+					<speed>9.58685302734375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015645142119277" lon="-84.19796133969348">
+				<ele>969.9142615841702</ele>
+				<time>2017-10-02T18:29:39Z</time>
+				<extensions>
+					<speed>9.419987678527832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01568106888695" lon="-84.19788262545377">
+				<ele>970.5964230690151</ele>
+				<time>2017-10-02T18:29:40Z</time>
+				<extensions>
+					<speed>9.864066123962402</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015719965984154" lon="-84.19780564209262">
+				<ele>971.310320504941</ele>
+				<time>2017-10-02T18:29:41Z</time>
+				<extensions>
+					<speed>9.582653999328613</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01575993200749" lon="-84.19772921487599">
+				<ele>971.4025265201926</ele>
+				<time>2017-10-02T18:29:42Z</time>
+				<extensions>
+					<speed>9.566797256469727</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015799554996756" lon="-84.19765174205338">
+				<ele>971.8540089018643</ele>
+				<time>2017-10-02T18:29:43Z</time>
+				<extensions>
+					<speed>9.574718475341797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015838307844799" lon="-84.19757537356233">
+				<ele>972.0353500628844</ele>
+				<time>2017-10-02T18:29:44Z</time>
+				<extensions>
+					<speed>9.436965942382813</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01587727756088" lon="-84.19750261198848">
+				<ele>972.1798218339682</ele>
+				<time>2017-10-02T18:29:45Z</time>
+				<extensions>
+					<speed>9.164689064025879</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01591572010628" lon="-84.19743092943953">
+				<ele>972.6034180754796</ele>
+				<time>2017-10-02T18:29:46Z</time>
+				<extensions>
+					<speed>8.953256607055664</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015951566763333" lon="-84.19735519942095">
+				<ele>973.121671449393</ele>
+				<time>2017-10-02T18:29:47Z</time>
+				<extensions>
+					<speed>9.303266525268555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015990437516994" lon="-84.1972816878845">
+				<ele>973.5643439032137</ele>
+				<time>2017-10-02T18:29:48Z</time>
+				<extensions>
+					<speed>9.268524169921875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016031990853792" lon="-84.19721290261974">
+				<ele>974.0642422959208</ele>
+				<time>2017-10-02T18:29:49Z</time>
+				<extensions>
+					<speed>9.01978588104248</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016070933742734" lon="-84.19714649401486">
+				<ele>974.2833199147135</ele>
+				<time>2017-10-02T18:29:50Z</time>
+				<extensions>
+					<speed>8.528373718261719</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016112321344218" lon="-84.19708120550098">
+				<ele>974.617306124419</ele>
+				<time>2017-10-02T18:29:51Z</time>
+				<extensions>
+					<speed>8.779115676879883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01615896160429" lon="-84.19701810420179">
+				<ele>974.8039585836232</ele>
+				<time>2017-10-02T18:29:52Z</time>
+				<extensions>
+					<speed>8.771402359008789</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016207176559512" lon="-84.1969504020933">
+				<ele>975.0553215779364</ele>
+				<time>2017-10-02T18:29:53Z</time>
+				<extensions>
+					<speed>8.909042358398438</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01625918339054" lon="-84.19688749445989">
+				<ele>975.4966509882361</ele>
+				<time>2017-10-02T18:29:54Z</time>
+				<extensions>
+					<speed>8.836604118347168</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016309808775874" lon="-84.19682277121856">
+				<ele>975.8163187876344</ele>
+				<time>2017-10-02T18:29:55Z</time>
+				<extensions>
+					<speed>9.0033597946167</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016360624093936" lon="-84.19676252366293">
+				<ele>976.6878544138744</ele>
+				<time>2017-10-02T18:29:56Z</time>
+				<extensions>
+					<speed>8.889642715454102</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016415935039255" lon="-84.1967014972644">
+				<ele>976.899213373661</ele>
+				<time>2017-10-02T18:29:57Z</time>
+				<extensions>
+					<speed>8.524843215942383</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016467697255145" lon="-84.19664010602462">
+				<ele>977.1760267224163</ele>
+				<time>2017-10-02T18:29:58Z</time>
+				<extensions>
+					<speed>8.541646003723145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01652003796856" lon="-84.19657611967446">
+				<ele>977.6510981917381</ele>
+				<time>2017-10-02T18:29:59Z</time>
+				<extensions>
+					<speed>8.746908187866211</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016574466741849" lon="-84.1965134888805">
+				<ele>978.1114818183705</ele>
+				<time>2017-10-02T18:30:00Z</time>
+				<extensions>
+					<speed>8.397120475769043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016623811188609" lon="-84.19645637238614">
+				<ele>977.579395798035</ele>
+				<time>2017-10-02T18:30:01Z</time>
+				<extensions>
+					<speed>7.931497097015381</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01667072709939" lon="-84.19640385664427">
+				<ele>977.4533193316311</ele>
+				<time>2017-10-02T18:30:02Z</time>
+				<extensions>
+					<speed>6.957464218139648</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016713748292094" lon="-84.1963653989698">
+				<ele>977.7525369953364</ele>
+				<time>2017-10-02T18:30:03Z</time>
+				<extensions>
+					<speed>5.413171291351318</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016748305564752" lon="-84.19633786625378">
+				<ele>977.7342751808465</ele>
+				<time>2017-10-02T18:30:04Z</time>
+				<extensions>
+					<speed>3.9346442222595215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016773570356968" lon="-84.19631685217949">
+				<ele>977.7779221860692</ele>
+				<time>2017-10-02T18:30:05Z</time>
+				<extensions>
+					<speed>2.202219009399414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016783469461819" lon="-84.19630583986172">
+				<ele>977.898336741142</ele>
+				<time>2017-10-02T18:30:06Z</time>
+				<extensions>
+					<speed>0.7041206359863281</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016787166094687" lon="-84.19630247738144">
+				<ele>978.5697254696861</ele>
+				<time>2017-10-02T18:30:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016787166094687" lon="-84.19630247738144">
+				<ele>978.5697254696861</ele>
+				<time>2017-10-02T18:30:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016794134941437" lon="-84.19629372368765">
+				<ele>978.950687774457</ele>
+				<time>2017-10-02T18:30:09Z</time>
+				<extensions>
+					<speed>1.3009772300720215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01680787646287" lon="-84.19628403332486">
+				<ele>979.378378151916</ele>
+				<time>2017-10-02T18:30:10Z</time>
+				<extensions>
+					<speed>1.904891848564148</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016827517346513" lon="-84.19626627998032">
+				<ele>979.2415228039026</ele>
+				<time>2017-10-02T18:30:11Z</time>
+				<extensions>
+					<speed>3.142803907394409</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016858555661104" lon="-84.19624167778218">
+				<ele>979.0640011942014</ele>
+				<time>2017-10-02T18:30:12Z</time>
+				<extensions>
+					<speed>4.867116451263428</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016901793511893" lon="-84.1962067219985">
+				<ele>978.53568596486</ele>
+				<time>2017-10-02T18:30:13Z</time>
+				<extensions>
+					<speed>6.620262145996094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016954201630604" lon="-84.19616542687359">
+				<ele>978.4357570065185</ele>
+				<time>2017-10-02T18:30:14Z</time>
+				<extensions>
+					<speed>7.500146865844727</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017016087912962" lon="-84.19611592965323">
+				<ele>978.0467035155743</ele>
+				<time>2017-10-02T18:30:15Z</time>
+				<extensions>
+					<speed>8.245905876159668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017080340908551" lon="-84.19606697184237">
+				<ele>978.1557553997263</ele>
+				<time>2017-10-02T18:30:16Z</time>
+				<extensions>
+					<speed>8.397879600524902</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017135668543753" lon="-84.1960149197972">
+				<ele>976.5234905965626</ele>
+				<time>2017-10-02T18:30:17Z</time>
+				<extensions>
+					<speed>7.301356792449951</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017182553280133" lon="-84.19597400429254">
+				<ele>975.3015212323517</ele>
+				<time>2017-10-02T18:30:18Z</time>
+				<extensions>
+					<speed>5.799450397491455</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017220118238251" lon="-84.19594278360714">
+				<ele>975.1924519408494</ele>
+				<time>2017-10-02T18:30:19Z</time>
+				<extensions>
+					<speed>4.585626125335693</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017249006969266" lon="-84.19592109079713">
+				<ele>975.6720148604363</ele>
+				<time>2017-10-02T18:30:20Z</time>
+				<extensions>
+					<speed>2.8936004638671875</speed>
+				</extensions>
+			</trkpt>
+		</trkseg>
+	</trk>
+</gpx>

--- a/bus_alajuela-targuases/asistentes/fran_2017_10_30.gpx
+++ b/bus_alajuela-targuases/asistentes/fran_2017_10_30.gpx
@@ -1,0 +1,12537 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="OSMTracker for Android™ - https://github.com/nguillaumin/osmtracker-android" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd ">
+	<wpt lat="10.015332314818952" lon="-84.2133703058057">
+		<ele>955.6284881569445</ele>
+		<time>2017-10-30T17:30:32Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015332314818952" lon="-84.2133703058057">
+		<ele>955.6284881569445</ele>
+		<time>2017-10-30T17:30:34Z</time>
+		<name><![CDATA[3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015792715768361" lon="-84.21173951095322">
+		<ele>958.9506626408547</ele>
+		<time>2017-10-30T17:32:03Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015803063247887" lon="-84.21171484545653">
+		<ele>959.8929372373968</ele>
+		<time>2017-10-30T17:32:04Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.00862838994758" lon="-84.21071190996557">
+		<ele>940.0386124467477</ele>
+		<time>2017-10-30T17:40:17Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.00862952176989" lon="-84.21068470514987">
+		<ele>940.1800776124</ele>
+		<time>2017-10-30T17:40:19Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.00859397740753" lon="-84.21007611741707">
+		<ele>941.3666419712827</ele>
+		<time>2017-10-30T17:40:41Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008601217698445" lon="-84.21006465425411">
+		<ele>941.2093558236957</ele>
+		<time>2017-10-30T17:40:42Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.006139902802186" lon="-84.20419629151496">
+		<ele>939.6627855161205</ele>
+		<time>2017-10-30T17:44:47Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.006149494976471" lon="-84.20417663759432">
+		<ele>939.740431833081</ele>
+		<time>2017-10-30T17:44:48Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.007295215211824" lon="-84.20463160150786">
+		<ele>943.0640810066834</ele>
+		<time>2017-10-30T17:45:47Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.007330879041106" lon="-84.20459508006863">
+		<ele>943.0090745454654</ele>
+		<time>2017-10-30T17:45:48Z</time>
+		<name><![CDATA[3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008895829084603" lon="-84.20324206984262">
+		<ele>951.4680854128674</ele>
+		<time>2017-10-30T17:46:50Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008926666311819" lon="-84.20321639103528">
+		<ele>951.4318770850077</ele>
+		<time>2017-10-30T17:46:51Z</time>
+		<name><![CDATA[3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.01021342011525" lon="-84.2021319753577">
+		<ele>952.8665957525373</ele>
+		<time>2017-10-30T17:47:30Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.010212673602453" lon="-84.20213932391303">
+		<ele>953.1826245328411</ele>
+		<time>2017-10-30T17:47:31Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.011446031373177" lon="-84.20145019634364">
+		<ele>958.6120996326208</ele>
+		<time>2017-10-30T17:48:18Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.011471533379751" lon="-84.20143569114803">
+		<ele>958.5840690433979</ele>
+		<time>2017-10-30T17:48:19Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015274383545329" lon="-84.20193373140003">
+		<ele>949.5347539931536</ele>
+		<time>2017-10-30T17:50:23Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.01527623067863" lon="-84.20192248874324">
+		<ele>949.5007237205282</ele>
+		<time>2017-10-30T17:50:24Z</time>
+		<name><![CDATA[3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.014545752257677" lon="-84.19944239331299">
+		<ele>969.6714297840372</ele>
+		<time>2017-10-30T17:53:09Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.01453626190725" lon="-84.19945097944692">
+		<ele>970.2543016579002</ele>
+		<time>2017-10-30T17:53:11Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<trk>
+		<name><![CDATA[Trazado con OSMTracker para Android™]]></name>
+		<trkseg>
+			<trkpt lat="10.01401930567438" lon="-84.2169467893315">
+				<ele>963.353549647145</ele>
+				<time>2017-10-30T17:24:50Z</time>
+				<extensions>
+					<speed>1.0217360258102417</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01394545422561" lon="-84.21687941480205">
+				<ele>978.1504077101126</ele>
+				<time>2017-10-30T17:24:51Z</time>
+				<extensions>
+					<speed>0.45092785358428955</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014325069153907" lon="-84.21718197152332">
+				<ele>943.6959906537086</ele>
+				<time>2017-10-30T17:24:56Z</time>
+				<extensions>
+					<speed>0.28170764446258545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014458069051264" lon="-84.21752549221043">
+				<ele>987.7245147274807</ele>
+				<time>2017-10-30T17:24:57Z</time>
+				<extensions>
+					<speed>1.0799866914749146</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014444334536213" lon="-84.21708360163909">
+				<ele>984.9165338054299</ele>
+				<time>2017-10-30T17:24:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:24:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:25:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430898452083" lon="-84.21696382242278">
+				<ele>980.1455770879984</ele>
+				<time>2017-10-30T17:26:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01431190345393" lon="-84.21695557435507">
+				<ele>980.0252061747015</ele>
+				<time>2017-10-30T17:26:59Z</time>
+				<extensions>
+					<speed>1.0027003288269043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01431714773541" lon="-84.21694753252207">
+				<ele>979.9121139813215</ele>
+				<time>2017-10-30T17:27:00Z</time>
+				<extensions>
+					<speed>0.9733437895774841</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014324766354802" lon="-84.21693820401966">
+				<ele>979.6870641391724</ele>
+				<time>2017-10-30T17:27:01Z</time>
+				<extensions>
+					<speed>1.2024683952331543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014334400502534" lon="-84.21692780298073">
+				<ele>979.4048385284841</ele>
+				<time>2017-10-30T17:27:02Z</time>
+				<extensions>
+					<speed>1.221323013305664</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014344021622424" lon="-84.21691820659049">
+				<ele>979.2632192634046</ele>
+				<time>2017-10-30T17:27:03Z</time>
+				<extensions>
+					<speed>1.3323664665222168</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014354577012977" lon="-84.21690811849055">
+				<ele>978.9596734819934</ele>
+				<time>2017-10-30T17:27:04Z</time>
+				<extensions>
+					<speed>1.0589532852172852</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014360122417997" lon="-84.21690125673469">
+				<ele>978.1965648401529</ele>
+				<time>2017-10-30T17:27:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014362600007733" lon="-84.21689776856495">
+				<ele>977.8268765620887</ele>
+				<time>2017-10-30T17:27:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014362600007733" lon="-84.21689776856495">
+				<ele>977.8268765620887</ele>
+				<time>2017-10-30T17:27:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014362600007733" lon="-84.21689776856495">
+				<ele>977.8268765620887</ele>
+				<time>2017-10-30T17:27:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014365536856017" lon="-84.21689237522418">
+				<ele>977.673306713812</ele>
+				<time>2017-10-30T17:27:09Z</time>
+				<extensions>
+					<speed>0.9176474809646606</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014370450277152" lon="-84.21688140902415">
+				<ele>977.56130927708</ele>
+				<time>2017-10-30T17:27:10Z</time>
+				<extensions>
+					<speed>1.6335235834121704</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437434921898" lon="-84.21686560769714">
+				<ele>977.3434621822089</ele>
+				<time>2017-10-30T17:27:11Z</time>
+				<extensions>
+					<speed>2.0268852710723877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014381734994608" lon="-84.2168457345834">
+				<ele>977.1722186561674</ele>
+				<time>2017-10-30T17:27:12Z</time>
+				<extensions>
+					<speed>2.350491762161255</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014391148773301" lon="-84.21682366694696">
+				<ele>976.96662819013</ele>
+				<time>2017-10-30T17:27:13Z</time>
+				<extensions>
+					<speed>2.7588860988616943</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01440075673581" lon="-84.21679579319135">
+				<ele>976.6912991609424</ele>
+				<time>2017-10-30T17:27:14Z</time>
+				<extensions>
+					<speed>3.051085948944092</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014409363101791" lon="-84.21676511041025">
+				<ele>976.364064630121</ele>
+				<time>2017-10-30T17:27:15Z</time>
+				<extensions>
+					<speed>3.0762760639190674</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014418364156446" lon="-84.21673568738453">
+				<ele>976.1276957476512</ele>
+				<time>2017-10-30T17:27:16Z</time>
+				<extensions>
+					<speed>3.0441651344299316</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01442662564582" lon="-84.21670750250293">
+				<ele>975.8901310255751</ele>
+				<time>2017-10-30T17:27:17Z</time>
+				<extensions>
+					<speed>2.825711965560913</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01443327069341" lon="-84.21668392007874">
+				<ele>975.7586716627702</ele>
+				<time>2017-10-30T17:27:18Z</time>
+				<extensions>
+					<speed>2.316678285598755</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014436933556668" lon="-84.21666750168094">
+				<ele>975.6002854239196</ele>
+				<time>2017-10-30T17:27:19Z</time>
+				<extensions>
+					<speed>1.443202018737793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014440260265387" lon="-84.2166538409193">
+				<ele>975.5254899831489</ele>
+				<time>2017-10-30T17:27:20Z</time>
+				<extensions>
+					<speed>1.4415810108184814</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014443753101904" lon="-84.2166434616847">
+				<ele>975.4602910820395</ele>
+				<time>2017-10-30T17:27:21Z</time>
+				<extensions>
+					<speed>1.184437870979309</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014448903219277" lon="-84.21664110344072">
+				<ele>975.3658753782511</ele>
+				<time>2017-10-30T17:27:22Z</time>
+				<extensions>
+					<speed>0.6956555247306824</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014448903219277" lon="-84.21664110344072">
+				<ele>975.3658753782511</ele>
+				<time>2017-10-30T17:27:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014444386656375" lon="-84.21664300077492">
+				<ele>975.0276529621333</ele>
+				<time>2017-10-30T17:27:24Z</time>
+				<extensions>
+					<speed>0.46868810057640076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014444386656375" lon="-84.21664300077492">
+				<ele>975.0276529621333</ele>
+				<time>2017-10-30T17:27:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014444453044716" lon="-84.2166456522254">
+				<ele>974.809036324732</ele>
+				<time>2017-10-30T17:27:26Z</time>
+				<extensions>
+					<speed>0.5042138695716858</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014444453044716" lon="-84.2166456522254">
+				<ele>974.809036324732</ele>
+				<time>2017-10-30T17:27:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014439732247649" lon="-84.21664828823074">
+				<ele>974.702167795971</ele>
+				<time>2017-10-30T17:27:28Z</time>
+				<extensions>
+					<speed>0.4027705490589142</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014439732247649" lon="-84.21664828823074">
+				<ele>974.702167795971</ele>
+				<time>2017-10-30T17:27:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014442374019977" lon="-84.21664367620407">
+				<ele>974.3860911857337</ele>
+				<time>2017-10-30T17:27:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014442374019977" lon="-84.21664367620407">
+				<ele>974.3860911857337</ele>
+				<time>2017-10-30T17:27:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014442374019977" lon="-84.21664367620407">
+				<ele>974.3860911857337</ele>
+				<time>2017-10-30T17:27:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014442374019977" lon="-84.21664367620407">
+				<ele>974.3860911857337</ele>
+				<time>2017-10-30T17:27:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014442374019977" lon="-84.21664367620407">
+				<ele>974.3860911857337</ele>
+				<time>2017-10-30T17:27:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014442374019977" lon="-84.21664367620407">
+				<ele>974.3860911857337</ele>
+				<time>2017-10-30T17:27:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014442374019977" lon="-84.21664367620407">
+				<ele>974.3860911857337</ele>
+				<time>2017-10-30T17:27:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014442374019977" lon="-84.21664367620407">
+				<ele>974.3860911857337</ele>
+				<time>2017-10-30T17:27:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014442374019977" lon="-84.21664367620407">
+				<ele>974.3860911857337</ele>
+				<time>2017-10-30T17:27:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014442374019977" lon="-84.21664367620407">
+				<ele>974.3860911857337</ele>
+				<time>2017-10-30T17:27:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014442374019977" lon="-84.21664367620407">
+				<ele>974.3860911857337</ele>
+				<time>2017-10-30T17:27:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014442374019977" lon="-84.21664367620407">
+				<ele>974.3860911857337</ele>
+				<time>2017-10-30T17:27:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014442374019977" lon="-84.21664367620407">
+				<ele>974.3860911857337</ele>
+				<time>2017-10-30T17:27:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014442374019977" lon="-84.21664367620407">
+				<ele>974.3860911857337</ele>
+				<time>2017-10-30T17:27:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014442374019977" lon="-84.21664367620407">
+				<ele>974.3860911857337</ele>
+				<time>2017-10-30T17:27:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014442374019977" lon="-84.21664367620407">
+				<ele>974.3860911857337</ele>
+				<time>2017-10-30T17:27:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014449625628988" lon="-84.2166296602802">
+				<ele>973.8840350806713</ele>
+				<time>2017-10-30T17:27:46Z</time>
+				<extensions>
+					<speed>1.2362403869628906</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014455049021228" lon="-84.21661962595509">
+				<ele>973.6142935222015</ele>
+				<time>2017-10-30T17:27:47Z</time>
+				<extensions>
+					<speed>1.168748140335083</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014457590337674" lon="-84.21661009478757">
+				<ele>973.3125487966463</ele>
+				<time>2017-10-30T17:27:48Z</time>
+				<extensions>
+					<speed>0.795558750629425</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445969717392" lon="-84.21660494039224">
+				<ele>973.1134804384783</ele>
+				<time>2017-10-30T17:27:49Z</time>
+				<extensions>
+					<speed>0.09155897796154022</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01446141198678" lon="-84.21660282967795">
+				<ele>972.9998649917543</ele>
+				<time>2017-10-30T17:27:50Z</time>
+				<extensions>
+					<speed>0.20853538811206818</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01446141198678" lon="-84.21660282967795">
+				<ele>972.9998649917543</ele>
+				<time>2017-10-30T17:27:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01446141198678" lon="-84.21660282967795">
+				<ele>972.9998649917543</ele>
+				<time>2017-10-30T17:27:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01446141198678" lon="-84.21660282967795">
+				<ele>972.9998649917543</ele>
+				<time>2017-10-30T17:27:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01446141198678" lon="-84.21660282967795">
+				<ele>972.9998649917543</ele>
+				<time>2017-10-30T17:27:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01446141198678" lon="-84.21660282967795">
+				<ele>972.9998649917543</ele>
+				<time>2017-10-30T17:27:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01446141198678" lon="-84.21660282967795">
+				<ele>972.9998649917543</ele>
+				<time>2017-10-30T17:27:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014467322095815" lon="-84.216597655477">
+				<ele>972.8855876345187</ele>
+				<time>2017-10-30T17:27:57Z</time>
+				<extensions>
+					<speed>1.0524104833602905</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014471215794284" lon="-84.21658602495508">
+				<ele>972.7896364293993</ele>
+				<time>2017-10-30T17:27:58Z</time>
+				<extensions>
+					<speed>1.674534797668457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014472959965012" lon="-84.21656782095677">
+				<ele>972.7626571394503</ele>
+				<time>2017-10-30T17:27:59Z</time>
+				<extensions>
+					<speed>2.090620279312134</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014472486091009" lon="-84.21654252797143">
+				<ele>972.5601976076141</ele>
+				<time>2017-10-30T17:28:00Z</time>
+				<extensions>
+					<speed>2.6910276412963867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014472025315621" lon="-84.21651451127426">
+				<ele>972.6044492777437</ele>
+				<time>2017-10-30T17:28:01Z</time>
+				<extensions>
+					<speed>2.6987810134887695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014469858822636" lon="-84.21648748314965">
+				<ele>972.1913651898503</ele>
+				<time>2017-10-30T17:28:02Z</time>
+				<extensions>
+					<speed>2.6497602462768555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014467510081724" lon="-84.21645552338815">
+				<ele>971.7473545074463</ele>
+				<time>2017-10-30T17:28:03Z</time>
+				<extensions>
+					<speed>2.7659339904785156</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447003863374" lon="-84.21642397783235">
+				<ele>971.5278230272233</ele>
+				<time>2017-10-30T17:28:04Z</time>
+				<extensions>
+					<speed>2.878870725631714</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014479143386321" lon="-84.21639350972647">
+				<ele>971.2465791599825</ele>
+				<time>2017-10-30T17:28:05Z</time>
+				<extensions>
+					<speed>3.197793483734131</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014491349051024" lon="-84.21635582309531">
+				<ele>971.0246996721253</ele>
+				<time>2017-10-30T17:28:06Z</time>
+				<extensions>
+					<speed>3.848048686981201</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014504051047286" lon="-84.21631721303244">
+				<ele>971.0434621106833</ele>
+				<time>2017-10-30T17:28:07Z</time>
+				<extensions>
+					<speed>3.9330499172210693</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01451946219403" lon="-84.21627834727548">
+				<ele>970.9146250421181</ele>
+				<time>2017-10-30T17:28:08Z</time>
+				<extensions>
+					<speed>3.926819324493408</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014532152949164" lon="-84.21624120821603">
+				<ele>970.5835433490574</ele>
+				<time>2017-10-30T17:28:09Z</time>
+				<extensions>
+					<speed>3.4408631324768066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01454296673327" lon="-84.2162088893091">
+				<ele>970.230220919475</ele>
+				<time>2017-10-30T17:28:10Z</time>
+				<extensions>
+					<speed>3.31136417388916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014556661333227" lon="-84.21617588002216">
+				<ele>969.8940623784438</ele>
+				<time>2017-10-30T17:28:11Z</time>
+				<extensions>
+					<speed>3.592543601989746</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014571857651937" lon="-84.21613643227029">
+				<ele>969.3552783792838</ele>
+				<time>2017-10-30T17:28:12Z</time>
+				<extensions>
+					<speed>3.916872024536133</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014587592230031" lon="-84.21609462975995">
+				<ele>968.6974084926769</ele>
+				<time>2017-10-30T17:28:13Z</time>
+				<extensions>
+					<speed>4.056766510009766</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014599654865915" lon="-84.21605943874042">
+				<ele>968.1335929147899</ele>
+				<time>2017-10-30T17:28:14Z</time>
+				<extensions>
+					<speed>3.6487722396850586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01460845287165" lon="-84.21602365743844">
+				<ele>967.515974804759</ele>
+				<time>2017-10-30T17:28:15Z</time>
+				<extensions>
+					<speed>3.7797744274139404</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014620336706729" lon="-84.21598983862732">
+				<ele>966.8710643127561</ele>
+				<time>2017-10-30T17:28:16Z</time>
+				<extensions>
+					<speed>3.05452561378479</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014631700070701" lon="-84.21596224186732">
+				<ele>965.6354309068993</ele>
+				<time>2017-10-30T17:28:17Z</time>
+				<extensions>
+					<speed>2.792572259902954</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014641289014863" lon="-84.21593386736508">
+				<ele>964.9712086739019</ele>
+				<time>2017-10-30T17:28:18Z</time>
+				<extensions>
+					<speed>2.690382242202759</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648255429766" lon="-84.21590532970691">
+				<ele>964.6779401190579</ele>
+				<time>2017-10-30T17:28:19Z</time>
+				<extensions>
+					<speed>2.5673062801361084</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014654701148665" lon="-84.21588145083503">
+				<ele>963.797617518343</ele>
+				<time>2017-10-30T17:28:20Z</time>
+				<extensions>
+					<speed>1.592651128768921</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014658098438689" lon="-84.2158685398229">
+				<ele>962.2175980731845</ele>
+				<time>2017-10-30T17:28:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014658996532905" lon="-84.21586479860962">
+				<ele>960.139460105449</ele>
+				<time>2017-10-30T17:28:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014658996532905" lon="-84.21586479860962">
+				<ele>960.139460105449</ele>
+				<time>2017-10-30T17:28:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014658996532905" lon="-84.21586479860962">
+				<ele>960.139460105449</ele>
+				<time>2017-10-30T17:28:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014658996532905" lon="-84.21586479860962">
+				<ele>960.139460105449</ele>
+				<time>2017-10-30T17:28:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014658996532905" lon="-84.21586479860962">
+				<ele>960.139460105449</ele>
+				<time>2017-10-30T17:28:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014658996532905" lon="-84.21586479860962">
+				<ele>960.139460105449</ele>
+				<time>2017-10-30T17:28:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014659817615478" lon="-84.21585646919748">
+				<ele>960.1326719745994</ele>
+				<time>2017-10-30T17:28:28Z</time>
+				<extensions>
+					<speed>0.8537313938140869</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014664016798724" lon="-84.21584163219904">
+				<ele>959.9889553748071</ele>
+				<time>2017-10-30T17:28:29Z</time>
+				<extensions>
+					<speed>2.1156866550445557</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014675231837359" lon="-84.21581493665735">
+				<ele>959.5738273030147</ele>
+				<time>2017-10-30T17:28:30Z</time>
+				<extensions>
+					<speed>3.719853162765503</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014688558332944" lon="-84.21577681533246">
+				<ele>959.0057012382895</ele>
+				<time>2017-10-30T17:28:31Z</time>
+				<extensions>
+					<speed>4.372923374176025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014702244787543" lon="-84.21573500096517">
+				<ele>958.7614006754011</ele>
+				<time>2017-10-30T17:28:32Z</time>
+				<extensions>
+					<speed>5.002627372741699</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014716377042696" lon="-84.21568427091314">
+				<ele>958.8008837830275</ele>
+				<time>2017-10-30T17:28:33Z</time>
+				<extensions>
+					<speed>5.685617446899414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01472927924901" lon="-84.21563236474157">
+				<ele>958.6968875210732</ele>
+				<time>2017-10-30T17:28:34Z</time>
+				<extensions>
+					<speed>5.713900089263916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014741789723248" lon="-84.21557922984442">
+				<ele>958.4595040520653</ele>
+				<time>2017-10-30T17:28:35Z</time>
+				<extensions>
+					<speed>5.765760898590088</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014752544662024" lon="-84.21552736490105">
+				<ele>958.4296533167362</ele>
+				<time>2017-10-30T17:28:36Z</time>
+				<extensions>
+					<speed>5.6243367195129395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014759633204338" lon="-84.21548061665392">
+				<ele>958.421798796393</ele>
+				<time>2017-10-30T17:28:37Z</time>
+				<extensions>
+					<speed>4.898395538330078</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01477634687343" lon="-84.21544230827472">
+				<ele>958.3948662625626</ele>
+				<time>2017-10-30T17:28:38Z</time>
+				<extensions>
+					<speed>4.406750202178955</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01478777081498" lon="-84.21540265164059">
+				<ele>958.2175412075594</ele>
+				<time>2017-10-30T17:28:39Z</time>
+				<extensions>
+					<speed>4.05649471282959</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014798406391767" lon="-84.21536670172655">
+				<ele>957.7163707390428</ele>
+				<time>2017-10-30T17:28:40Z</time>
+				<extensions>
+					<speed>3.9084622859954834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014808479789902" lon="-84.21532935716736">
+				<ele>957.2375161722302</ele>
+				<time>2017-10-30T17:28:41Z</time>
+				<extensions>
+					<speed>4.1243109703063965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014820391204584" lon="-84.2152919455141">
+				<ele>956.7997545553371</ele>
+				<time>2017-10-30T17:28:42Z</time>
+				<extensions>
+					<speed>3.952471971511841</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014833009743985" lon="-84.21525286074018">
+				<ele>956.6389537723735</ele>
+				<time>2017-10-30T17:28:43Z</time>
+				<extensions>
+					<speed>4.607545852661133</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014844267375706" lon="-84.2152096086703">
+				<ele>956.4702099030837</ele>
+				<time>2017-10-30T17:28:44Z</time>
+				<extensions>
+					<speed>4.450362682342529</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014853278487381" lon="-84.21516528026648">
+				<ele>956.4291424453259</ele>
+				<time>2017-10-30T17:28:45Z</time>
+				<extensions>
+					<speed>4.660963535308838</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858689077794" lon="-84.21511922463631">
+				<ele>956.0734873088077</ele>
+				<time>2017-10-30T17:28:46Z</time>
+				<extensions>
+					<speed>4.421605587005615</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014861541415694" lon="-84.21507815392543">
+				<ele>955.6346822446212</ele>
+				<time>2017-10-30T17:28:47Z</time>
+				<extensions>
+					<speed>4.031310081481934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014867523344765" lon="-84.21503946204612">
+				<ele>955.5190376630053</ele>
+				<time>2017-10-30T17:28:48Z</time>
+				<extensions>
+					<speed>3.608701229095459</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01487673357264" lon="-84.21499796423785">
+				<ele>955.3823253363371</ele>
+				<time>2017-10-30T17:28:49Z</time>
+				<extensions>
+					<speed>3.3811280727386475</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01488214758126" lon="-84.2149633003256">
+				<ele>955.190915866755</ele>
+				<time>2017-10-30T17:28:50Z</time>
+				<extensions>
+					<speed>2.803650140762329</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014889663792898" lon="-84.21493462553441">
+				<ele>955.0970771033317</ele>
+				<time>2017-10-30T17:28:51Z</time>
+				<extensions>
+					<speed>2.334561347961426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014893063717206" lon="-84.21491442696026">
+				<ele>955.0775945475325</ele>
+				<time>2017-10-30T17:28:52Z</time>
+				<extensions>
+					<speed>1.4753446578979492</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014893784066984" lon="-84.21490026407376">
+				<ele>955.0450385985896</ele>
+				<time>2017-10-30T17:28:53Z</time>
+				<extensions>
+					<speed>0.7160684466362</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014893784066984" lon="-84.21490026407376">
+				<ele>955.0450385985896</ele>
+				<time>2017-10-30T17:28:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014900832750032" lon="-84.21489634423963">
+				<ele>954.6677949167788</ele>
+				<time>2017-10-30T17:28:55Z</time>
+				<extensions>
+					<speed>0.619113028049469</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014900832750032" lon="-84.21489634423963">
+				<ele>954.6677949167788</ele>
+				<time>2017-10-30T17:28:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01489798347578" lon="-84.21488779569073">
+				<ele>955.5959582263604</ele>
+				<time>2017-10-30T17:28:57Z</time>
+				<extensions>
+					<speed>0.4931630492210388</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014896444148706" lon="-84.21487731602868">
+				<ele>956.8739037290215</ele>
+				<time>2017-10-30T17:28:58Z</time>
+				<extensions>
+					<speed>1.0641248226165771</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:28:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014892275418033" lon="-84.21486778170748">
+				<ele>957.4057254483923</ele>
+				<time>2017-10-30T17:29:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0148912191008" lon="-84.21487745208489">
+				<ele>955.9823327297345</ele>
+				<time>2017-10-30T17:29:29Z</time>
+				<extensions>
+					<speed>1.0343369245529175</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01489606732879" lon="-84.2148850924586">
+				<ele>952.5381808923557</ele>
+				<time>2017-10-30T17:29:30Z</time>
+				<extensions>
+					<speed>1.0371098518371582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014904514899793" lon="-84.2148869930771">
+				<ele>944.6984631717205</ele>
+				<time>2017-10-30T17:29:31Z</time>
+				<extensions>
+					<speed>0.5762472748756409</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014909008564507" lon="-84.21486707385115">
+				<ele>942.7222015708685</ele>
+				<time>2017-10-30T17:29:32Z</time>
+				<extensions>
+					<speed>3.015765905380249</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0149169852397" lon="-84.21482504592402">
+				<ele>942.3236957434565</ele>
+				<time>2017-10-30T17:29:33Z</time>
+				<extensions>
+					<speed>4.711893558502197</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014928563394376" lon="-84.21477418174103">
+				<ele>942.5197778260335</ele>
+				<time>2017-10-30T17:29:34Z</time>
+				<extensions>
+					<speed>5.444793224334717</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0149465259937" lon="-84.21471601163792">
+				<ele>942.5140294581652</ele>
+				<time>2017-10-30T17:29:35Z</time>
+				<extensions>
+					<speed>6.101145267486572</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014955591851407" lon="-84.21465338790208">
+				<ele>942.9499677075073</ele>
+				<time>2017-10-30T17:29:36Z</time>
+				<extensions>
+					<speed>6.285720348358154</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014961742867017" lon="-84.21459084848934">
+				<ele>942.9334688177332</ele>
+				<time>2017-10-30T17:29:37Z</time>
+				<extensions>
+					<speed>6.281803607940674</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014971148400319" lon="-84.21453134448478">
+				<ele>942.7432018797845</ele>
+				<time>2017-10-30T17:29:38Z</time>
+				<extensions>
+					<speed>6.299537181854248</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01498086229804" lon="-84.21447149390565">
+				<ele>942.945227060467</ele>
+				<time>2017-10-30T17:29:39Z</time>
+				<extensions>
+					<speed>6.298183441162109</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014993659955683" lon="-84.21441100751093">
+				<ele>943.737951410003</ele>
+				<time>2017-10-30T17:29:40Z</time>
+				<extensions>
+					<speed>5.768594264984131</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01500785970905" lon="-84.21435713092019">
+				<ele>944.3443172508851</ele>
+				<time>2017-10-30T17:29:41Z</time>
+				<extensions>
+					<speed>5.499042987823486</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01503018082663" lon="-84.21430509776397">
+				<ele>944.5727039733902</ele>
+				<time>2017-10-30T17:29:42Z</time>
+				<extensions>
+					<speed>5.542552471160889</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015051526026328" lon="-84.21424980964659">
+				<ele>944.588103318587</ele>
+				<time>2017-10-30T17:29:43Z</time>
+				<extensions>
+					<speed>5.88320779800415</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015069031292294" lon="-84.21419276012729">
+				<ele>944.5403657024726</ele>
+				<time>2017-10-30T17:29:44Z</time>
+				<extensions>
+					<speed>5.918542385101318</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0150768189559" lon="-84.21414660272076">
+				<ele>944.5298931766301</ele>
+				<time>2017-10-30T17:29:45Z</time>
+				<extensions>
+					<speed>4.824034690856934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015090480783591" lon="-84.2141071051965">
+				<ele>944.4331275820732</ele>
+				<time>2017-10-30T17:29:46Z</time>
+				<extensions>
+					<speed>3.707359552383423</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015104003575853" lon="-84.2140842102656">
+				<ele>944.3179319798946</ele>
+				<time>2017-10-30T17:29:47Z</time>
+				<extensions>
+					<speed>2.082080364227295</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01510916526082" lon="-84.21407341954949">
+				<ele>944.3166760560125</ele>
+				<time>2017-10-30T17:29:48Z</time>
+				<extensions>
+					<speed>0.5071821808815002</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015103305358837" lon="-84.21407176323983">
+				<ele>944.4523297110572</ele>
+				<time>2017-10-30T17:29:49Z</time>
+				<extensions>
+					<speed>0.7944849729537964</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015096676166209" lon="-84.21407576227062">
+				<ele>944.4843028690666</ele>
+				<time>2017-10-30T17:29:50Z</time>
+				<extensions>
+					<speed>1.1229619979858398</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015086853133155" lon="-84.21407981830193">
+				<ele>944.644815729931</ele>
+				<time>2017-10-30T17:29:51Z</time>
+				<extensions>
+					<speed>1.0884861946105957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015079569063957" lon="-84.21408044669909">
+				<ele>944.9112708335742</ele>
+				<time>2017-10-30T17:29:52Z</time>
+				<extensions>
+					<speed>0.7142021656036377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015079569063957" lon="-84.21408044669909">
+				<ele>944.9112708335742</ele>
+				<time>2017-10-30T17:29:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015079164029396" lon="-84.21408045941244">
+				<ele>945.0621239980683</ele>
+				<time>2017-10-30T17:29:54Z</time>
+				<extensions>
+					<speed>0.033608872443437576</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015079164029396" lon="-84.21408045941244">
+				<ele>945.0621239980683</ele>
+				<time>2017-10-30T17:29:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015079164029396" lon="-84.21408045941244">
+				<ele>945.0621239980683</ele>
+				<time>2017-10-30T17:29:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015079164029396" lon="-84.21408045941244">
+				<ele>945.0621239980683</ele>
+				<time>2017-10-30T17:29:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015079164029396" lon="-84.21408045941244">
+				<ele>945.0621239980683</ele>
+				<time>2017-10-30T17:29:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015079164029396" lon="-84.21408045941244">
+				<ele>945.0621239980683</ele>
+				<time>2017-10-30T17:29:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015079164029396" lon="-84.21408045941244">
+				<ele>945.0621239980683</ele>
+				<time>2017-10-30T17:30:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015079164029396" lon="-84.21408045941244">
+				<ele>945.0621239980683</ele>
+				<time>2017-10-30T17:30:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015079164029396" lon="-84.21408045941244">
+				<ele>945.0621239980683</ele>
+				<time>2017-10-30T17:30:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015079164029396" lon="-84.21408045941244">
+				<ele>945.0621239980683</ele>
+				<time>2017-10-30T17:30:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015079164029396" lon="-84.21408045941244">
+				<ele>945.0621239980683</ele>
+				<time>2017-10-30T17:30:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015079164029396" lon="-84.21408045941244">
+				<ele>945.0621239980683</ele>
+				<time>2017-10-30T17:30:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015079164029396" lon="-84.21408045941244">
+				<ele>945.0621239980683</ele>
+				<time>2017-10-30T17:30:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015079164029396" lon="-84.21408045941244">
+				<ele>945.0621239980683</ele>
+				<time>2017-10-30T17:30:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015079164029396" lon="-84.21408045941244">
+				<ele>945.0621239980683</ele>
+				<time>2017-10-30T17:30:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015079164029396" lon="-84.21408045941244">
+				<ele>945.0621239980683</ele>
+				<time>2017-10-30T17:30:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015091107838652" lon="-84.21406851704569">
+				<ele>945.395664896816</ele>
+				<time>2017-10-30T17:30:10Z</time>
+				<extensions>
+					<speed>1.2738417387008667</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015100854545226" lon="-84.21404948903243">
+				<ele>945.8749068621546</ele>
+				<time>2017-10-30T17:30:11Z</time>
+				<extensions>
+					<speed>2.02646541595459</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015120283343562" lon="-84.2140112046466">
+				<ele>946.4090341683477</ele>
+				<time>2017-10-30T17:30:12Z</time>
+				<extensions>
+					<speed>3.7569780349731445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015136406805315" lon="-84.21396940190904">
+				<ele>947.0261952960864</ele>
+				<time>2017-10-30T17:30:13Z</time>
+				<extensions>
+					<speed>4.725725173950195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015155343428157" lon="-84.2139129975795">
+				<ele>948.3225039876997</ele>
+				<time>2017-10-30T17:30:14Z</time>
+				<extensions>
+					<speed>5.7476701736450195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015183255541904" lon="-84.21384231354803">
+				<ele>949.5086563872173</ele>
+				<time>2017-10-30T17:30:15Z</time>
+				<extensions>
+					<speed>7.044520854949951</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015217986213584" lon="-84.21376552787211">
+				<ele>950.6041752425954</ele>
+				<time>2017-10-30T17:30:16Z</time>
+				<extensions>
+					<speed>7.829028606414795</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015232669476855" lon="-84.21368359488599">
+				<ele>951.5386425592005</ele>
+				<time>2017-10-30T17:30:17Z</time>
+				<extensions>
+					<speed>8.340641021728516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015249536191343" lon="-84.21360587236396">
+				<ele>952.3293076921254</ele>
+				<time>2017-10-30T17:30:18Z</time>
+				<extensions>
+					<speed>8.28901481628418</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01526830670711" lon="-84.21354144918455">
+				<ele>952.3465073984116</ele>
+				<time>2017-10-30T17:30:19Z</time>
+				<extensions>
+					<speed>7.542633533477783</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015288024269456" lon="-84.21348069512935">
+				<ele>952.741342689842</ele>
+				<time>2017-10-30T17:30:20Z</time>
+				<extensions>
+					<speed>7.001040935516357</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015303926965492" lon="-84.21342538952653">
+				<ele>953.0592670598999</ele>
+				<time>2017-10-30T17:30:21Z</time>
+				<extensions>
+					<speed>6.246959209442139</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01531631836289" lon="-84.21337747322696">
+				<ele>953.5303414594382</ele>
+				<time>2017-10-30T17:30:22Z</time>
+				<extensions>
+					<speed>5.373287200927734</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015323429790264" lon="-84.21334339309574">
+				<ele>954.3928799703717</ele>
+				<time>2017-10-30T17:30:23Z</time>
+				<extensions>
+					<speed>4.135043144226074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01533045280274" lon="-84.21332268535826">
+				<ele>954.9971989970654</ele>
+				<time>2017-10-30T17:30:24Z</time>
+				<extensions>
+					<speed>2.041731834411621</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015338317905343" lon="-84.21332007430233">
+				<ele>955.1890185521916</ele>
+				<time>2017-10-30T17:30:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01534036059435" lon="-84.21332984970613">
+				<ele>955.3624492771924</ele>
+				<time>2017-10-30T17:30:26Z</time>
+				<extensions>
+					<speed>0.8343434929847717</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015342109885065" lon="-84.21334515345401">
+				<ele>955.6130666108802</ele>
+				<time>2017-10-30T17:30:27Z</time>
+				<extensions>
+					<speed>1.0168650150299072</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01534125900298" lon="-84.21335843240763">
+				<ele>955.7046262994409</ele>
+				<time>2017-10-30T17:30:28Z</time>
+				<extensions>
+					<speed>0.8630297780036926</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01534125900298" lon="-84.21335843240763">
+				<ele>955.7046262994409</ele>
+				<time>2017-10-30T17:30:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015335967510037" lon="-84.21336594808021">
+				<ele>955.7386099835858</ele>
+				<time>2017-10-30T17:30:30Z</time>
+				<extensions>
+					<speed>0.43823570013046265</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015335967510037" lon="-84.21336594808021">
+				<ele>955.7386099835858</ele>
+				<time>2017-10-30T17:30:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:30:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:31:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:31:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:31:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:31:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:31:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:31:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:31:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:31:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:31:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:31:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:31:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332314818952" lon="-84.2133703058057">
+				<ele>955.6284881569445</ele>
+				<time>2017-10-30T17:31:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015343884912033" lon="-84.21336754448076">
+				<ele>955.3251459253952</ele>
+				<time>2017-10-30T17:31:12Z</time>
+				<extensions>
+					<speed>1.2508972883224487</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01534942114098" lon="-84.21336626583602">
+				<ele>955.5619628569111</ele>
+				<time>2017-10-30T17:31:13Z</time>
+				<extensions>
+					<speed>0.13634748756885529</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015349825259774" lon="-84.21336576433596">
+				<ele>956.1537633258849</ele>
+				<time>2017-10-30T17:31:14Z</time>
+				<extensions>
+					<speed>0.47008830308914185</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015349825259774" lon="-84.21336576433596">
+				<ele>956.1537633258849</ele>
+				<time>2017-10-30T17:31:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015351975915229" lon="-84.21336650531711">
+				<ele>956.7130191503093</ele>
+				<time>2017-10-30T17:31:16Z</time>
+				<extensions>
+					<speed>0.13665035367012024</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015351975915229" lon="-84.21336650531711">
+				<ele>956.7130191503093</ele>
+				<time>2017-10-30T17:31:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015351975915229" lon="-84.21336650531711">
+				<ele>956.7130191503093</ele>
+				<time>2017-10-30T17:31:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015351975915229" lon="-84.21336650531711">
+				<ele>956.7130191503093</ele>
+				<time>2017-10-30T17:31:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015351975915229" lon="-84.21336650531711">
+				<ele>956.7130191503093</ele>
+				<time>2017-10-30T17:31:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015351975915229" lon="-84.21336650531711">
+				<ele>956.7130191503093</ele>
+				<time>2017-10-30T17:31:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015351975915229" lon="-84.21336650531711">
+				<ele>956.7130191503093</ele>
+				<time>2017-10-30T17:31:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015351975915229" lon="-84.21336650531711">
+				<ele>956.7130191503093</ele>
+				<time>2017-10-30T17:31:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015351975915229" lon="-84.21336650531711">
+				<ele>956.7130191503093</ele>
+				<time>2017-10-30T17:31:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015351975915229" lon="-84.21336650531711">
+				<ele>956.7130191503093</ele>
+				<time>2017-10-30T17:31:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015351975915229" lon="-84.21336650531711">
+				<ele>956.7130191503093</ele>
+				<time>2017-10-30T17:31:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015351975915229" lon="-84.21336650531711">
+				<ele>956.7130191503093</ele>
+				<time>2017-10-30T17:31:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015351975915229" lon="-84.21336650531711">
+				<ele>956.7130191503093</ele>
+				<time>2017-10-30T17:31:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015351975915229" lon="-84.21336650531711">
+				<ele>956.7130191503093</ele>
+				<time>2017-10-30T17:31:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015353851342223" lon="-84.2133614679551">
+				<ele>956.8240418173373</ele>
+				<time>2017-10-30T17:31:30Z</time>
+				<extensions>
+					<speed>0.7898191809654236</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015355471755445" lon="-84.21335429317686">
+				<ele>957.10592275206</ele>
+				<time>2017-10-30T17:31:31Z</time>
+				<extensions>
+					<speed>0.980868399143219</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01535662419163" lon="-84.21334446365226">
+				<ele>957.3113954914734</ele>
+				<time>2017-10-30T17:31:32Z</time>
+				<extensions>
+					<speed>1.170837640762329</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015355544448102" lon="-84.21333226132556">
+				<ele>957.4454124132171</ele>
+				<time>2017-10-30T17:31:33Z</time>
+				<extensions>
+					<speed>1.3594212532043457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015352260681505" lon="-84.2133198863896">
+				<ele>957.3322720294818</ele>
+				<time>2017-10-30T17:31:34Z</time>
+				<extensions>
+					<speed>1.3051095008850098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015350707103158" lon="-84.21330739035932">
+				<ele>957.3720423299819</ele>
+				<time>2017-10-30T17:31:35Z</time>
+				<extensions>
+					<speed>1.4417870044708252</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015349260964062" lon="-84.21329341072864">
+				<ele>957.4134474433959</ele>
+				<time>2017-10-30T17:31:36Z</time>
+				<extensions>
+					<speed>1.5480611324310303</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015356332258259" lon="-84.21327312322205">
+				<ele>957.2855508644134</ele>
+				<time>2017-10-30T17:31:37Z</time>
+				<extensions>
+					<speed>2.205935478210449</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01536003907335" lon="-84.21325245614264">
+				<ele>957.270171248354</ele>
+				<time>2017-10-30T17:31:38Z</time>
+				<extensions>
+					<speed>2.4440581798553467</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015367198449036" lon="-84.21322706875821">
+				<ele>957.4462456591427</ele>
+				<time>2017-10-30T17:31:39Z</time>
+				<extensions>
+					<speed>2.946942090988159</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015374383634574" lon="-84.21319135489163">
+				<ele>957.3857853952795</ele>
+				<time>2017-10-30T17:31:40Z</time>
+				<extensions>
+					<speed>3.7401864528656006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015383384343318" lon="-84.21315095593297">
+				<ele>957.367597065866</ele>
+				<time>2017-10-30T17:31:41Z</time>
+				<extensions>
+					<speed>4.42996072769165</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01539634195462" lon="-84.21310732820912">
+				<ele>957.5746482666582</ele>
+				<time>2017-10-30T17:31:42Z</time>
+				<extensions>
+					<speed>5.015468120574951</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015416385906068" lon="-84.21306150401051">
+				<ele>957.9184295823798</ele>
+				<time>2017-10-30T17:31:43Z</time>
+				<extensions>
+					<speed>5.5860209465026855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015422937920885" lon="-84.21300801685223">
+				<ele>958.3233776222914</ele>
+				<time>2017-10-30T17:31:44Z</time>
+				<extensions>
+					<speed>6.12106990814209</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01543323955611" lon="-84.21295322991983">
+				<ele>958.8878025766462</ele>
+				<time>2017-10-30T17:31:45Z</time>
+				<extensions>
+					<speed>6.815096855163574</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015446045815052" lon="-84.21289302995211">
+				<ele>959.128753115423</ele>
+				<time>2017-10-30T17:31:46Z</time>
+				<extensions>
+					<speed>7.615362644195557</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0154666578037" lon="-84.21282681244399">
+				<ele>958.9291926827282</ele>
+				<time>2017-10-30T17:31:47Z</time>
+				<extensions>
+					<speed>7.844608306884766</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01549183656858" lon="-84.21275824927368">
+				<ele>958.8897590031847</ele>
+				<time>2017-10-30T17:31:48Z</time>
+				<extensions>
+					<speed>8.361332893371582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015517505133085" lon="-84.21268614936851">
+				<ele>958.8562693130225</ele>
+				<time>2017-10-30T17:31:49Z</time>
+				<extensions>
+					<speed>8.545194625854492</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01554053799441" lon="-84.21261373624216">
+				<ele>958.8872975483537</ele>
+				<time>2017-10-30T17:31:50Z</time>
+				<extensions>
+					<speed>8.419041633605957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015561177102816" lon="-84.21254109931888">
+				<ele>959.0642938623205</ele>
+				<time>2017-10-30T17:31:51Z</time>
+				<extensions>
+					<speed>8.39104175567627</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015581049205135" lon="-84.21246550502364">
+				<ele>959.2571368003264</ele>
+				<time>2017-10-30T17:31:52Z</time>
+				<extensions>
+					<speed>8.50717544555664</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015601462053848" lon="-84.21238690168605">
+				<ele>959.3064521905035</ele>
+				<time>2017-10-30T17:31:53Z</time>
+				<extensions>
+					<speed>8.766318321228027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01562119396131" lon="-84.21230659857765">
+				<ele>959.3343925205991</ele>
+				<time>2017-10-30T17:31:54Z</time>
+				<extensions>
+					<speed>8.99276351928711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015640507231678" lon="-84.21222560089352">
+				<ele>959.312739293091</ele>
+				<time>2017-10-30T17:31:55Z</time>
+				<extensions>
+					<speed>9.032846450805664</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015663038531637" lon="-84.21214503122091">
+				<ele>959.284407232888</ele>
+				<time>2017-10-30T17:31:56Z</time>
+				<extensions>
+					<speed>9.087875366210938</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01568567593269" lon="-84.21206238463195">
+				<ele>959.2172821937129</ele>
+				<time>2017-10-30T17:31:57Z</time>
+				<extensions>
+					<speed>9.161202430725098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015709736545148" lon="-84.2119862716326">
+				<ele>959.3150266800076</ele>
+				<time>2017-10-30T17:31:58Z</time>
+				<extensions>
+					<speed>9.073570251464844</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735300949935" lon="-84.2119189660343">
+				<ele>959.3729170393199</ele>
+				<time>2017-10-30T17:31:59Z</time>
+				<extensions>
+					<speed>8.80882740020752</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0157528741978" lon="-84.21189248492134">
+				<ele>959.382313914597</ele>
+				<time>2017-10-30T17:32:00Z</time>
+				<extensions>
+					<speed>7.01271915435791</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015774368489234" lon="-84.2118318630862">
+				<ele>959.3337551048025</ele>
+				<time>2017-10-30T17:32:01Z</time>
+				<extensions>
+					<speed>6.738883972167969</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0157725929536" lon="-84.21178664374824">
+				<ele>959.0627311635762</ele>
+				<time>2017-10-30T17:32:02Z</time>
+				<extensions>
+					<speed>5.341497898101807</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015792715768361" lon="-84.21173951095322">
+				<ele>958.9506626408547</ele>
+				<time>2017-10-30T17:32:03Z</time>
+				<extensions>
+					<speed>4.20188570022583</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015803063247887" lon="-84.21171484545653">
+				<ele>959.8929372373968</ele>
+				<time>2017-10-30T17:32:04Z</time>
+				<extensions>
+					<speed>3.0646111965179443</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015809758502236" lon="-84.21170528607189">
+				<ele>960.5249895043671</ele>
+				<time>2017-10-30T17:32:05Z</time>
+				<extensions>
+					<speed>1.4864391088485718</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015811683482786" lon="-84.21170754910771">
+				<ele>960.5656851669773</ele>
+				<time>2017-10-30T17:32:06Z</time>
+				<extensions>
+					<speed>0.13880255818367004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015811683482786" lon="-84.21170754910771">
+				<ele>960.5656851669773</ele>
+				<time>2017-10-30T17:32:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015810099962602" lon="-84.21172339951063">
+				<ele>960.7669236380607</ele>
+				<time>2017-10-30T17:32:08Z</time>
+				<extensions>
+					<speed>1.2461706399917603</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015810390325008" lon="-84.21173871285953">
+				<ele>960.9616688489914</ele>
+				<time>2017-10-30T17:32:09Z</time>
+				<extensions>
+					<speed>1.1550973653793335</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01580841980937" lon="-84.211748609911">
+				<ele>961.1709117377177</ele>
+				<time>2017-10-30T17:32:10Z</time>
+				<extensions>
+					<speed>0.8854380249977112</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01580841980937" lon="-84.211748609911">
+				<ele>961.1709117377177</ele>
+				<time>2017-10-30T17:32:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01580934037072" lon="-84.21175572626701">
+				<ele>961.4740417925641</ele>
+				<time>2017-10-30T17:32:12Z</time>
+				<extensions>
+					<speed>0.3620847761631012</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01580934037072" lon="-84.21175572626701">
+				<ele>961.4740417925641</ele>
+				<time>2017-10-30T17:32:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01580934037072" lon="-84.21175572626701">
+				<ele>961.4740417925641</ele>
+				<time>2017-10-30T17:32:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01580934037072" lon="-84.21175572626701">
+				<ele>961.4740417925641</ele>
+				<time>2017-10-30T17:32:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01580934037072" lon="-84.21175572626701">
+				<ele>961.4740417925641</ele>
+				<time>2017-10-30T17:32:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01580934037072" lon="-84.21175572626701">
+				<ele>961.4740417925641</ele>
+				<time>2017-10-30T17:32:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01580934037072" lon="-84.21175572626701">
+				<ele>961.4740417925641</ele>
+				<time>2017-10-30T17:32:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01580934037072" lon="-84.21175572626701">
+				<ele>961.4740417925641</ele>
+				<time>2017-10-30T17:32:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01580934037072" lon="-84.21175572626701">
+				<ele>961.4740417925641</ele>
+				<time>2017-10-30T17:32:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01580934037072" lon="-84.21175572626701">
+				<ele>961.4740417925641</ele>
+				<time>2017-10-30T17:32:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01580934037072" lon="-84.21175572626701">
+				<ele>961.4740417925641</ele>
+				<time>2017-10-30T17:32:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01580934037072" lon="-84.21175572626701">
+				<ele>961.4740417925641</ele>
+				<time>2017-10-30T17:32:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01580934037072" lon="-84.21175572626701">
+				<ele>961.4740417925641</ele>
+				<time>2017-10-30T17:32:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01580918458865" lon="-84.21175053082435">
+				<ele>961.889156605117</ele>
+				<time>2017-10-30T17:32:25Z</time>
+				<extensions>
+					<speed>0.7057048678398132</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015812235095272" lon="-84.21173915081769">
+				<ele>962.2346851537004</ele>
+				<time>2017-10-30T17:32:26Z</time>
+				<extensions>
+					<speed>1.9250911474227905</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01582052720122" lon="-84.2117147119731">
+				<ele>962.5451765377074</ele>
+				<time>2017-10-30T17:32:27Z</time>
+				<extensions>
+					<speed>3.3631670475006104</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015835199448398" lon="-84.21167809472219">
+				<ele>963.0951608270407</ele>
+				<time>2017-10-30T17:32:28Z</time>
+				<extensions>
+					<speed>4.758359909057617</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015850466134234" lon="-84.2116331374095">
+				<ele>963.1959729352966</ele>
+				<time>2017-10-30T17:32:29Z</time>
+				<extensions>
+					<speed>5.524177551269531</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015864182531027" lon="-84.21158519885354">
+				<ele>963.2126918574795</ele>
+				<time>2017-10-30T17:32:30Z</time>
+				<extensions>
+					<speed>5.4455132484436035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015877985677557" lon="-84.21154065493292">
+				<ele>963.2599711026996</ele>
+				<time>2017-10-30T17:32:31Z</time>
+				<extensions>
+					<speed>5.153824329376221</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015888814453763" lon="-84.2115032478808">
+				<ele>963.4214789289981</ele>
+				<time>2017-10-30T17:32:32Z</time>
+				<extensions>
+					<speed>4.445568561553955</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015892759294873" lon="-84.2114731375427">
+				<ele>963.3824686268345</ele>
+				<time>2017-10-30T17:32:33Z</time>
+				<extensions>
+					<speed>3.4875457286834717</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015891253674495" lon="-84.21145466457529">
+				<ele>963.3114109383896</ele>
+				<time>2017-10-30T17:32:34Z</time>
+				<extensions>
+					<speed>1.974280595779419</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015884204103108" lon="-84.21144031943287">
+				<ele>963.1421203948557</ele>
+				<time>2017-10-30T17:32:35Z</time>
+				<extensions>
+					<speed>1.5361542701721191</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015863917109844" lon="-84.21142190846979">
+				<ele>963.0420632595196</ele>
+				<time>2017-10-30T17:32:36Z</time>
+				<extensions>
+					<speed>2.03627347946167</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015848540268061" lon="-84.21140169356224">
+				<ele>963.077432510443</ele>
+				<time>2017-10-30T17:32:37Z</time>
+				<extensions>
+					<speed>2.472325086593628</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01582586256925" lon="-84.21138284835268">
+				<ele>963.1829850105569</ele>
+				<time>2017-10-30T17:32:38Z</time>
+				<extensions>
+					<speed>2.8809871673583984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015795511617052" lon="-84.21136726963176">
+				<ele>963.3866391628981</ele>
+				<time>2017-10-30T17:32:39Z</time>
+				<extensions>
+					<speed>3.324924945831299</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015762011577861" lon="-84.2113528536254">
+				<ele>963.5004774499685</ele>
+				<time>2017-10-30T17:32:40Z</time>
+				<extensions>
+					<speed>3.93924617767334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015726771784726" lon="-84.21133768969568">
+				<ele>963.6954508600757</ele>
+				<time>2017-10-30T17:32:41Z</time>
+				<extensions>
+					<speed>4.354166507720947</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015670252178923" lon="-84.21135416838953">
+				<ele>962.3330929856747</ele>
+				<time>2017-10-30T17:32:42Z</time>
+				<extensions>
+					<speed>5.552535057067871</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01560842103664" lon="-84.21134271757913">
+				<ele>962.0112542249262</ele>
+				<time>2017-10-30T17:32:43Z</time>
+				<extensions>
+					<speed>6.704635143280029</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015533257390711" lon="-84.21131765791532">
+				<ele>962.8911012681201</ele>
+				<time>2017-10-30T17:32:44Z</time>
+				<extensions>
+					<speed>7.547147274017334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015466635042424" lon="-84.21129134797745">
+				<ele>962.6039968226105</ele>
+				<time>2017-10-30T17:32:45Z</time>
+				<extensions>
+					<speed>7.15324068069458</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015399751654058" lon="-84.2112730265268">
+				<ele>962.5607789475471</ele>
+				<time>2017-10-30T17:32:46Z</time>
+				<extensions>
+					<speed>6.914575576782227</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015340887534169" lon="-84.21126006731788">
+				<ele>961.8410871587694</ele>
+				<time>2017-10-30T17:32:47Z</time>
+				<extensions>
+					<speed>6.564971446990967</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015287245797293" lon="-84.21124767416536">
+				<ele>961.2917011119425</ele>
+				<time>2017-10-30T17:32:48Z</time>
+				<extensions>
+					<speed>5.929553985595703</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015242018382116" lon="-84.21123564796417">
+				<ele>961.1533098611981</ele>
+				<time>2017-10-30T17:32:49Z</time>
+				<extensions>
+					<speed>4.8646016120910645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015199353475673" lon="-84.21123219310951">
+				<ele>960.4402670720592</ele>
+				<time>2017-10-30T17:32:50Z</time>
+				<extensions>
+					<speed>5.1873698234558105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015153179211044" lon="-84.21121294346113">
+				<ele>960.3267876002938</ele>
+				<time>2017-10-30T17:32:51Z</time>
+				<extensions>
+					<speed>5.587438106536865</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015105223031147" lon="-84.21119465541102">
+				<ele>959.4555304804817</ele>
+				<time>2017-10-30T17:32:52Z</time>
+				<extensions>
+					<speed>5.963325023651123</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015048148148011" lon="-84.21116415631995">
+				<ele>958.2874418953434</ele>
+				<time>2017-10-30T17:32:53Z</time>
+				<extensions>
+					<speed>6.991241455078125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014983265958348" lon="-84.21112530755501">
+				<ele>956.4050859818235</ele>
+				<time>2017-10-30T17:32:54Z</time>
+				<extensions>
+					<speed>7.931206703186035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014912209971023" lon="-84.2110951260182">
+				<ele>955.0917765125632</ele>
+				<time>2017-10-30T17:32:55Z</time>
+				<extensions>
+					<speed>8.5382080078125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014837050397661" lon="-84.21106465921793">
+				<ele>954.759672020562</ele>
+				<time>2017-10-30T17:32:56Z</time>
+				<extensions>
+					<speed>8.749503135681152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014755547664867" lon="-84.21103353242442">
+				<ele>954.3690300919116</ele>
+				<time>2017-10-30T17:32:57Z</time>
+				<extensions>
+					<speed>9.231791496276855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014672815043895" lon="-84.21100171469554">
+				<ele>953.7236224962398</ele>
+				<time>2017-10-30T17:32:58Z</time>
+				<extensions>
+					<speed>9.001139640808105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01459352310775" lon="-84.21097471701832">
+				<ele>953.3180943150073</ele>
+				<time>2017-10-30T17:32:59Z</time>
+				<extensions>
+					<speed>8.84841537475586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01451729893581" lon="-84.21094109771163">
+				<ele>953.0668289819732</ele>
+				<time>2017-10-30T17:33:00Z</time>
+				<extensions>
+					<speed>8.785284996032715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014444676930681" lon="-84.21090424188942">
+				<ele>952.8419772544876</ele>
+				<time>2017-10-30T17:33:01Z</time>
+				<extensions>
+					<speed>8.51920223236084</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014372509216194" lon="-84.2108649969645">
+				<ele>953.1419243961573</ele>
+				<time>2017-10-30T17:33:02Z</time>
+				<extensions>
+					<speed>8.491086959838867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014297019363612" lon="-84.21082116338141">
+				<ele>953.3637457042933</ele>
+				<time>2017-10-30T17:33:03Z</time>
+				<extensions>
+					<speed>8.244954109191895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01422675119453" lon="-84.21077864022362">
+				<ele>953.5259256539866</ele>
+				<time>2017-10-30T17:33:04Z</time>
+				<extensions>
+					<speed>7.7534098625183105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014167252137062" lon="-84.21074576387338">
+				<ele>954.1720716478303</ele>
+				<time>2017-10-30T17:33:05Z</time>
+				<extensions>
+					<speed>7.049409866333008</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014114019749204" lon="-84.21071742627298">
+				<ele>954.5316552659497</ele>
+				<time>2017-10-30T17:33:06Z</time>
+				<extensions>
+					<speed>6.5233001708984375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014061235618462" lon="-84.21068887871708">
+				<ele>954.8037119898945</ele>
+				<time>2017-10-30T17:33:07Z</time>
+				<extensions>
+					<speed>6.582241058349609</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014008159963037" lon="-84.21065918509518">
+				<ele>954.6922561721876</ele>
+				<time>2017-10-30T17:33:08Z</time>
+				<extensions>
+					<speed>6.5107831954956055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013957569532693" lon="-84.21063163967034">
+				<ele>954.5976509321481</ele>
+				<time>2017-10-30T17:33:09Z</time>
+				<extensions>
+					<speed>6.308773517608643</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013912928523222" lon="-84.21061288083403">
+				<ele>954.1419212352484</ele>
+				<time>2017-10-30T17:33:10Z</time>
+				<extensions>
+					<speed>5.553754806518555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013860537202765" lon="-84.21059270048228">
+				<ele>953.9264122564346</ele>
+				<time>2017-10-30T17:33:11Z</time>
+				<extensions>
+					<speed>5.852496147155762</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013803811374272" lon="-84.21056975845084">
+				<ele>954.2744238954037</ele>
+				<time>2017-10-30T17:33:12Z</time>
+				<extensions>
+					<speed>5.999176502227783</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01375065694518" lon="-84.21054593801612">
+				<ele>954.2455524243414</ele>
+				<time>2017-10-30T17:33:13Z</time>
+				<extensions>
+					<speed>5.975582122802734</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013694520141726" lon="-84.21051921169229">
+				<ele>954.2863812763244</ele>
+				<time>2017-10-30T17:33:14Z</time>
+				<extensions>
+					<speed>6.3473052978515625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013638192784645" lon="-84.21049620077083">
+				<ele>954.6029372550547</ele>
+				<time>2017-10-30T17:33:15Z</time>
+				<extensions>
+					<speed>6.415174961090088</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013586976037937" lon="-84.21047193657463">
+				<ele>954.9773763678968</ele>
+				<time>2017-10-30T17:33:16Z</time>
+				<extensions>
+					<speed>5.979231834411621</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013537888294234" lon="-84.21044788628126">
+				<ele>954.762318010442</ele>
+				<time>2017-10-30T17:33:17Z</time>
+				<extensions>
+					<speed>5.597264289855957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013493521370712" lon="-84.2104288276696">
+				<ele>954.5653038350865</ele>
+				<time>2017-10-30T17:33:18Z</time>
+				<extensions>
+					<speed>4.9788360595703125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0134545039129" lon="-84.21041135865117">
+				<ele>954.3806588007137</ele>
+				<time>2017-10-30T17:33:19Z</time>
+				<extensions>
+					<speed>4.794855117797852</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013420137346854" lon="-84.21039900078334">
+				<ele>953.7570709809661</ele>
+				<time>2017-10-30T17:33:20Z</time>
+				<extensions>
+					<speed>3.7344725131988525</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013385149776" lon="-84.21038775063793">
+				<ele>953.5297110620886</ele>
+				<time>2017-10-30T17:33:21Z</time>
+				<extensions>
+					<speed>3.5414814949035645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013352799795664" lon="-84.21037664719098">
+				<ele>953.3891422608867</ele>
+				<time>2017-10-30T17:33:22Z</time>
+				<extensions>
+					<speed>3.1628806591033936</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013326627797907" lon="-84.21036443534751">
+				<ele>953.3294854024425</ele>
+				<time>2017-10-30T17:33:23Z</time>
+				<extensions>
+					<speed>2.5727968215942383</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013303194713473" lon="-84.21035452302503">
+				<ele>953.4252212001011</ele>
+				<time>2017-10-30T17:33:24Z</time>
+				<extensions>
+					<speed>2.3231756687164307</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01329927836741" lon="-84.21035293436898">
+				<ele>953.4348993366584</ele>
+				<time>2017-10-30T17:33:25Z</time>
+				<extensions>
+					<speed>0.47889864444732666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:33:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013297876193965" lon="-84.21034977221625">
+				<ele>953.4434325164184</ele>
+				<time>2017-10-30T17:34:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013291143249383" lon="-84.21034462123944">
+				<ele>953.6801510965452</ele>
+				<time>2017-10-30T17:34:26Z</time>
+				<extensions>
+					<speed>0.6525558233261108</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013274137459055" lon="-84.21034096783943">
+				<ele>953.5074878167361</ele>
+				<time>2017-10-30T17:34:27Z</time>
+				<extensions>
+					<speed>1.6775604486465454</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013251210111989" lon="-84.21033047726492">
+				<ele>953.702947053127</ele>
+				<time>2017-10-30T17:34:28Z</time>
+				<extensions>
+					<speed>2.9992504119873047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013214474291726" lon="-84.21031758297352">
+				<ele>953.5770531883463</ele>
+				<time>2017-10-30T17:34:29Z</time>
+				<extensions>
+					<speed>4.731523513793945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013165354741217" lon="-84.21030114254916">
+				<ele>953.4191835746169</ele>
+				<time>2017-10-30T17:34:30Z</time>
+				<extensions>
+					<speed>5.9605631828308105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01310699887146" lon="-84.21028077473645">
+				<ele>953.2803815258667</ele>
+				<time>2017-10-30T17:34:31Z</time>
+				<extensions>
+					<speed>6.710526466369629</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01304310888731" lon="-84.2102585435019">
+				<ele>953.1303400062025</ele>
+				<time>2017-10-30T17:34:32Z</time>
+				<extensions>
+					<speed>7.211557865142822</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012981086974511" lon="-84.21023535919566">
+				<ele>952.956795453094</ele>
+				<time>2017-10-30T17:34:33Z</time>
+				<extensions>
+					<speed>6.8526530265808105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292344242925" lon="-84.21021023605284">
+				<ele>953.0202365051955</ele>
+				<time>2017-10-30T17:34:34Z</time>
+				<extensions>
+					<speed>6.608912944793701</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012866730240503" lon="-84.21018326270952">
+				<ele>952.9786544181406</ele>
+				<time>2017-10-30T17:34:35Z</time>
+				<extensions>
+					<speed>6.468179702758789</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012813711384466" lon="-84.21015394386335">
+				<ele>953.3900566315278</ele>
+				<time>2017-10-30T17:34:36Z</time>
+				<extensions>
+					<speed>6.501149654388428</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012763840155563" lon="-84.21012630784817">
+				<ele>953.5893411338329</ele>
+				<time>2017-10-30T17:34:37Z</time>
+				<extensions>
+					<speed>6.170321941375732</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012718374151591" lon="-84.21010795919574">
+				<ele>953.5665745129809</ele>
+				<time>2017-10-30T17:34:38Z</time>
+				<extensions>
+					<speed>4.928531646728516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012681246459774" lon="-84.21009903236236">
+				<ele>953.5298938592896</ele>
+				<time>2017-10-30T17:34:39Z</time>
+				<extensions>
+					<speed>3.705981731414795</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012654566748509" lon="-84.21009693215626">
+				<ele>953.3547436054796</ele>
+				<time>2017-10-30T17:34:40Z</time>
+				<extensions>
+					<speed>2.4388561248779297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012639165858852" lon="-84.21010025948692">
+				<ele>953.2864799546078</ele>
+				<time>2017-10-30T17:34:41Z</time>
+				<extensions>
+					<speed>1.299776315689087</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012627138983895" lon="-84.21010990924105">
+				<ele>952.994835539721</ele>
+				<time>2017-10-30T17:34:42Z</time>
+				<extensions>
+					<speed>1.5253522396087646</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012621803381967" lon="-84.21013100203908">
+				<ele>952.8085012836382</ele>
+				<time>2017-10-30T17:34:43Z</time>
+				<extensions>
+					<speed>2.4310972690582275</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012613759562619" lon="-84.21015827350575">
+				<ele>952.7074290616438</ele>
+				<time>2017-10-30T17:34:44Z</time>
+				<extensions>
+					<speed>3.216742992401123</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012591413502964" lon="-84.21019601187459">
+				<ele>951.8942361883819</ele>
+				<time>2017-10-30T17:34:45Z</time>
+				<extensions>
+					<speed>4.1455912590026855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012575185644565" lon="-84.21023825513366">
+				<ele>951.908513606526</ele>
+				<time>2017-10-30T17:34:46Z</time>
+				<extensions>
+					<speed>5.240303039550781</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012558761576038" lon="-84.21029071997336">
+				<ele>951.7198715750128</ele>
+				<time>2017-10-30T17:34:47Z</time>
+				<extensions>
+					<speed>6.109813690185547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0125387851493" lon="-84.21035215082979">
+				<ele>951.4847993431613</ele>
+				<time>2017-10-30T17:34:48Z</time>
+				<extensions>
+					<speed>7.02473258972168</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012522341812243" lon="-84.21042216877778">
+				<ele>951.3437537336722</ele>
+				<time>2017-10-30T17:34:49Z</time>
+				<extensions>
+					<speed>7.926008224487305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012504571439774" lon="-84.21049455884837">
+				<ele>951.4036816721782</ele>
+				<time>2017-10-30T17:34:50Z</time>
+				<extensions>
+					<speed>8.306245803833008</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01248648405677" lon="-84.21056889174825">
+				<ele>951.2773150317371</ele>
+				<time>2017-10-30T17:34:51Z</time>
+				<extensions>
+					<speed>8.23989200592041</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012463165065826" lon="-84.21064961325186">
+				<ele>950.9943928029388</ele>
+				<time>2017-10-30T17:34:52Z</time>
+				<extensions>
+					<speed>9.05471420288086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012436108873633" lon="-84.21073493599876">
+				<ele>950.5781294209883</ele>
+				<time>2017-10-30T17:34:53Z</time>
+				<extensions>
+					<speed>9.66000747680664</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0124075194974" lon="-84.21081244095879">
+				<ele>950.1729290056974</ele>
+				<time>2017-10-30T17:34:54Z</time>
+				<extensions>
+					<speed>8.959900856018066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012375806726158" lon="-84.21089073815178">
+				<ele>950.0637621488422</ele>
+				<time>2017-10-30T17:34:55Z</time>
+				<extensions>
+					<speed>9.06908893585205</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012341823690535" lon="-84.21096856358422">
+				<ele>950.0560398232192</ele>
+				<time>2017-10-30T17:34:56Z</time>
+				<extensions>
+					<speed>8.968435287475586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012304711334414" lon="-84.21105373963327">
+				<ele>949.5633266652003</ele>
+				<time>2017-10-30T17:34:57Z</time>
+				<extensions>
+					<speed>9.36125373840332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012272262235907" lon="-84.2111467310893">
+				<ele>949.0548414476216</ele>
+				<time>2017-10-30T17:34:58Z</time>
+				<extensions>
+					<speed>10.053906440734863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0122392900993" lon="-84.21123910704236">
+				<ele>948.4911378249526</ele>
+				<time>2017-10-30T17:34:59Z</time>
+				<extensions>
+					<speed>9.905454635620117</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01220973339513" lon="-84.21133015946468">
+				<ele>948.0205404134467</ele>
+				<time>2017-10-30T17:35:00Z</time>
+				<extensions>
+					<speed>9.97010612487793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012182764579238" lon="-84.21141157965124">
+				<ele>947.536579539068</ele>
+				<time>2017-10-30T17:35:01Z</time>
+				<extensions>
+					<speed>9.187000274658203</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012163474021968" lon="-84.21148089223298">
+				<ele>947.3847367428243</ele>
+				<time>2017-10-30T17:35:02Z</time>
+				<extensions>
+					<speed>7.952410697937012</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012147956814719" lon="-84.21153606953816">
+				<ele>947.2279836041853</ele>
+				<time>2017-10-30T17:35:03Z</time>
+				<extensions>
+					<speed>6.07991361618042</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012138592476754" lon="-84.21157543422088">
+				<ele>946.9500710815191</ele>
+				<time>2017-10-30T17:35:04Z</time>
+				<extensions>
+					<speed>4.418885231018066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01214264054486" lon="-84.2115907733918">
+				<ele>946.6677530985326</ele>
+				<time>2017-10-30T17:35:05Z</time>
+				<extensions>
+					<speed>1.6095683574676514</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012151103462028" lon="-84.21159093408188">
+				<ele>946.817814052105</ele>
+				<time>2017-10-30T17:35:06Z</time>
+				<extensions>
+					<speed>0.5314865708351135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012159286330142" lon="-84.21158484701562">
+				<ele>947.680286500603</ele>
+				<time>2017-10-30T17:35:07Z</time>
+				<extensions>
+					<speed>0.9966251850128174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012159286330142" lon="-84.21158484701562">
+				<ele>947.680286500603</ele>
+				<time>2017-10-30T17:35:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012165267289056" lon="-84.21157816440667">
+				<ele>948.1678555076942</ele>
+				<time>2017-10-30T17:35:09Z</time>
+				<extensions>
+					<speed>0.9357127547264099</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012165267289056" lon="-84.21157816440667">
+				<ele>948.1678555076942</ele>
+				<time>2017-10-30T17:35:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012170828273751" lon="-84.2115723169906">
+				<ele>948.384052102454</ele>
+				<time>2017-10-30T17:35:11Z</time>
+				<extensions>
+					<speed>0.8088045716285706</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012170828273751" lon="-84.2115723169906">
+				<ele>948.384052102454</ele>
+				<time>2017-10-30T17:35:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:13Z</time>
+				<extensions>
+					<speed>0.10537495464086533</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217173198359" lon="-84.21157374081811">
+				<ele>948.5155606754124</ele>
+				<time>2017-10-30T17:35:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012170596460248" lon="-84.21158968409583">
+				<ele>948.6148489257321</ele>
+				<time>2017-10-30T17:35:48Z</time>
+				<extensions>
+					<speed>0.9096311926841736</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01216003322142" lon="-84.21161963457499">
+				<ele>948.9617109792307</ele>
+				<time>2017-10-30T17:35:49Z</time>
+				<extensions>
+					<speed>2.2340242862701416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01214560964665" lon="-84.21165593828623">
+				<ele>949.46711502783</ele>
+				<time>2017-10-30T17:35:50Z</time>
+				<extensions>
+					<speed>3.713230609893799</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01213222993029" lon="-84.21169945227166">
+				<ele>949.9234100244939</ele>
+				<time>2017-10-30T17:35:51Z</time>
+				<extensions>
+					<speed>4.667441368103027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012117677302852" lon="-84.21174437337727">
+				<ele>950.247918093577</ele>
+				<time>2017-10-30T17:35:52Z</time>
+				<extensions>
+					<speed>4.875479698181152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012102638147386" lon="-84.21179077495101">
+				<ele>950.7427039118484</ele>
+				<time>2017-10-30T17:35:53Z</time>
+				<extensions>
+					<speed>5.066469192504883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01209120984766" lon="-84.21183855428558">
+				<ele>951.2229443984106</ele>
+				<time>2017-10-30T17:35:54Z</time>
+				<extensions>
+					<speed>5.158254623413086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012073778856792" lon="-84.21188947438776">
+				<ele>951.9580619083717</ele>
+				<time>2017-10-30T17:35:55Z</time>
+				<extensions>
+					<speed>5.365009307861328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01205443339351" lon="-84.21193888931447">
+				<ele>952.9659054260701</ele>
+				<time>2017-10-30T17:35:56Z</time>
+				<extensions>
+					<speed>5.407834053039551</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012045531614003" lon="-84.2119860407918">
+				<ele>953.6811184510589</ele>
+				<time>2017-10-30T17:35:57Z</time>
+				<extensions>
+					<speed>5.332517623901367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01204348609933" lon="-84.21201720895989">
+				<ele>954.0635635713115</ele>
+				<time>2017-10-30T17:35:58Z</time>
+				<extensions>
+					<speed>4.719027996063232</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012043807968505" lon="-84.2120476812271">
+				<ele>954.0965398130938</ele>
+				<time>2017-10-30T17:35:59Z</time>
+				<extensions>
+					<speed>4.209567546844482</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012029288493302" lon="-84.21208387811784">
+				<ele>954.0476300213486</ele>
+				<time>2017-10-30T17:36:00Z</time>
+				<extensions>
+					<speed>3.812281847000122</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012020940168691" lon="-84.21211410975826">
+				<ele>953.8792898980901</ele>
+				<time>2017-10-30T17:36:01Z</time>
+				<extensions>
+					<speed>3.336752414703369</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012020098753629" lon="-84.21214101322975">
+				<ele>953.2934202766046</ele>
+				<time>2017-10-30T17:36:02Z</time>
+				<extensions>
+					<speed>3.089097738265991</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012017741743275" lon="-84.21216928591673">
+				<ele>953.2695788610727</ele>
+				<time>2017-10-30T17:36:03Z</time>
+				<extensions>
+					<speed>2.8318862915039063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012009809599084" lon="-84.21218945308068">
+				<ele>952.9996152110398</ele>
+				<time>2017-10-30T17:36:04Z</time>
+				<extensions>
+					<speed>2.4687864780426025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01199703974545" lon="-84.2122176437586">
+				<ele>952.4531395053491</ele>
+				<time>2017-10-30T17:36:05Z</time>
+				<extensions>
+					<speed>2.414245367050171</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011989912956901" lon="-84.21224504115476">
+				<ele>951.9974192529917</ele>
+				<time>2017-10-30T17:36:06Z</time>
+				<extensions>
+					<speed>2.143244981765747</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983411810006" lon="-84.21224920755553">
+				<ele>951.7858421374112</ele>
+				<time>2017-10-30T17:36:07Z</time>
+				<extensions>
+					<speed>1.1769423484802246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011983139521607" lon="-84.21224712852175">
+				<ele>951.6302206404507</ele>
+				<time>2017-10-30T17:36:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011982267913545" lon="-84.21225326023097">
+				<ele>950.8196331560612</ele>
+				<time>2017-10-30T17:36:54Z</time>
+				<extensions>
+					<speed>0.6242920160293579</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011982087313259" lon="-84.21226069733746">
+				<ele>950.4908959111199</ele>
+				<time>2017-10-30T17:36:55Z</time>
+				<extensions>
+					<speed>0.6671720743179321</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011980844756945" lon="-84.21226814153773">
+				<ele>950.2690934743732</ele>
+				<time>2017-10-30T17:36:56Z</time>
+				<extensions>
+					<speed>0.6825861930847168</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011979593729322" lon="-84.21227592572303">
+				<ele>950.2582516800612</ele>
+				<time>2017-10-30T17:36:57Z</time>
+				<extensions>
+					<speed>0.691676139831543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011977238559613" lon="-84.21228847372095">
+				<ele>950.2913530934602</ele>
+				<time>2017-10-30T17:36:58Z</time>
+				<extensions>
+					<speed>1.0878558158874512</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011971255836384" lon="-84.21230527923414">
+				<ele>950.3481133999303</ele>
+				<time>2017-10-30T17:36:59Z</time>
+				<extensions>
+					<speed>1.5617326498031616</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011963670034413" lon="-84.21232424421633">
+				<ele>950.7499895012006</ele>
+				<time>2017-10-30T17:37:00Z</time>
+				<extensions>
+					<speed>2.073343276977539</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011955392043737" lon="-84.21235459758124">
+				<ele>951.2245825435966</ele>
+				<time>2017-10-30T17:37:01Z</time>
+				<extensions>
+					<speed>2.908557891845703</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011945174230572" lon="-84.21238886109091">
+				<ele>951.6316152680665</ele>
+				<time>2017-10-30T17:37:02Z</time>
+				<extensions>
+					<speed>3.819408655166626</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011933168488087" lon="-84.2124300852819">
+				<ele>952.0922633558512</ele>
+				<time>2017-10-30T17:37:03Z</time>
+				<extensions>
+					<speed>4.67063045501709</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011921774416438" lon="-84.21248022299098">
+				<ele>952.581277994439</ele>
+				<time>2017-10-30T17:37:04Z</time>
+				<extensions>
+					<speed>5.080204963684082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011908282239334" lon="-84.21252871645369">
+				<ele>952.5399897452444</ele>
+				<time>2017-10-30T17:37:05Z</time>
+				<extensions>
+					<speed>5.156472682952881</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01189493779425" lon="-84.2125779770902">
+				<ele>952.5059917317703</ele>
+				<time>2017-10-30T17:37:06Z</time>
+				<extensions>
+					<speed>5.264009952545166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011882534074719" lon="-84.21262666787236">
+				<ele>952.3758025690913</ele>
+				<time>2017-10-30T17:37:07Z</time>
+				<extensions>
+					<speed>4.988501071929932</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011873091360258" lon="-84.21267071997643">
+				<ele>952.4786484437063</ele>
+				<time>2017-10-30T17:37:08Z</time>
+				<extensions>
+					<speed>4.172617435455322</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011865239763015" lon="-84.2127041846367">
+				<ele>952.140163433738</ele>
+				<time>2017-10-30T17:37:09Z</time>
+				<extensions>
+					<speed>2.86883282661438</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011857218197424" lon="-84.21272878234973">
+				<ele>951.8912734379992</ele>
+				<time>2017-10-30T17:37:10Z</time>
+				<extensions>
+					<speed>2.3653857707977295</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011854951317105" lon="-84.21274674506978">
+				<ele>951.8576954714954</ele>
+				<time>2017-10-30T17:37:11Z</time>
+				<extensions>
+					<speed>1.7470707893371582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01185525733751" lon="-84.2127580244511">
+				<ele>951.7978818584234</ele>
+				<time>2017-10-30T17:37:12Z</time>
+				<extensions>
+					<speed>1.280753254890442</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01185674962504" lon="-84.21274820900948">
+				<ele>952.1834770822898</ele>
+				<time>2017-10-30T17:37:13Z</time>
+				<extensions>
+					<speed>0.47315287590026855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01185674962504" lon="-84.21274820900948">
+				<ele>952.1834770822898</ele>
+				<time>2017-10-30T17:37:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0118564581967" lon="-84.21274136646787">
+				<ele>952.0673976866528</ele>
+				<time>2017-10-30T17:37:15Z</time>
+				<extensions>
+					<speed>1.0944654941558838</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011858675889588" lon="-84.21273577057379">
+				<ele>952.2262716833502</ele>
+				<time>2017-10-30T17:37:16Z</time>
+				<extensions>
+					<speed>1.2029253244400024</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861374257782" lon="-84.2127315703869">
+				<ele>952.3563982425258</ele>
+				<time>2017-10-30T17:37:17Z</time>
+				<extensions>
+					<speed>1.160386085510254</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011863306697247" lon="-84.2127276352089">
+				<ele>952.5206935871392</ele>
+				<time>2017-10-30T17:37:18Z</time>
+				<extensions>
+					<speed>0.8748312592506409</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011863306697247" lon="-84.2127276352089">
+				<ele>952.5206935871392</ele>
+				<time>2017-10-30T17:37:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:37:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:38:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:38:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:38:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:38:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:38:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:38:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861671332515" lon="-84.21272864731075">
+				<ele>952.6573403216898</ele>
+				<time>2017-10-30T17:38:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011861589562523" lon="-84.21273663108396">
+				<ele>952.3932915804908</ele>
+				<time>2017-10-30T17:38:07Z</time>
+				<extensions>
+					<speed>1.018762230873108</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01185790307151" lon="-84.21275051470191">
+				<ele>952.2174707725644</ele>
+				<time>2017-10-30T17:38:08Z</time>
+				<extensions>
+					<speed>1.831859827041626</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01185046063448" lon="-84.21277019575635">
+				<ele>952.2293430855498</ele>
+				<time>2017-10-30T17:38:09Z</time>
+				<extensions>
+					<speed>2.467425584793091</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011839846789526" lon="-84.21279957136328">
+				<ele>952.4246007539332</ele>
+				<time>2017-10-30T17:38:10Z</time>
+				<extensions>
+					<speed>3.629500389099121</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011824583210181" lon="-84.21284322940956">
+				<ele>952.4715021587908</ele>
+				<time>2017-10-30T17:38:11Z</time>
+				<extensions>
+					<speed>5.519672870635986</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011809105220523" lon="-84.21290023710985">
+				<ele>952.420296151191</ele>
+				<time>2017-10-30T17:38:12Z</time>
+				<extensions>
+					<speed>6.870045185089111</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011790875113519" lon="-84.21296550577541">
+				<ele>952.3348224079236</ele>
+				<time>2017-10-30T17:38:13Z</time>
+				<extensions>
+					<speed>7.436677932739258</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01177225028818" lon="-84.21303467702552">
+				<ele>952.232119220309</ele>
+				<time>2017-10-30T17:38:14Z</time>
+				<extensions>
+					<speed>7.557867527008057</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01175162786731" lon="-84.21310512856688">
+				<ele>952.1161506371573</ele>
+				<time>2017-10-30T17:38:15Z</time>
+				<extensions>
+					<speed>7.677318572998047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011728978511231" lon="-84.21318047283157">
+				<ele>951.7021002704278</ele>
+				<time>2017-10-30T17:38:16Z</time>
+				<extensions>
+					<speed>7.942063331604004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011707862158149" lon="-84.21325235486485">
+				<ele>951.29610855598</ele>
+				<time>2017-10-30T17:38:17Z</time>
+				<extensions>
+					<speed>7.671475410461426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01169001885034" lon="-84.21332208768293">
+				<ele>951.2092683697119</ele>
+				<time>2017-10-30T17:38:18Z</time>
+				<extensions>
+					<speed>7.1713409423828125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011675877188814" lon="-84.2133838182243">
+				<ele>951.3216413278133</ele>
+				<time>2017-10-30T17:38:19Z</time>
+				<extensions>
+					<speed>6.249430179595947</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011661283111627" lon="-84.21343721234234">
+				<ele>951.6755132088438</ele>
+				<time>2017-10-30T17:38:20Z</time>
+				<extensions>
+					<speed>5.696444511413574</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011648985638708" lon="-84.21348558620272">
+				<ele>951.9442529566586</ele>
+				<time>2017-10-30T17:38:21Z</time>
+				<extensions>
+					<speed>5.224515438079834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011639400973714" lon="-84.21351665090009">
+				<ele>952.0465715872124</ele>
+				<time>2017-10-30T17:38:22Z</time>
+				<extensions>
+					<speed>3.3680381774902344</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011631657692803" lon="-84.21353831588817">
+				<ele>952.4744555409998</ele>
+				<time>2017-10-30T17:38:23Z</time>
+				<extensions>
+					<speed>1.6640485525131226</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01162947641111" lon="-84.21354728474203">
+				<ele>952.443873308599</ele>
+				<time>2017-10-30T17:38:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011629849692348" lon="-84.21354738485353">
+				<ele>952.3547668838874</ele>
+				<time>2017-10-30T17:38:25Z</time>
+				<extensions>
+					<speed>0.5600793957710266</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011629849692348" lon="-84.21354738485353">
+				<ele>952.3547668838874</ele>
+				<time>2017-10-30T17:38:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011632548637161" lon="-84.21353853228841">
+				<ele>952.4293363299221</ele>
+				<time>2017-10-30T17:38:27Z</time>
+				<extensions>
+					<speed>1.239565134048462</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011634267163092" lon="-84.21352700302285">
+				<ele>952.389700406231</ele>
+				<time>2017-10-30T17:38:28Z</time>
+				<extensions>
+					<speed>1.3887556791305542</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011634656508717" lon="-84.21351430992816">
+				<ele>952.4574978565797</ele>
+				<time>2017-10-30T17:38:29Z</time>
+				<extensions>
+					<speed>1.3580150604248047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01163663197769" lon="-84.21349993496038">
+				<ele>952.4593901345506</ele>
+				<time>2017-10-30T17:38:30Z</time>
+				<extensions>
+					<speed>1.6743443012237549</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011642258695696" lon="-84.21348705040428">
+				<ele>952.5422176551074</ele>
+				<time>2017-10-30T17:38:31Z</time>
+				<extensions>
+					<speed>1.4737014770507813</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011646788126427" lon="-84.2134728594234">
+				<ele>952.7513779699802</ele>
+				<time>2017-10-30T17:38:32Z</time>
+				<extensions>
+					<speed>1.4571897983551025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011647498718954" lon="-84.2134618328921">
+				<ele>952.7579563101754</ele>
+				<time>2017-10-30T17:38:33Z</time>
+				<extensions>
+					<speed>1.2553972005844116</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011651449184498" lon="-84.2134568462453">
+				<ele>953.0089061055332</ele>
+				<time>2017-10-30T17:38:34Z</time>
+				<extensions>
+					<speed>0.7908940315246582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011651449184498" lon="-84.2134568462453">
+				<ele>953.0089061055332</ele>
+				<time>2017-10-30T17:38:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011650121062871" lon="-84.21346017883621">
+				<ele>953.0707786912099</ele>
+				<time>2017-10-30T17:38:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011650121062871" lon="-84.21346017883621">
+				<ele>953.0707786912099</ele>
+				<time>2017-10-30T17:38:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011650121062871" lon="-84.21346017883621">
+				<ele>953.0707786912099</ele>
+				<time>2017-10-30T17:38:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011650121062871" lon="-84.21346017883621">
+				<ele>953.0707786912099</ele>
+				<time>2017-10-30T17:38:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011650121062871" lon="-84.21346017883621">
+				<ele>953.0707786912099</ele>
+				<time>2017-10-30T17:38:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011650121062871" lon="-84.21346017883621">
+				<ele>953.0707786912099</ele>
+				<time>2017-10-30T17:38:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011647312437207" lon="-84.2134677715003">
+				<ele>952.925850036554</ele>
+				<time>2017-10-30T17:38:42Z</time>
+				<extensions>
+					<speed>0.7432575821876526</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011641521566775" lon="-84.21348009681223">
+				<ele>953.147134328261</ele>
+				<time>2017-10-30T17:38:43Z</time>
+				<extensions>
+					<speed>1.3574466705322266</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0116370483115" lon="-84.21349699420121">
+				<ele>953.2890723459423</ele>
+				<time>2017-10-30T17:38:44Z</time>
+				<extensions>
+					<speed>1.8232409954071045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011635115159482" lon="-84.21351932972847">
+				<ele>952.7565537532791</ele>
+				<time>2017-10-30T17:38:45Z</time>
+				<extensions>
+					<speed>2.0358846187591553</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011630653532956" lon="-84.21355333785988">
+				<ele>952.3421473326162</ele>
+				<time>2017-10-30T17:38:46Z</time>
+				<extensions>
+					<speed>3.113973617553711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011623799815387" lon="-84.21359049446306">
+				<ele>952.4224621197209</ele>
+				<time>2017-10-30T17:38:47Z</time>
+				<extensions>
+					<speed>4.193800926208496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011610047758023" lon="-84.21363175520611">
+				<ele>952.2443669037893</ele>
+				<time>2017-10-30T17:38:48Z</time>
+				<extensions>
+					<speed>4.32907772064209</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01158767532248" lon="-84.21366979139835">
+				<ele>952.1100710071623</ele>
+				<time>2017-10-30T17:38:49Z</time>
+				<extensions>
+					<speed>4.545158863067627</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011557268510048" lon="-84.21370250727732">
+				<ele>951.7304249871522</ele>
+				<time>2017-10-30T17:38:50Z</time>
+				<extensions>
+					<speed>5.065746784210205</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011519410621077" lon="-84.21372833249646">
+				<ele>951.6817218884826</ele>
+				<time>2017-10-30T17:38:51Z</time>
+				<extensions>
+					<speed>4.548271656036377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011480518647335" lon="-84.21376408856705">
+				<ele>950.4563741721213</ele>
+				<time>2017-10-30T17:38:52Z</time>
+				<extensions>
+					<speed>5.083932876586914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011432358982095" lon="-84.21376468900422">
+				<ele>949.82169118803</ele>
+				<time>2017-10-30T17:38:53Z</time>
+				<extensions>
+					<speed>6.144292831420898</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011375979738592" lon="-84.2137408463903">
+				<ele>949.3368373960257</ele>
+				<time>2017-10-30T17:38:54Z</time>
+				<extensions>
+					<speed>6.837465286254883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011317810988048" lon="-84.21371113760846">
+				<ele>948.8870778726414</ele>
+				<time>2017-10-30T17:38:55Z</time>
+				<extensions>
+					<speed>7.008713245391846</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011255884590891" lon="-84.21368255877204">
+				<ele>948.5973506234586</ele>
+				<time>2017-10-30T17:38:56Z</time>
+				<extensions>
+					<speed>7.532181262969971</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011185775176607" lon="-84.21364927010562">
+				<ele>948.4135071542114</ele>
+				<time>2017-10-30T17:38:57Z</time>
+				<extensions>
+					<speed>8.183087348937988</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011113696547678" lon="-84.21361759677136">
+				<ele>948.5275454381481</ele>
+				<time>2017-10-30T17:38:58Z</time>
+				<extensions>
+					<speed>8.694354057312012</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011040167093695" lon="-84.21358944173814">
+				<ele>948.411601065658</ele>
+				<time>2017-10-30T17:38:59Z</time>
+				<extensions>
+					<speed>8.717795372009277</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010966364370397" lon="-84.21356290468471">
+				<ele>948.5853197621182</ele>
+				<time>2017-10-30T17:39:00Z</time>
+				<extensions>
+					<speed>8.7070951461792</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010895073480052" lon="-84.21353642290117">
+				<ele>948.8187793130055</ele>
+				<time>2017-10-30T17:39:01Z</time>
+				<extensions>
+					<speed>8.232123374938965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010827760998028" lon="-84.21351198879847">
+				<ele>948.9439439726993</ele>
+				<time>2017-10-30T17:39:02Z</time>
+				<extensions>
+					<speed>7.659761905670166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010764391247402" lon="-84.21348877054963">
+				<ele>948.9433116139844</ele>
+				<time>2017-10-30T17:39:03Z</time>
+				<extensions>
+					<speed>7.369534492492676</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01070145852543" lon="-84.2134671649812">
+				<ele>948.8736016750336</ele>
+				<time>2017-10-30T17:39:04Z</time>
+				<extensions>
+					<speed>7.235074996948242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010641716151325" lon="-84.21344900046756">
+				<ele>948.8725446043536</ele>
+				<time>2017-10-30T17:39:05Z</time>
+				<extensions>
+					<speed>6.590816974639893</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01058622887916" lon="-84.2134366185152">
+				<ele>948.7865382442251</ele>
+				<time>2017-10-30T17:39:06Z</time>
+				<extensions>
+					<speed>5.7368903160095215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010537902974864" lon="-84.21342515870901">
+				<ele>948.6528120040894</ele>
+				<time>2017-10-30T17:39:07Z</time>
+				<extensions>
+					<speed>5.021141052246094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010495084333954" lon="-84.21341314774881">
+				<ele>948.4964182926342</ele>
+				<time>2017-10-30T17:39:08Z</time>
+				<extensions>
+					<speed>4.6467413902282715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010457421031997" lon="-84.21340367958716">
+				<ele>948.2713113958016</ele>
+				<time>2017-10-30T17:39:09Z</time>
+				<extensions>
+					<speed>4.057497501373291</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010421757977282" lon="-84.2133911561232">
+				<ele>948.1099749440327</ele>
+				<time>2017-10-30T17:39:10Z</time>
+				<extensions>
+					<speed>3.93953013420105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010388535866834" lon="-84.21337681479257">
+				<ele>948.0937171280384</ele>
+				<time>2017-10-30T17:39:11Z</time>
+				<extensions>
+					<speed>3.8317689895629883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010359268327809" lon="-84.21336163810182">
+				<ele>948.0042102495208</ele>
+				<time>2017-10-30T17:39:12Z</time>
+				<extensions>
+					<speed>3.6816842555999756</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01033334897457" lon="-84.21334766193867">
+				<ele>947.8724409071729</ele>
+				<time>2017-10-30T17:39:13Z</time>
+				<extensions>
+					<speed>3.406355381011963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010309703703964" lon="-84.21333329397932">
+				<ele>947.8208974273875</ele>
+				<time>2017-10-30T17:39:14Z</time>
+				<extensions>
+					<speed>3.240084648132324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010286258399269" lon="-84.21332132304002">
+				<ele>947.9258119035512</ele>
+				<time>2017-10-30T17:39:15Z</time>
+				<extensions>
+					<speed>3.0326879024505615</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010263654237354" lon="-84.21330120856123">
+				<ele>948.0124164866284</ele>
+				<time>2017-10-30T17:39:16Z</time>
+				<extensions>
+					<speed>3.0034799575805664</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010291162422" lon="-84.21331237461321">
+				<ele>947.7364142695442</ele>
+				<time>2017-10-30T17:39:17Z</time>
+				<extensions>
+					<speed>1.7076112031936646</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010308523020475" lon="-84.21327043215983">
+				<ele>947.6610427759588</ele>
+				<time>2017-10-30T17:39:18Z</time>
+				<extensions>
+					<speed>3.2008724212646484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010314870773032" lon="-84.21322149117161">
+				<ele>948.5371734574437</ele>
+				<time>2017-10-30T17:39:19Z</time>
+				<extensions>
+					<speed>3.905039072036743</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01029893248708" lon="-84.21316808744521">
+				<ele>949.3353060930967</ele>
+				<time>2017-10-30T17:39:20Z</time>
+				<extensions>
+					<speed>3.8858113288879395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01029372294141" lon="-84.21311703052906">
+				<ele>950.2755625527352</ele>
+				<time>2017-10-30T17:39:21Z</time>
+				<extensions>
+					<speed>4.1150007247924805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010285583365949" lon="-84.21307056679414">
+				<ele>950.7913123359904</ele>
+				<time>2017-10-30T17:39:22Z</time>
+				<extensions>
+					<speed>4.374819755554199</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010268913670668" lon="-84.21303350539732">
+				<ele>950.9065899224952</ele>
+				<time>2017-10-30T17:39:23Z</time>
+				<extensions>
+					<speed>4.242544174194336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01024159140257" lon="-84.2129900865175">
+				<ele>950.8762510400265</ele>
+				<time>2017-10-30T17:39:24Z</time>
+				<extensions>
+					<speed>4.241811752319336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010205824970203" lon="-84.21293883623574">
+				<ele>950.5714835170656</ele>
+				<time>2017-10-30T17:39:25Z</time>
+				<extensions>
+					<speed>4.364444255828857</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010171920420188" lon="-84.2129066387702">
+				<ele>950.7432387527078</ele>
+				<time>2017-10-30T17:39:26Z</time>
+				<extensions>
+					<speed>4.319271564483643</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010138006337787" lon="-84.21287615445769">
+				<ele>950.8341173445806</ele>
+				<time>2017-10-30T17:39:27Z</time>
+				<extensions>
+					<speed>4.9056572914123535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010106263463975" lon="-84.21284384792186">
+				<ele>950.5638793604448</ele>
+				<time>2017-10-30T17:39:28Z</time>
+				<extensions>
+					<speed>4.749321460723877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010075007897436" lon="-84.21281376459868">
+				<ele>950.7375685237348</ele>
+				<time>2017-10-30T17:39:29Z</time>
+				<extensions>
+					<speed>4.6470417976379395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010044660524816" lon="-84.21278631378033">
+				<ele>950.6505897706375</ele>
+				<time>2017-10-30T17:39:30Z</time>
+				<extensions>
+					<speed>4.491366386413574</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010013880077713" lon="-84.21275482012531">
+				<ele>950.8972472818568</ele>
+				<time>2017-10-30T17:39:31Z</time>
+				<extensions>
+					<speed>4.506460666656494</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009978870150015" lon="-84.2127183158428">
+				<ele>950.6984428204596</ele>
+				<time>2017-10-30T17:39:32Z</time>
+				<extensions>
+					<speed>4.815766334533691</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009945416195974" lon="-84.21268653496789">
+				<ele>950.7949499003589</ele>
+				<time>2017-10-30T17:39:33Z</time>
+				<extensions>
+					<speed>4.498712062835693</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009910677926678" lon="-84.21265735274764">
+				<ele>950.8929111687467</ele>
+				<time>2017-10-30T17:39:34Z</time>
+				<extensions>
+					<speed>4.826241970062256</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00987713847707" lon="-84.21263023385536">
+				<ele>950.7684691883624</ele>
+				<time>2017-10-30T17:39:35Z</time>
+				<extensions>
+					<speed>4.428150177001953</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009847107718262" lon="-84.21260271153945">
+				<ele>950.4557638419792</ele>
+				<time>2017-10-30T17:39:36Z</time>
+				<extensions>
+					<speed>4.27940559387207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009817084759796" lon="-84.21257685126763">
+				<ele>950.3590964321047</ele>
+				<time>2017-10-30T17:39:37Z</time>
+				<extensions>
+					<speed>4.270312786102295</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009785350218017" lon="-84.21255114257966">
+				<ele>950.3030094830319</ele>
+				<time>2017-10-30T17:39:38Z</time>
+				<extensions>
+					<speed>4.553212642669678</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009756142682166" lon="-84.21252443855445">
+				<ele>950.2798150125891</ele>
+				<time>2017-10-30T17:39:39Z</time>
+				<extensions>
+					<speed>4.037542819976807</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009726406202297" lon="-84.2124944051163">
+				<ele>949.907350320369</ele>
+				<time>2017-10-30T17:39:40Z</time>
+				<extensions>
+					<speed>4.066473007202148</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009688550893049" lon="-84.21246321360658">
+				<ele>949.7075981544331</ele>
+				<time>2017-10-30T17:39:41Z</time>
+				<extensions>
+					<speed>5.226983547210693</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009647468966081" lon="-84.21243166752333">
+				<ele>949.5354384407401</ele>
+				<time>2017-10-30T17:39:42Z</time>
+				<extensions>
+					<speed>5.457361221313477</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009606568616373" lon="-84.21239889351574">
+				<ele>949.3842856353149</ele>
+				<time>2017-10-30T17:39:43Z</time>
+				<extensions>
+					<speed>5.545067310333252</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009567854850944" lon="-84.2123607436124">
+				<ele>948.8249460076913</ele>
+				<time>2017-10-30T17:39:44Z</time>
+				<extensions>
+					<speed>5.698044300079346</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009521660778395" lon="-84.21231532579655">
+				<ele>948.4084950871766</ele>
+				<time>2017-10-30T17:39:45Z</time>
+				<extensions>
+					<speed>6.552698612213135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009470278288363" lon="-84.21226854801503">
+				<ele>947.8035309286788</ele>
+				<time>2017-10-30T17:39:46Z</time>
+				<extensions>
+					<speed>7.231010913848877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009419235050514" lon="-84.2122223133249">
+				<ele>947.1907842289656</ele>
+				<time>2017-10-30T17:39:47Z</time>
+				<extensions>
+					<speed>6.978461265563965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009372064290226" lon="-84.2121808215384">
+				<ele>946.7386887762696</ele>
+				<time>2017-10-30T17:39:48Z</time>
+				<extensions>
+					<speed>6.657127857208252</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009328739156313" lon="-84.21214165668144">
+				<ele>946.4905561804771</ele>
+				<time>2017-10-30T17:39:49Z</time>
+				<extensions>
+					<speed>6.500765800476074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00928572326078" lon="-84.21210093532918">
+				<ele>946.0141682280228</ele>
+				<time>2017-10-30T17:39:50Z</time>
+				<extensions>
+					<speed>6.556740760803223</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009241322743483" lon="-84.21205941587995">
+				<ele>945.6643478041515</ele>
+				<time>2017-10-30T17:39:51Z</time>
+				<extensions>
+					<speed>6.769416809082031</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009192986266257" lon="-84.2120136859298">
+				<ele>945.3656765650958</ele>
+				<time>2017-10-30T17:39:52Z</time>
+				<extensions>
+					<speed>7.316298007965088</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009140320817082" lon="-84.2119639518801">
+				<ele>945.27950601466</ele>
+				<time>2017-10-30T17:39:53Z</time>
+				<extensions>
+					<speed>7.763355731964111</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009087379271339" lon="-84.21191476229744">
+				<ele>945.1710149012506</ele>
+				<time>2017-10-30T17:39:54Z</time>
+				<extensions>
+					<speed>7.8748602867126465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009035972958248" lon="-84.21186431108627">
+				<ele>944.8732205703855</ele>
+				<time>2017-10-30T17:39:55Z</time>
+				<extensions>
+					<speed>7.767143249511719</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009009166656815" lon="-84.21183298817205">
+				<ele>944.6808948088437</ele>
+				<time>2017-10-30T17:39:56Z</time>
+				<extensions>
+					<speed>6.036237716674805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008969652078454" lon="-84.21179428946492">
+				<ele>944.1432437980548</ele>
+				<time>2017-10-30T17:39:57Z</time>
+				<extensions>
+					<speed>5.248986721038818</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008928255436098" lon="-84.21176253231714">
+				<ele>942.8648158153519</ele>
+				<time>2017-10-30T17:39:58Z</time>
+				<extensions>
+					<speed>5.023959159851074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008907716162657" lon="-84.21172927819329">
+				<ele>942.9164811577648</ele>
+				<time>2017-10-30T17:39:59Z</time>
+				<extensions>
+					<speed>4.444039344787598</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008880112484245" lon="-84.21170152378052">
+				<ele>942.3147913618013</ele>
+				<time>2017-10-30T17:40:00Z</time>
+				<extensions>
+					<speed>4.380484580993652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008858253276781" lon="-84.2116696650586">
+				<ele>942.220455063507</ele>
+				<time>2017-10-30T17:40:01Z</time>
+				<extensions>
+					<speed>4.449169635772705</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008828737020398" lon="-84.21164611228454">
+				<ele>941.3625125102699</ele>
+				<time>2017-10-30T17:40:02Z</time>
+				<extensions>
+					<speed>4.348148345947266</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008805475092261" lon="-84.21161502328052">
+				<ele>940.8677226500586</ele>
+				<time>2017-10-30T17:40:03Z</time>
+				<extensions>
+					<speed>4.475865364074707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008783166124815" lon="-84.21157159306186">
+				<ele>940.5401180936024</ele>
+				<time>2017-10-30T17:40:04Z</time>
+				<extensions>
+					<speed>5.247325897216797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008761467785874" lon="-84.21152531110505">
+				<ele>940.1345979254693</ele>
+				<time>2017-10-30T17:40:05Z</time>
+				<extensions>
+					<speed>5.535281181335449</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008745109109642" lon="-84.21147279524763">
+				<ele>939.9264842821285</ele>
+				<time>2017-10-30T17:40:06Z</time>
+				<extensions>
+					<speed>5.967241287231445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008727624069131" lon="-84.21141617116419">
+				<ele>940.000115388073</ele>
+				<time>2017-10-30T17:40:07Z</time>
+				<extensions>
+					<speed>6.5864481925964355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008706160582927" lon="-84.21134774230907">
+				<ele>940.1520943492651</ele>
+				<time>2017-10-30T17:40:08Z</time>
+				<extensions>
+					<speed>7.9419732093811035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008684434736688" lon="-84.21126912878826">
+				<ele>940.2227566689253</ele>
+				<time>2017-10-30T17:40:09Z</time>
+				<extensions>
+					<speed>8.922798156738281</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008663105654188" lon="-84.2111801000749">
+				<ele>940.0317539833486</ele>
+				<time>2017-10-30T17:40:10Z</time>
+				<extensions>
+					<speed>9.978911399841309</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008648425084154" lon="-84.21108585528793">
+				<ele>939.7632530117407</ele>
+				<time>2017-10-30T17:40:11Z</time>
+				<extensions>
+					<speed>9.94288444519043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0086363987219" lon="-84.21099503321312">
+				<ele>939.5427410658449</ele>
+				<time>2017-10-30T17:40:12Z</time>
+				<extensions>
+					<speed>9.310321807861328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008630291106286" lon="-84.21091552988626">
+				<ele>939.2999544590712</ele>
+				<time>2017-10-30T17:40:13Z</time>
+				<extensions>
+					<speed>7.903048038482666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008629715680877" lon="-84.21084891033395">
+				<ele>939.1782693825662</ele>
+				<time>2017-10-30T17:40:14Z</time>
+				<extensions>
+					<speed>6.277403831481934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008629323137763" lon="-84.21079532383506">
+				<ele>939.5369945047423</ele>
+				<time>2017-10-30T17:40:15Z</time>
+				<extensions>
+					<speed>5.251226902008057</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008628646452168" lon="-84.21075095043577">
+				<ele>940.0242135124281</ele>
+				<time>2017-10-30T17:40:16Z</time>
+				<extensions>
+					<speed>4.090256690979004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00862838994758" lon="-84.21071190996557">
+				<ele>940.0386124467477</ele>
+				<time>2017-10-30T17:40:17Z</time>
+				<extensions>
+					<speed>3.7790307998657227</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008626324453674" lon="-84.21068715252069">
+				<ele>939.9127043215558</ele>
+				<time>2017-10-30T17:40:18Z</time>
+				<extensions>
+					<speed>2.257111072540283</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00862952176989" lon="-84.21068470514987">
+				<ele>940.1800776124</ele>
+				<time>2017-10-30T17:40:19Z</time>
+				<extensions>
+					<speed>0.6349813938140869</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00862920201456" lon="-84.210691633897">
+				<ele>940.3585498826578</ele>
+				<time>2017-10-30T17:40:20Z</time>
+				<extensions>
+					<speed>1.2686409950256348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008627776912528" lon="-84.21070098586543">
+				<ele>940.4852502634749</ele>
+				<time>2017-10-30T17:40:21Z</time>
+				<extensions>
+					<speed>1.401894450187683</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008623956570315" lon="-84.21070799252823">
+				<ele>940.5241670021787</ele>
+				<time>2017-10-30T17:40:22Z</time>
+				<extensions>
+					<speed>1.3386276960372925</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008621426858383" lon="-84.21071666753225">
+				<ele>940.4872935982421</ele>
+				<time>2017-10-30T17:40:23Z</time>
+				<extensions>
+					<speed>1.3336519002914429</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008618188281286" lon="-84.21072923647797">
+				<ele>940.5946525568143</ele>
+				<time>2017-10-30T17:40:24Z</time>
+				<extensions>
+					<speed>1.587506890296936</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008611748801801" lon="-84.21072515313475">
+				<ele>940.7236714381725</ele>
+				<time>2017-10-30T17:40:25Z</time>
+				<extensions>
+					<speed>0.8531442880630493</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008607955217254" lon="-84.21072102336834">
+				<ele>941.0115893576294</ele>
+				<time>2017-10-30T17:40:26Z</time>
+				<extensions>
+					<speed>0.3068065345287323</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008605133109578" lon="-84.21070611724622">
+				<ele>941.5972616979852</ele>
+				<time>2017-10-30T17:40:27Z</time>
+				<extensions>
+					<speed>1.9518803358078003</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008603652090402" lon="-84.21068046711812">
+				<ele>941.8267737152055</ele>
+				<time>2017-10-30T17:40:28Z</time>
+				<extensions>
+					<speed>3.504575490951538</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008600964335892" lon="-84.21064608987778">
+				<ele>941.8316214345396</ele>
+				<time>2017-10-30T17:40:29Z</time>
+				<extensions>
+					<speed>4.378602027893066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008598089861003" lon="-84.21060535338248">
+				<ele>941.6528964908794</ele>
+				<time>2017-10-30T17:40:30Z</time>
+				<extensions>
+					<speed>4.924635887145996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008594691942895" lon="-84.21055378291594">
+				<ele>941.630946546793</ele>
+				<time>2017-10-30T17:40:31Z</time>
+				<extensions>
+					<speed>5.516611099243164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008593963234384" lon="-84.2104904037631">
+				<ele>941.9916064944118</ele>
+				<time>2017-10-30T17:40:32Z</time>
+				<extensions>
+					<speed>6.691704273223877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008594079412058" lon="-84.21042159305185">
+				<ele>942.3153869425878</ele>
+				<time>2017-10-30T17:40:33Z</time>
+				<extensions>
+					<speed>7.046855926513672</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008594389812226" lon="-84.21035108894031">
+				<ele>941.9870043927804</ele>
+				<time>2017-10-30T17:40:34Z</time>
+				<extensions>
+					<speed>7.340029716491699</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008593338741901" lon="-84.2102834200033">
+				<ele>942.108989524655</ele>
+				<time>2017-10-30T17:40:35Z</time>
+				<extensions>
+					<speed>6.8586039543151855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008595289136265" lon="-84.21022414018981">
+				<ele>941.8708444563672</ele>
+				<time>2017-10-30T17:40:36Z</time>
+				<extensions>
+					<speed>5.740107536315918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00859533703296" lon="-84.21017773532154">
+				<ele>941.3910334063694</ele>
+				<time>2017-10-30T17:40:37Z</time>
+				<extensions>
+					<speed>4.118588924407959</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008596138709583" lon="-84.2101425867101">
+				<ele>940.8823829730973</ele>
+				<time>2017-10-30T17:40:38Z</time>
+				<extensions>
+					<speed>3.4079782962799072</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008587144769134" lon="-84.21011075971461">
+				<ele>941.7908723242581</ele>
+				<time>2017-10-30T17:40:39Z</time>
+				<extensions>
+					<speed>1.2103052139282227</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008590252115004" lon="-84.21009638452699">
+				<ele>941.4480104232207</ele>
+				<time>2017-10-30T17:40:40Z</time>
+				<extensions>
+					<speed>1.5351444482803345</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00859397740753" lon="-84.21007611741707">
+				<ele>941.3666419712827</ele>
+				<time>2017-10-30T17:40:41Z</time>
+				<extensions>
+					<speed>2.0561959743499756</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008601217698445" lon="-84.21006465425411">
+				<ele>941.2093558236957</ele>
+				<time>2017-10-30T17:40:42Z</time>
+				<extensions>
+					<speed>1.5333986282348633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008603294546528" lon="-84.21005975639551">
+				<ele>941.0616773180664</ele>
+				<time>2017-10-30T17:40:43Z</time>
+				<extensions>
+					<speed>0.7774487137794495</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008601252104553" lon="-84.21005616169884">
+				<ele>940.6470096567646</ele>
+				<time>2017-10-30T17:40:44Z</time>
+				<extensions>
+					<speed>0.5574826002120972</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008601252104553" lon="-84.21005616169884">
+				<ele>940.6470096567646</ele>
+				<time>2017-10-30T17:40:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008597239198853" lon="-84.21006566513587">
+				<ele>940.6767223048955</ele>
+				<time>2017-10-30T17:40:46Z</time>
+				<extensions>
+					<speed>1.049338936805725</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008595546328626" lon="-84.21007248628504">
+				<ele>940.7394282091409</ele>
+				<time>2017-10-30T17:40:47Z</time>
+				<extensions>
+					<speed>0.8478866219520569</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008595546328626" lon="-84.21007248628504">
+				<ele>940.7394282091409</ele>
+				<time>2017-10-30T17:40:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008596020158766" lon="-84.21008389017004">
+				<ele>940.7039760435</ele>
+				<time>2017-10-30T17:40:49Z</time>
+				<extensions>
+					<speed>0.7460961937904358</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00859606440624" lon="-84.21009636651826">
+				<ele>940.8271894054487</ele>
+				<time>2017-10-30T17:40:50Z</time>
+				<extensions>
+					<speed>1.0394277572631836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008596691846982" lon="-84.21011175250278">
+				<ele>941.0663340128958</ele>
+				<time>2017-10-30T17:40:51Z</time>
+				<extensions>
+					<speed>1.5427930355072021</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008596535395295" lon="-84.21012728746234">
+				<ele>941.323838933371</ele>
+				<time>2017-10-30T17:40:52Z</time>
+				<extensions>
+					<speed>1.4536585807800293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008595346517852" lon="-84.21015105068554">
+				<ele>941.6267494810745</ele>
+				<time>2017-10-30T17:40:53Z</time>
+				<extensions>
+					<speed>1.9710285663604736</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008592543769776" lon="-84.21017063383168">
+				<ele>941.9422289961949</ele>
+				<time>2017-10-30T17:40:54Z</time>
+				<extensions>
+					<speed>1.8272855281829834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00858752786277" lon="-84.21017755437069">
+				<ele>942.4993719272316</ele>
+				<time>2017-10-30T17:40:55Z</time>
+				<extensions>
+					<speed>1.3840125799179077</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008587277546884" lon="-84.21017805384916">
+				<ele>942.8195267533883</ele>
+				<time>2017-10-30T17:40:56Z</time>
+				<extensions>
+					<speed>0.4059671461582184</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008588427159676" lon="-84.21019358102888">
+				<ele>942.9476211657748</ele>
+				<time>2017-10-30T17:40:57Z</time>
+				<extensions>
+					<speed>1.1857904195785522</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00858862550789" lon="-84.2102076843932">
+				<ele>942.9384921779856</ele>
+				<time>2017-10-30T17:40:58Z</time>
+				<extensions>
+					<speed>1.0190403461456299</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008585708061371" lon="-84.21022376693067">
+				<ele>943.1024356493726</ele>
+				<time>2017-10-30T17:40:59Z</time>
+				<extensions>
+					<speed>1.113087773323059</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008584456512999" lon="-84.21023980504715">
+				<ele>943.13465990033</ele>
+				<time>2017-10-30T17:41:00Z</time>
+				<extensions>
+					<speed>0.45951828360557556</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008584456512999" lon="-84.21023980504715">
+				<ele>943.13465990033</ele>
+				<time>2017-10-30T17:41:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00857980896394" lon="-84.21024287780146">
+				<ele>943.3796271961182</ele>
+				<time>2017-10-30T17:41:02Z</time>
+				<extensions>
+					<speed>0.21082377433776855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00857980896394" lon="-84.21024287780146">
+				<ele>943.3796271961182</ele>
+				<time>2017-10-30T17:41:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00857980896394" lon="-84.21024287780146">
+				<ele>943.3796271961182</ele>
+				<time>2017-10-30T17:41:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00857536619305" lon="-84.21022796845614">
+				<ele>943.8787087993696</ele>
+				<time>2017-10-30T17:41:05Z</time>
+				<extensions>
+					<speed>0.9362273812294006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00857221289691" lon="-84.21020967894528">
+				<ele>944.3166973320767</ele>
+				<time>2017-10-30T17:41:06Z</time>
+				<extensions>
+					<speed>1.451688289642334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008570499241161" lon="-84.21018360944707">
+				<ele>944.3575020870194</ele>
+				<time>2017-10-30T17:41:07Z</time>
+				<extensions>
+					<speed>1.8575382232666016</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0085740865341" lon="-84.21015943058171">
+				<ele>944.5955645656213</ele>
+				<time>2017-10-30T17:41:08Z</time>
+				<extensions>
+					<speed>2.456476926803589</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008579460706871" lon="-84.21012386364481">
+				<ele>944.7015533531085</ele>
+				<time>2017-10-30T17:41:09Z</time>
+				<extensions>
+					<speed>3.174755096435547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008585337869963" lon="-84.21008753729726">
+				<ele>944.6809046966955</ele>
+				<time>2017-10-30T17:41:10Z</time>
+				<extensions>
+					<speed>3.4949722290039063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008587024668406" lon="-84.21004512423569">
+				<ele>944.7922015171498</ele>
+				<time>2017-10-30T17:41:11Z</time>
+				<extensions>
+					<speed>4.3683061599731445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008582490233024" lon="-84.20999731374782">
+				<ele>944.6994499536231</ele>
+				<time>2017-10-30T17:41:12Z</time>
+				<extensions>
+					<speed>5.139631271362305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008577835739377" lon="-84.20994553318414">
+				<ele>944.4452641075477</ele>
+				<time>2017-10-30T17:41:13Z</time>
+				<extensions>
+					<speed>5.273111343383789</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008569697302951" lon="-84.20988411953384">
+				<ele>944.0403066845611</ele>
+				<time>2017-10-30T17:41:14Z</time>
+				<extensions>
+					<speed>5.549294948577881</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008559796404457" lon="-84.20981261318437">
+				<ele>944.0053973654285</ele>
+				<time>2017-10-30T17:41:15Z</time>
+				<extensions>
+					<speed>6.309210777282715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008552980769013" lon="-84.20973997784328">
+				<ele>943.7820603502914</ele>
+				<time>2017-10-30T17:41:16Z</time>
+				<extensions>
+					<speed>7.1874260902404785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008555178323277" lon="-84.20966713504566">
+				<ele>943.4426560113207</ele>
+				<time>2017-10-30T17:41:17Z</time>
+				<extensions>
+					<speed>7.391436576843262</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00856065430995" lon="-84.20959436317716">
+				<ele>943.0946532012895</ele>
+				<time>2017-10-30T17:41:18Z</time>
+				<extensions>
+					<speed>7.451272964477539</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008565997483352" lon="-84.20952189434085">
+				<ele>943.1448247591034</ele>
+				<time>2017-10-30T17:41:19Z</time>
+				<extensions>
+					<speed>7.396979331970215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00857025079404" lon="-84.20945451432581">
+				<ele>943.2905368097126</ele>
+				<time>2017-10-30T17:41:20Z</time>
+				<extensions>
+					<speed>6.929460525512695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008575959154694" lon="-84.2093876383135">
+				<ele>943.0509032830596</ele>
+				<time>2017-10-30T17:41:21Z</time>
+				<extensions>
+					<speed>6.312696933746338</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008579808788923" lon="-84.20933105968774">
+				<ele>942.9423931762576</ele>
+				<time>2017-10-30T17:41:22Z</time>
+				<extensions>
+					<speed>5.748111248016357</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008586093577135" lon="-84.20928168295191">
+				<ele>942.6696303086355</ele>
+				<time>2017-10-30T17:41:23Z</time>
+				<extensions>
+					<speed>4.658238410949707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008587462945972" lon="-84.20925070870462">
+				<ele>943.0332907233387</ele>
+				<time>2017-10-30T17:41:24Z</time>
+				<extensions>
+					<speed>2.610663652420044</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008590737687497" lon="-84.20923353477485">
+				<ele>943.5396227482706</ele>
+				<time>2017-10-30T17:41:25Z</time>
+				<extensions>
+					<speed>1.6191679239273071</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008594122364194" lon="-84.20922064993299">
+				<ele>943.9598267823458</ele>
+				<time>2017-10-30T17:41:26Z</time>
+				<extensions>
+					<speed>1.3691105842590332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008599438705417" lon="-84.20921459806426">
+				<ele>944.6062462422997</ele>
+				<time>2017-10-30T17:41:27Z</time>
+				<extensions>
+					<speed>0.9298732280731201</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008599438705417" lon="-84.20921459806426">
+				<ele>944.6062462422997</ele>
+				<time>2017-10-30T17:41:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008602043133903" lon="-84.20920627423841">
+				<ele>944.7349235164002</ele>
+				<time>2017-10-30T17:41:29Z</time>
+				<extensions>
+					<speed>0.7775151133537292</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008602043133903" lon="-84.20920627423841">
+				<ele>944.7349235164002</ele>
+				<time>2017-10-30T17:41:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00860416470714" lon="-84.20918720700047">
+				<ele>944.4967419365421</ele>
+				<time>2017-10-30T17:41:31Z</time>
+				<extensions>
+					<speed>1.8508787155151367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00860474578997" lon="-84.2091619102982">
+				<ele>944.256183270365</ele>
+				<time>2017-10-30T17:41:32Z</time>
+				<extensions>
+					<speed>2.7354161739349365</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008601242654574" lon="-84.20913245760251">
+				<ele>943.9265831271186</ele>
+				<time>2017-10-30T17:41:33Z</time>
+				<extensions>
+					<speed>3.069840669631958</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008601726424352" lon="-84.20910065447984">
+				<ele>943.7150355372578</ele>
+				<time>2017-10-30T17:41:34Z</time>
+				<extensions>
+					<speed>3.4096362590789795</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008602106246592" lon="-84.20906489575516">
+				<ele>943.4064061427489</ele>
+				<time>2017-10-30T17:41:35Z</time>
+				<extensions>
+					<speed>4.068709850311279</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008601899837254" lon="-84.20902015482785">
+				<ele>943.2210692269728</ele>
+				<time>2017-10-30T17:41:36Z</time>
+				<extensions>
+					<speed>4.602613925933838</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008602473031237" lon="-84.20896804734004">
+				<ele>942.9618426701054</ele>
+				<time>2017-10-30T17:41:37Z</time>
+				<extensions>
+					<speed>5.422311782836914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008608985615941" lon="-84.20891127747352">
+				<ele>942.743151506409</ele>
+				<time>2017-10-30T17:41:38Z</time>
+				<extensions>
+					<speed>6.017641067504883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008609609308468" lon="-84.20885156581419">
+				<ele>942.6225253818557</ele>
+				<time>2017-10-30T17:41:39Z</time>
+				<extensions>
+					<speed>6.723165988922119</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008614102259637" lon="-84.20878628122327">
+				<ele>942.5218664491549</ele>
+				<time>2017-10-30T17:41:40Z</time>
+				<extensions>
+					<speed>7.261588096618652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008623630981873" lon="-84.20871998637777">
+				<ele>942.855591586791</ele>
+				<time>2017-10-30T17:41:41Z</time>
+				<extensions>
+					<speed>7.180638313293457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008631742498865" lon="-84.20865408486048">
+				<ele>943.1610395470634</ele>
+				<time>2017-10-30T17:41:42Z</time>
+				<extensions>
+					<speed>7.171238899230957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640564111952" lon="-84.2085884999133">
+				<ele>943.780024769716</ele>
+				<time>2017-10-30T17:41:43Z</time>
+				<extensions>
+					<speed>7.06282377243042</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640568808561" lon="-84.20852159107353">
+				<ele>943.8488961514086</ele>
+				<time>2017-10-30T17:41:44Z</time>
+				<extensions>
+					<speed>7.1394124031066895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633828182196" lon="-84.20845923652858">
+				<ele>943.6758423345163</ele>
+				<time>2017-10-30T17:41:45Z</time>
+				<extensions>
+					<speed>7.050407886505127</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00862470997755" lon="-84.2084001024061">
+				<ele>943.341026074253</ele>
+				<time>2017-10-30T17:41:46Z</time>
+				<extensions>
+					<speed>6.83719539642334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008605530683294" lon="-84.20834258950758">
+				<ele>942.4494479624555</ele>
+				<time>2017-10-30T17:41:47Z</time>
+				<extensions>
+					<speed>6.644925594329834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008589189140663" lon="-84.20828257371457">
+				<ele>941.5379502782598</ele>
+				<time>2017-10-30T17:41:48Z</time>
+				<extensions>
+					<speed>6.561819076538086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00858413938221" lon="-84.20822635356475">
+				<ele>941.224468825385</ele>
+				<time>2017-10-30T17:41:49Z</time>
+				<extensions>
+					<speed>6.267005443572998</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00858061534738" lon="-84.20817240272557">
+				<ele>940.9728065030649</ele>
+				<time>2017-10-30T17:41:50Z</time>
+				<extensions>
+					<speed>5.986316680908203</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008576790707618" lon="-84.20812164055211">
+				<ele>940.502800969407</ele>
+				<time>2017-10-30T17:41:51Z</time>
+				<extensions>
+					<speed>5.651355266571045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008566830971407" lon="-84.2080724509439">
+				<ele>940.0564422989264</ele>
+				<time>2017-10-30T17:41:52Z</time>
+				<extensions>
+					<speed>5.304455757141113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00855884141774" lon="-84.20803373382314">
+				<ele>939.7076640399173</ele>
+				<time>2017-10-30T17:41:53Z</time>
+				<extensions>
+					<speed>4.719418525695801</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008557197485873" lon="-84.20800773921925">
+				<ele>939.462205841206</ele>
+				<time>2017-10-30T17:41:54Z</time>
+				<extensions>
+					<speed>3.961376667022705</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008553956272754" lon="-84.20798126727193">
+				<ele>939.4088264601305</ele>
+				<time>2017-10-30T17:41:55Z</time>
+				<extensions>
+					<speed>3.509258985519409</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008557254675585" lon="-84.20796649569606">
+				<ele>939.527385564521</ele>
+				<time>2017-10-30T17:41:56Z</time>
+				<extensions>
+					<speed>2.700528144836426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008558331778582" lon="-84.20794429225509">
+				<ele>939.6593909570947</ele>
+				<time>2017-10-30T17:41:57Z</time>
+				<extensions>
+					<speed>2.6486663818359375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008559866245195" lon="-84.20791779825005">
+				<ele>939.7974971449003</ele>
+				<time>2017-10-30T17:41:58Z</time>
+				<extensions>
+					<speed>2.9303345680236816</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008555640466241" lon="-84.20788573771769">
+				<ele>940.1919715097174</ele>
+				<time>2017-10-30T17:41:59Z</time>
+				<extensions>
+					<speed>3.3005735874176025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008538644992425" lon="-84.20783982352204">
+				<ele>940.5439329408109</ele>
+				<time>2017-10-30T17:42:00Z</time>
+				<extensions>
+					<speed>3.9043807983398438</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008512816445043" lon="-84.20780359600512">
+				<ele>940.5439287852496</ele>
+				<time>2017-10-30T17:42:01Z</time>
+				<extensions>
+					<speed>4.898371696472168</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008483158337922" lon="-84.20776914333612">
+				<ele>940.5312021933496</ele>
+				<time>2017-10-30T17:42:02Z</time>
+				<extensions>
+					<speed>4.825804710388184</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008449863777741" lon="-84.20773892186018">
+				<ele>940.5403099367395</ele>
+				<time>2017-10-30T17:42:03Z</time>
+				<extensions>
+					<speed>4.7922043800354</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008419001902995" lon="-84.20771266998202">
+				<ele>940.391469584778</ele>
+				<time>2017-10-30T17:42:04Z</time>
+				<extensions>
+					<speed>4.951690673828125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008385420016058" lon="-84.2076843240311">
+				<ele>940.1807034052908</ele>
+				<time>2017-10-30T17:42:05Z</time>
+				<extensions>
+					<speed>5.347253322601318</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008340802153228" lon="-84.20765148026618">
+				<ele>939.9142262116075</ele>
+				<time>2017-10-30T17:42:06Z</time>
+				<extensions>
+					<speed>6.399134159088135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008291815636944" lon="-84.2076050456168">
+				<ele>939.7792722731829</ele>
+				<time>2017-10-30T17:42:07Z</time>
+				<extensions>
+					<speed>7.868422031402588</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008233635312262" lon="-84.20754947677663">
+				<ele>939.5662929555401</ele>
+				<time>2017-10-30T17:42:08Z</time>
+				<extensions>
+					<speed>8.698037147521973</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008172480109653" lon="-84.20749202750737">
+				<ele>939.2881155274808</ele>
+				<time>2017-10-30T17:42:09Z</time>
+				<extensions>
+					<speed>9.044775009155273</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008109268470463" lon="-84.20742537141379">
+				<ele>939.1265128077939</ele>
+				<time>2017-10-30T17:42:10Z</time>
+				<extensions>
+					<speed>9.571159362792969</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008046044414025" lon="-84.20734454040809">
+				<ele>938.1615625703707</ele>
+				<time>2017-10-30T17:42:11Z</time>
+				<extensions>
+					<speed>10.319188117980957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007968631318237" lon="-84.20726785605567">
+				<ele>937.7460168860853</ele>
+				<time>2017-10-30T17:42:12Z</time>
+				<extensions>
+					<speed>11.078376770019531</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007885781649458" lon="-84.20718845957069">
+				<ele>937.6211834764108</ele>
+				<time>2017-10-30T17:42:13Z</time>
+				<extensions>
+					<speed>11.518987655639648</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007794108218217" lon="-84.20709768186175">
+				<ele>937.5939423143864</ele>
+				<time>2017-10-30T17:42:14Z</time>
+				<extensions>
+					<speed>12.45526123046875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007700521609042" lon="-84.2070039484241">
+				<ele>937.4297161027789</ele>
+				<time>2017-10-30T17:42:15Z</time>
+				<extensions>
+					<speed>13.001224517822266</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007607081625265" lon="-84.20691938602243">
+				<ele>937.4452474834397</ele>
+				<time>2017-10-30T17:42:16Z</time>
+				<extensions>
+					<speed>13.260477066040039</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00751460879263" lon="-84.20683321838787">
+				<ele>936.905650883913</ele>
+				<time>2017-10-30T17:42:17Z</time>
+				<extensions>
+					<speed>13.388673782348633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007418044383382" lon="-84.20675402343832">
+				<ele>936.7048398787156</ele>
+				<time>2017-10-30T17:42:18Z</time>
+				<extensions>
+					<speed>13.416251182556152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007321663168705" lon="-84.20667689644901">
+				<ele>936.6248050602153</ele>
+				<time>2017-10-30T17:42:19Z</time>
+				<extensions>
+					<speed>13.415548324584961</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007224252967376" lon="-84.20659671459458">
+				<ele>936.4671432767063</ele>
+				<time>2017-10-30T17:42:20Z</time>
+				<extensions>
+					<speed>13.501331329345703</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007126191810361" lon="-84.2065111036048">
+				<ele>936.441198123619</ele>
+				<time>2017-10-30T17:42:21Z</time>
+				<extensions>
+					<speed>13.67943286895752</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007029513322015" lon="-84.2064236270076">
+				<ele>936.4647469799966</ele>
+				<time>2017-10-30T17:42:22Z</time>
+				<extensions>
+					<speed>13.87157154083252</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006939531482193" lon="-84.2063414048551">
+				<ele>936.3603292284533</ele>
+				<time>2017-10-30T17:42:23Z</time>
+				<extensions>
+					<speed>14.040976524353027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006844654944867" lon="-84.20625756847168">
+				<ele>936.2515642074868</ele>
+				<time>2017-10-30T17:42:24Z</time>
+				<extensions>
+					<speed>14.267683982849121</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006750664513456" lon="-84.2061800449338">
+				<ele>936.1122283535078</ele>
+				<time>2017-10-30T17:42:25Z</time>
+				<extensions>
+					<speed>14.141266822814941</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006654144339752" lon="-84.2061029042418">
+				<ele>936.0180893102661</ele>
+				<time>2017-10-30T17:42:26Z</time>
+				<extensions>
+					<speed>14.095718383789063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006555134655223" lon="-84.20601933753034">
+				<ele>935.7338173585013</ele>
+				<time>2017-10-30T17:42:27Z</time>
+				<extensions>
+					<speed>14.08446979522705</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006455850686425" lon="-84.20593500341862">
+				<ele>935.3495455440134</ele>
+				<time>2017-10-30T17:42:28Z</time>
+				<extensions>
+					<speed>14.109052658081055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006368559190822" lon="-84.20586973932247">
+				<ele>935.2122318455949</ele>
+				<time>2017-10-30T17:42:29Z</time>
+				<extensions>
+					<speed>13.433088302612305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006277720305823" lon="-84.2058045901222">
+				<ele>935.3304522847757</ele>
+				<time>2017-10-30T17:42:30Z</time>
+				<extensions>
+					<speed>12.840729713439941</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006197202198313" lon="-84.2057413886209">
+				<ele>935.5824647871777</ele>
+				<time>2017-10-30T17:42:31Z</time>
+				<extensions>
+					<speed>12.147270202636719</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006134521562315" lon="-84.20570340878922">
+				<ele>935.6494672009721</ele>
+				<time>2017-10-30T17:42:32Z</time>
+				<extensions>
+					<speed>10.412938117980957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006075035508514" lon="-84.20566490882219">
+				<ele>935.9684158936143</ele>
+				<time>2017-10-30T17:42:33Z</time>
+				<extensions>
+					<speed>8.175597190856934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006027460705578" lon="-84.20562818121816">
+				<ele>936.0922113396227</ele>
+				<time>2017-10-30T17:42:34Z</time>
+				<extensions>
+					<speed>6.263084411621094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005990254309259" lon="-84.20560486397372">
+				<ele>936.1292959544808</ele>
+				<time>2017-10-30T17:42:35Z</time>
+				<extensions>
+					<speed>4.92929220199585</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005958191110738" lon="-84.20558931449858">
+				<ele>936.291909860447</ele>
+				<time>2017-10-30T17:42:36Z</time>
+				<extensions>
+					<speed>4.406469345092773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005925615741216" lon="-84.20557744271134">
+				<ele>936.451330001466</ele>
+				<time>2017-10-30T17:42:37Z</time>
+				<extensions>
+					<speed>4.1423749923706055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005899292899713" lon="-84.20558098506623">
+				<ele>936.5487343100831</ele>
+				<time>2017-10-30T17:42:38Z</time>
+				<extensions>
+					<speed>3.729391098022461</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00588634782925" lon="-84.2056022898037">
+				<ele>936.6585723608732</ele>
+				<time>2017-10-30T17:42:39Z</time>
+				<extensions>
+					<speed>3.203680992126465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005883977236126" lon="-84.20564017389745">
+				<ele>936.5715306708589</ele>
+				<time>2017-10-30T17:42:40Z</time>
+				<extensions>
+					<speed>2.8255228996276855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005877005238665" lon="-84.20567983382716">
+				<ele>936.5827769655734</ele>
+				<time>2017-10-30T17:42:41Z</time>
+				<extensions>
+					<speed>3.377794027328491</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005874835182174" lon="-84.20572521479407">
+				<ele>936.7046125456691</ele>
+				<time>2017-10-30T17:42:42Z</time>
+				<extensions>
+					<speed>3.952181100845337</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005864746696398" lon="-84.20578544354551">
+				<ele>936.4469529399648</ele>
+				<time>2017-10-30T17:42:43Z</time>
+				<extensions>
+					<speed>4.653801441192627</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005846565609463" lon="-84.2058432347514">
+				<ele>936.3721024114639</ele>
+				<time>2017-10-30T17:42:44Z</time>
+				<extensions>
+					<speed>5.065847873687744</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00583186506373" lon="-84.2058965401905">
+				<ele>936.4043064331636</ele>
+				<time>2017-10-30T17:42:45Z</time>
+				<extensions>
+					<speed>4.9824910163879395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005818576180483" lon="-84.20594167180236">
+				<ele>936.345664570108</ele>
+				<time>2017-10-30T17:42:46Z</time>
+				<extensions>
+					<speed>4.875195026397705</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005813039642177" lon="-84.20597484837646">
+				<ele>936.316560481675</ele>
+				<time>2017-10-30T17:42:47Z</time>
+				<extensions>
+					<speed>4.036488056182861</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00580656385746" lon="-84.20601621538007">
+				<ele>936.3729051025584</ele>
+				<time>2017-10-30T17:42:48Z</time>
+				<extensions>
+					<speed>3.7399730682373047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005815923638433" lon="-84.20606853104208">
+				<ele>934.9008218720555</ele>
+				<time>2017-10-30T17:42:49Z</time>
+				<extensions>
+					<speed>2.908926486968994</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00582923823104" lon="-84.2060849197461">
+				<ele>933.0163258751854</ele>
+				<time>2017-10-30T17:42:50Z</time>
+				<extensions>
+					<speed>0.3678891062736511</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005839196295367" lon="-84.20609524198709">
+				<ele>932.1260140612721</ele>
+				<time>2017-10-30T17:42:51Z</time>
+				<extensions>
+					<speed>0.8484853506088257</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005836062878242" lon="-84.20608927036687">
+				<ele>931.7786608040333</ele>
+				<time>2017-10-30T17:42:52Z</time>
+				<extensions>
+					<speed>1.049035906791687</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005831632202835" lon="-84.20607696209927">
+				<ele>931.7144468408078</ele>
+				<time>2017-10-30T17:42:53Z</time>
+				<extensions>
+					<speed>1.0511987209320068</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00582418328338" lon="-84.20605882114418">
+				<ele>931.0729532362893</ele>
+				<time>2017-10-30T17:42:54Z</time>
+				<extensions>
+					<speed>0.9532256126403809</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00582418328338" lon="-84.20605882114418">
+				<ele>931.0729532362893</ele>
+				<time>2017-10-30T17:42:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005806617671068" lon="-84.20604662733255">
+				<ele>929.8740230007097</ele>
+				<time>2017-10-30T17:42:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005806617671068" lon="-84.20604662733255">
+				<ele>929.8740230007097</ele>
+				<time>2017-10-30T17:42:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005788921575398" lon="-84.20605097317332">
+				<ele>929.4726187540218</ele>
+				<time>2017-10-30T17:42:58Z</time>
+				<extensions>
+					<speed>1.4625517129898071</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005773713789889" lon="-84.20606571426217">
+				<ele>929.2165039526299</ele>
+				<time>2017-10-30T17:42:59Z</time>
+				<extensions>
+					<speed>2.2887206077575684</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005746618930043" lon="-84.20608920585713">
+				<ele>928.9543004967272</ele>
+				<time>2017-10-30T17:43:00Z</time>
+				<extensions>
+					<speed>3.822845220565796</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005716800524828" lon="-84.20611689405105">
+				<ele>928.8840596014634</ele>
+				<time>2017-10-30T17:43:01Z</time>
+				<extensions>
+					<speed>4.358267784118652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00567992207823" lon="-84.20614926056105">
+				<ele>928.7661363892257</ele>
+				<time>2017-10-30T17:43:02Z</time>
+				<extensions>
+					<speed>5.044699192047119</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005634406466704" lon="-84.20619707640326">
+				<ele>927.9273407040164</ele>
+				<time>2017-10-30T17:43:03Z</time>
+				<extensions>
+					<speed>6.8708062171936035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005599296088153" lon="-84.2062491325599">
+				<ele>927.4613076411188</ele>
+				<time>2017-10-30T17:43:04Z</time>
+				<extensions>
+					<speed>6.917788028717041</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005560610240288" lon="-84.2063001465652">
+				<ele>927.1802406189963</ele>
+				<time>2017-10-30T17:43:05Z</time>
+				<extensions>
+					<speed>6.768041610717773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005513466182334" lon="-84.20635488294523">
+				<ele>927.1247779047117</ele>
+				<time>2017-10-30T17:43:06Z</time>
+				<extensions>
+					<speed>7.814916610717773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00546394040667" lon="-84.20641384603006">
+				<ele>927.1369535783306</ele>
+				<time>2017-10-30T17:43:07Z</time>
+				<extensions>
+					<speed>8.329005241394043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005409163952654" lon="-84.20647181827806">
+				<ele>927.2220104420558</ele>
+				<time>2017-10-30T17:43:08Z</time>
+				<extensions>
+					<speed>8.694442749023438</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005350924822574" lon="-84.20652742709599">
+				<ele>927.5786573626101</ele>
+				<time>2017-10-30T17:43:09Z</time>
+				<extensions>
+					<speed>8.956130981445313</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005292560851094" lon="-84.20658486761292">
+				<ele>927.890827305615</ele>
+				<time>2017-10-30T17:43:10Z</time>
+				<extensions>
+					<speed>8.82813549041748</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005234682585757" lon="-84.20663583248366">
+				<ele>928.3125966107473</ele>
+				<time>2017-10-30T17:43:11Z</time>
+				<extensions>
+					<speed>8.628012657165527</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00518260648127" lon="-84.20667961850225">
+				<ele>928.6662034858018</ele>
+				<time>2017-10-30T17:43:12Z</time>
+				<extensions>
+					<speed>7.355316162109375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005137014181859" lon="-84.20671706987497">
+				<ele>928.8368164859712</ele>
+				<time>2017-10-30T17:43:13Z</time>
+				<extensions>
+					<speed>6.161800861358643</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005103719876463" lon="-84.20674727041119">
+				<ele>929.1507774386555</ele>
+				<time>2017-10-30T17:43:14Z</time>
+				<extensions>
+					<speed>4.370731353759766</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005077660835784" lon="-84.20676897826377">
+				<ele>929.3890169179067</ele>
+				<time>2017-10-30T17:43:15Z</time>
+				<extensions>
+					<speed>3.162522792816162</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00505411613188" lon="-84.20678642558956">
+				<ele>929.6409396864474</ele>
+				<time>2017-10-30T17:43:16Z</time>
+				<extensions>
+					<speed>3.228715419769287</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005032704326805" lon="-84.2067923086384">
+				<ele>929.8416571365669</ele>
+				<time>2017-10-30T17:43:17Z</time>
+				<extensions>
+					<speed>2.5847787857055664</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00501204330909" lon="-84.20678916970901">
+				<ele>930.12422680296</ele>
+				<time>2017-10-30T17:43:18Z</time>
+				<extensions>
+					<speed>2.065079927444458</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00499693749406" lon="-84.2067841558998">
+				<ele>929.6674659652635</ele>
+				<time>2017-10-30T17:43:19Z</time>
+				<extensions>
+					<speed>1.751203179359436</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004985660746337" lon="-84.20677323654911">
+				<ele>929.4814965082332</ele>
+				<time>2017-10-30T17:43:20Z</time>
+				<extensions>
+					<speed>1.6578608751296997</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004964465347399" lon="-84.20675110129336">
+				<ele>929.8311769561842</ele>
+				<time>2017-10-30T17:43:21Z</time>
+				<extensions>
+					<speed>2.178783655166626</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004923436895034" lon="-84.20672292396684">
+				<ele>930.0035510379821</ele>
+				<time>2017-10-30T17:43:22Z</time>
+				<extensions>
+					<speed>3.5753705501556396</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004893684926763" lon="-84.2066976651245">
+				<ele>930.0664151217788</ele>
+				<time>2017-10-30T17:43:23Z</time>
+				<extensions>
+					<speed>3.765381097793579</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00486938235223" lon="-84.20666682764856">
+				<ele>930.2811972713098</ele>
+				<time>2017-10-30T17:43:24Z</time>
+				<extensions>
+					<speed>3.766700267791748</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004833023489578" lon="-84.2066384667945">
+				<ele>930.8118138117716</ele>
+				<time>2017-10-30T17:43:25Z</time>
+				<extensions>
+					<speed>3.9797072410583496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00480170526893" lon="-84.20659560259601">
+				<ele>931.1644472712651</ele>
+				<time>2017-10-30T17:43:26Z</time>
+				<extensions>
+					<speed>4.505753040313721</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004762709694749" lon="-84.20654546903691">
+				<ele>930.9704639008269</ele>
+				<time>2017-10-30T17:43:27Z</time>
+				<extensions>
+					<speed>5.226389408111572</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004730040625956" lon="-84.20650280359138">
+				<ele>930.6905242530629</ele>
+				<time>2017-10-30T17:43:28Z</time>
+				<extensions>
+					<speed>5.315852642059326</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004689334755954" lon="-84.2064618326134">
+				<ele>930.6639467468485</ele>
+				<time>2017-10-30T17:43:29Z</time>
+				<extensions>
+					<speed>5.539132595062256</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004644208216591" lon="-84.20641321070933">
+				<ele>930.0105001060292</ele>
+				<time>2017-10-30T17:43:30Z</time>
+				<extensions>
+					<speed>5.786364555358887</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00460745725839" lon="-84.20636588495385">
+				<ele>928.73284806218</ele>
+				<time>2017-10-30T17:43:31Z</time>
+				<extensions>
+					<speed>5.060805797576904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004563907713493" lon="-84.20632491281988">
+				<ele>928.5621946118772</ele>
+				<time>2017-10-30T17:43:32Z</time>
+				<extensions>
+					<speed>4.589922904968262</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00453212051655" lon="-84.20629178339155">
+				<ele>928.679851484485</ele>
+				<time>2017-10-30T17:43:33Z</time>
+				<extensions>
+					<speed>4.0708231925964355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004508957560672" lon="-84.20626152999434">
+				<ele>928.7399594010785</ele>
+				<time>2017-10-30T17:43:34Z</time>
+				<extensions>
+					<speed>3.835951566696167</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004386649496311" lon="-84.20623662919776">
+				<ele>922.8833044692874</ele>
+				<time>2017-10-30T17:43:35Z</time>
+				<extensions>
+					<speed>3.3943653106689453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004393602027548" lon="-84.20620756785367">
+				<ele>924.0818353956565</ele>
+				<time>2017-10-30T17:43:36Z</time>
+				<extensions>
+					<speed>2.838505744934082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004340119492493" lon="-84.206186962699">
+				<ele>920.5910036182031</ele>
+				<time>2017-10-30T17:43:37Z</time>
+				<extensions>
+					<speed>2.6842777729034424</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004375710102936" lon="-84.20616370714072">
+				<ele>922.3899336038157</ele>
+				<time>2017-10-30T17:43:38Z</time>
+				<extensions>
+					<speed>2.2205262184143066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004398873114015" lon="-84.20614350541837">
+				<ele>923.8132555689663</ele>
+				<time>2017-10-30T17:43:39Z</time>
+				<extensions>
+					<speed>2.251063585281372</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00441839674791" lon="-84.20613229012318">
+				<ele>925.5942477080971</ele>
+				<time>2017-10-30T17:43:40Z</time>
+				<extensions>
+					<speed>2.0839571952819824</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004442576100377" lon="-84.20612377711157">
+				<ele>926.218510100618</ele>
+				<time>2017-10-30T17:43:41Z</time>
+				<extensions>
+					<speed>2.7650020122528076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004468516535585" lon="-84.20611242690141">
+				<ele>926.1628998611122</ele>
+				<time>2017-10-30T17:43:42Z</time>
+				<extensions>
+					<speed>3.286259889602661</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004494165379345" lon="-84.20608996434596">
+				<ele>926.5081775700673</ele>
+				<time>2017-10-30T17:43:43Z</time>
+				<extensions>
+					<speed>3.9987173080444336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004521311206487" lon="-84.20606436999712">
+				<ele>926.614578153938</ele>
+				<time>2017-10-30T17:43:44Z</time>
+				<extensions>
+					<speed>4.290994644165039</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004551044390713" lon="-84.20603502784554">
+				<ele>926.7722097048536</ele>
+				<time>2017-10-30T17:43:45Z</time>
+				<extensions>
+					<speed>4.677480697631836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004585644016492" lon="-84.20600114470056">
+				<ele>926.9708169586957</ele>
+				<time>2017-10-30T17:43:46Z</time>
+				<extensions>
+					<speed>5.57509183883667</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00461945467087" lon="-84.20596680606326">
+				<ele>926.8944343961775</ele>
+				<time>2017-10-30T17:43:47Z</time>
+				<extensions>
+					<speed>5.16751766204834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00464799938923" lon="-84.20592911620436">
+				<ele>927.0649527320638</ele>
+				<time>2017-10-30T17:43:48Z</time>
+				<extensions>
+					<speed>5.2677507400512695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004675952204696" lon="-84.20588945320915">
+				<ele>927.0569037683308</ele>
+				<time>2017-10-30T17:43:49Z</time>
+				<extensions>
+					<speed>5.329067707061768</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004705124742227" lon="-84.20585138229144">
+				<ele>926.5441635074094</ele>
+				<time>2017-10-30T17:43:50Z</time>
+				<extensions>
+					<speed>5.393675804138184</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00473846268523" lon="-84.20581080807615">
+				<ele>926.9307763241231</ele>
+				<time>2017-10-30T17:43:51Z</time>
+				<extensions>
+					<speed>5.951052665710449</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004777702692436" lon="-84.20576705808787">
+				<ele>926.8869783645496</ele>
+				<time>2017-10-30T17:43:52Z</time>
+				<extensions>
+					<speed>6.8687896728515625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004821850787579" lon="-84.2057233892355">
+				<ele>927.032853606157</ele>
+				<time>2017-10-30T17:43:53Z</time>
+				<extensions>
+					<speed>6.99321174621582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004861971834908" lon="-84.20567944864102">
+				<ele>927.2602053377777</ele>
+				<time>2017-10-30T17:43:54Z</time>
+				<extensions>
+					<speed>6.3463358879089355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004895976960922" lon="-84.20563515212386">
+				<ele>927.6232774015516</ele>
+				<time>2017-10-30T17:43:55Z</time>
+				<extensions>
+					<speed>6.213845729827881</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004927844262102" lon="-84.20559682033429">
+				<ele>928.3756891386583</ele>
+				<time>2017-10-30T17:43:56Z</time>
+				<extensions>
+					<speed>5.998490333557129</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00496040766362" lon="-84.20555674549956">
+				<ele>928.9133260184899</ele>
+				<time>2017-10-30T17:43:57Z</time>
+				<extensions>
+					<speed>6.224296569824219</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004993673834123" lon="-84.20551168269616">
+				<ele>929.5476853530854</ele>
+				<time>2017-10-30T17:43:58Z</time>
+				<extensions>
+					<speed>6.584240913391113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005030806650675" lon="-84.20546638282418">
+				<ele>929.6907982155681</ele>
+				<time>2017-10-30T17:43:59Z</time>
+				<extensions>
+					<speed>6.882820129394531</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00507048032357" lon="-84.20542231147041">
+				<ele>929.6296436116099</ele>
+				<time>2017-10-30T17:44:00Z</time>
+				<extensions>
+					<speed>6.781365871429443</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005107193903596" lon="-84.20537825905156">
+				<ele>930.0789020583034</ele>
+				<time>2017-10-30T17:44:01Z</time>
+				<extensions>
+					<speed>6.289102077484131</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005141303092056" lon="-84.20533144380163">
+				<ele>929.9707037433982</ele>
+				<time>2017-10-30T17:44:02Z</time>
+				<extensions>
+					<speed>6.353631496429443</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005174976437134" lon="-84.20528779977312">
+				<ele>929.9406992048025</ele>
+				<time>2017-10-30T17:44:03Z</time>
+				<extensions>
+					<speed>5.955601692199707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005205719166254" lon="-84.20525074406993">
+				<ele>930.05828177277</ele>
+				<time>2017-10-30T17:44:04Z</time>
+				<extensions>
+					<speed>5.044841766357422</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005234082245204" lon="-84.20521646581858">
+				<ele>930.4388113729656</ele>
+				<time>2017-10-30T17:44:05Z</time>
+				<extensions>
+					<speed>4.8416218757629395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005257311386893" lon="-84.20518415404095">
+				<ele>930.7750153047964</ele>
+				<time>2017-10-30T17:44:06Z</time>
+				<extensions>
+					<speed>4.0297627449035645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005275401938011" lon="-84.20515883942508">
+				<ele>931.1988428402692</ele>
+				<time>2017-10-30T17:44:07Z</time>
+				<extensions>
+					<speed>3.070154905319214</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005289978759317" lon="-84.20514439505627">
+				<ele>931.3335027527064</ele>
+				<time>2017-10-30T17:44:08Z</time>
+				<extensions>
+					<speed>2.1499955654144287</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005300294497953" lon="-84.2051349763157">
+				<ele>932.0248935762793</ele>
+				<time>2017-10-30T17:44:09Z</time>
+				<extensions>
+					<speed>1.233794927597046</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005305343311624" lon="-84.20513105426912">
+				<ele>932.6526138950139</ele>
+				<time>2017-10-30T17:44:10Z</time>
+				<extensions>
+					<speed>0.4796038568019867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005305343311624" lon="-84.20513105426912">
+				<ele>932.6526138950139</ele>
+				<time>2017-10-30T17:44:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00530427854781" lon="-84.20513115434464">
+				<ele>933.1141526307911</ele>
+				<time>2017-10-30T17:44:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00530427854781" lon="-84.20513115434464">
+				<ele>933.1141526307911</ele>
+				<time>2017-10-30T17:44:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005308234404312" lon="-84.20512880950132">
+				<ele>933.4929845910519</ele>
+				<time>2017-10-30T17:44:14Z</time>
+				<extensions>
+					<speed>0.9227391481399536</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005317748816397" lon="-84.20512045245081">
+				<ele>933.5200834041461</ele>
+				<time>2017-10-30T17:44:15Z</time>
+				<extensions>
+					<speed>1.822166085243225</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005329724331256" lon="-84.2051063583432">
+				<ele>933.6356861265376</ele>
+				<time>2017-10-30T17:44:16Z</time>
+				<extensions>
+					<speed>1.9524472951889038</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005345950458223" lon="-84.20509296092479">
+				<ele>933.8420706409961</ele>
+				<time>2017-10-30T17:44:17Z</time>
+				<extensions>
+					<speed>2.321280002593994</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005364487780536" lon="-84.20507755084553">
+				<ele>934.2801165897399</ele>
+				<time>2017-10-30T17:44:18Z</time>
+				<extensions>
+					<speed>2.671238899230957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005385362776765" lon="-84.20506014632954">
+				<ele>934.7152587790042</ele>
+				<time>2017-10-30T17:44:19Z</time>
+				<extensions>
+					<speed>2.996474266052246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005406498711492" lon="-84.20504106904123">
+				<ele>935.0975197516382</ele>
+				<time>2017-10-30T17:44:20Z</time>
+				<extensions>
+					<speed>3.083780288696289</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005429835134517" lon="-84.20501927464565">
+				<ele>935.3418811559677</ele>
+				<time>2017-10-30T17:44:21Z</time>
+				<extensions>
+					<speed>3.5999443531036377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005456699605922" lon="-84.20499420939531">
+				<ele>935.2947306158021</ele>
+				<time>2017-10-30T17:44:22Z</time>
+				<extensions>
+					<speed>4.031636714935303</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005482024467854" lon="-84.20497257979282">
+				<ele>935.282636096701</ele>
+				<time>2017-10-30T17:44:23Z</time>
+				<extensions>
+					<speed>3.324556827545166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005502060075614" lon="-84.2049519638584">
+				<ele>935.3377981716767</ele>
+				<time>2017-10-30T17:44:24Z</time>
+				<extensions>
+					<speed>2.925795316696167</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005518524858633" lon="-84.20493310801162">
+				<ele>935.7241573985666</ele>
+				<time>2017-10-30T17:44:25Z</time>
+				<extensions>
+					<speed>2.5424015522003174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00553231738137" lon="-84.2049161172037">
+				<ele>936.1035328488797</ele>
+				<time>2017-10-30T17:44:26Z</time>
+				<extensions>
+					<speed>2.448484420776367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005547913317518" lon="-84.20490149130751">
+				<ele>936.0663634547964</ele>
+				<time>2017-10-30T17:44:27Z</time>
+				<extensions>
+					<speed>2.6466972827911377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005571005438794" lon="-84.20488189929134">
+				<ele>935.8505161646754</ele>
+				<time>2017-10-30T17:44:28Z</time>
+				<extensions>
+					<speed>3.6349449157714844</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005598096876357" lon="-84.20485674441866">
+				<ele>935.740794188343</ele>
+				<time>2017-10-30T17:44:29Z</time>
+				<extensions>
+					<speed>4.229640007019043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005627994098715" lon="-84.20483273058927">
+				<ele>935.4275243012235</ele>
+				<time>2017-10-30T17:44:30Z</time>
+				<extensions>
+					<speed>4.3507771492004395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005659117341947" lon="-84.2048040626559">
+				<ele>935.2364987535402</ele>
+				<time>2017-10-30T17:44:31Z</time>
+				<extensions>
+					<speed>4.683559894561768</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005689617991939" lon="-84.20476999151164">
+				<ele>935.3980161109939</ele>
+				<time>2017-10-30T17:44:32Z</time>
+				<extensions>
+					<speed>5.0129923820495605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005718966170878" lon="-84.20473343620961">
+				<ele>935.7499688137323</ele>
+				<time>2017-10-30T17:44:33Z</time>
+				<extensions>
+					<speed>5.134782314300537</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005746537349069" lon="-84.20469650067456">
+				<ele>935.9726293664426</ele>
+				<time>2017-10-30T17:44:34Z</time>
+				<extensions>
+					<speed>4.947723865509033</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00577418077201" lon="-84.20465904530842">
+				<ele>936.7382182516158</ele>
+				<time>2017-10-30T17:44:35Z</time>
+				<extensions>
+					<speed>4.960601806640625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005803671725713" lon="-84.20462362751184">
+				<ele>937.3320557558909</ele>
+				<time>2017-10-30T17:44:36Z</time>
+				<extensions>
+					<speed>4.97763204574585</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005836471260945" lon="-84.20458743184118">
+				<ele>937.4604237666354</ele>
+				<time>2017-10-30T17:44:37Z</time>
+				<extensions>
+					<speed>5.6244401931762695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005872900908537" lon="-84.204547679593">
+				<ele>937.5047578830272</ele>
+				<time>2017-10-30T17:44:38Z</time>
+				<extensions>
+					<speed>5.943196773529053</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005911831772504" lon="-84.20450408856622">
+				<ele>937.3856067638844</ele>
+				<time>2017-10-30T17:44:39Z</time>
+				<extensions>
+					<speed>6.523660182952881</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005951804096126" lon="-84.20446075961904">
+				<ele>937.4210542812943</ele>
+				<time>2017-10-30T17:44:40Z</time>
+				<extensions>
+					<speed>6.328829765319824</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005990799449771" lon="-84.20442055583011">
+				<ele>937.7959971157834</ele>
+				<time>2017-10-30T17:44:41Z</time>
+				<extensions>
+					<speed>5.925998687744141</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006026546525813" lon="-84.20437869593218">
+				<ele>938.4781945310533</ele>
+				<time>2017-10-30T17:44:42Z</time>
+				<extensions>
+					<speed>5.902167320251465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006057341367077" lon="-84.2043378303793">
+				<ele>938.7869083220139</ele>
+				<time>2017-10-30T17:44:43Z</time>
+				<extensions>
+					<speed>5.386722564697266</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006082778377094" lon="-84.20429756229156">
+				<ele>939.1697978666052</ele>
+				<time>2017-10-30T17:44:44Z</time>
+				<extensions>
+					<speed>5.149460792541504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006105123910146" lon="-84.20425843878276">
+				<ele>939.3912240648642</ele>
+				<time>2017-10-30T17:44:45Z</time>
+				<extensions>
+					<speed>4.911647319793701</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006124959628464" lon="-84.20422456193083">
+				<ele>939.5206994339824</ele>
+				<time>2017-10-30T17:44:46Z</time>
+				<extensions>
+					<speed>4.137862205505371</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006139902802186" lon="-84.20419629151496">
+				<ele>939.6627855161205</ele>
+				<time>2017-10-30T17:44:47Z</time>
+				<extensions>
+					<speed>3.1651134490966797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006149494976471" lon="-84.20417663759432">
+				<ele>939.740431833081</ele>
+				<time>2017-10-30T17:44:48Z</time>
+				<extensions>
+					<speed>1.7479279041290283</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006150731780856" lon="-84.20417098259428">
+				<ele>939.4048923077062</ele>
+				<time>2017-10-30T17:44:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00614953357815" lon="-84.20417355141421">
+				<ele>939.3744174707681</ele>
+				<time>2017-10-30T17:44:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006145842130284" lon="-84.2041822260407">
+				<ele>939.6021400131285</ele>
+				<time>2017-10-30T17:44:51Z</time>
+				<extensions>
+					<speed>1.0365796089172363</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006139016566575" lon="-84.20419204490425">
+				<ele>939.8430941589177</ele>
+				<time>2017-10-30T17:44:52Z</time>
+				<extensions>
+					<speed>1.5137853622436523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006133316827722" lon="-84.20419868698191">
+				<ele>939.9049196504056</ele>
+				<time>2017-10-30T17:44:53Z</time>
+				<extensions>
+					<speed>1.0489954948425293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006126364951351" lon="-84.20419221360153">
+				<ele>940.9396134419367</ele>
+				<time>2017-10-30T17:44:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006126364951351" lon="-84.20419221360153">
+				<ele>940.9396134419367</ele>
+				<time>2017-10-30T17:44:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006126364951351" lon="-84.20419221360153">
+				<ele>940.9396134419367</ele>
+				<time>2017-10-30T17:44:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006126364951351" lon="-84.20419221360153">
+				<ele>940.9396134419367</ele>
+				<time>2017-10-30T17:44:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006126364951351" lon="-84.20419221360153">
+				<ele>940.9396134419367</ele>
+				<time>2017-10-30T17:44:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006126364951351" lon="-84.20419221360153">
+				<ele>940.9396134419367</ele>
+				<time>2017-10-30T17:44:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006126364951351" lon="-84.20419221360153">
+				<ele>940.9396134419367</ele>
+				<time>2017-10-30T17:45:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00613001884348" lon="-84.20418667363529">
+				<ele>941.1020106030628</ele>
+				<time>2017-10-30T17:45:01Z</time>
+				<extensions>
+					<speed>0.7887760400772095</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006139980379686" lon="-84.20417588545087">
+				<ele>941.4363647829741</ele>
+				<time>2017-10-30T17:45:02Z</time>
+				<extensions>
+					<speed>1.8629337549209595</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006156432132245" lon="-84.20415573637634">
+				<ele>942.1513639148325</ele>
+				<time>2017-10-30T17:45:03Z</time>
+				<extensions>
+					<speed>3.1148531436920166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006178050601582" lon="-84.2041299559871">
+				<ele>942.5889488831162</ele>
+				<time>2017-10-30T17:45:04Z</time>
+				<extensions>
+					<speed>3.896390914916992</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00620310030509" lon="-84.20410014669717">
+				<ele>942.7006664192304</ele>
+				<time>2017-10-30T17:45:05Z</time>
+				<extensions>
+					<speed>4.457783222198486</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006226042067993" lon="-84.20407222587035">
+				<ele>942.6212416412309</ele>
+				<time>2017-10-30T17:45:06Z</time>
+				<extensions>
+					<speed>3.6524178981781006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00624608379425" lon="-84.20405197248527">
+				<ele>942.7768638161942</ele>
+				<time>2017-10-30T17:45:07Z</time>
+				<extensions>
+					<speed>2.827258586883545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006264070797041" lon="-84.20403931722407">
+				<ele>942.9052770128474</ele>
+				<time>2017-10-30T17:45:08Z</time>
+				<extensions>
+					<speed>2.0755419731140137</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006277159019058" lon="-84.20403176875757">
+				<ele>943.062277351506</ele>
+				<time>2017-10-30T17:45:09Z</time>
+				<extensions>
+					<speed>1.1999077796936035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006282231839078" lon="-84.20402951651998">
+				<ele>943.3043726915494</ele>
+				<time>2017-10-30T17:45:10Z</time>
+				<extensions>
+					<speed>0.22952833771705627</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006282231839078" lon="-84.20402951651998">
+				<ele>943.3043726915494</ele>
+				<time>2017-10-30T17:45:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006282231839078" lon="-84.20402951651998">
+				<ele>943.3043726915494</ele>
+				<time>2017-10-30T17:45:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006292136014608" lon="-84.20403433821959">
+				<ele>942.5234142998233</ele>
+				<time>2017-10-30T17:45:13Z</time>
+				<extensions>
+					<speed>1.0024347305297852</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00630793273542" lon="-84.2040384755377">
+				<ele>942.2233344772831</ele>
+				<time>2017-10-30T17:45:14Z</time>
+				<extensions>
+					<speed>1.7853127717971802</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006329553464704" lon="-84.20404296015641">
+				<ele>941.8937277393416</ele>
+				<time>2017-10-30T17:45:15Z</time>
+				<extensions>
+					<speed>2.459003210067749</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00635452232018" lon="-84.20405212323375">
+				<ele>941.4727604249492</ele>
+				<time>2017-10-30T17:45:16Z</time>
+				<extensions>
+					<speed>2.7295777797698975</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006381935717034" lon="-84.20406248069771">
+				<ele>941.3646098300815</ele>
+				<time>2017-10-30T17:45:17Z</time>
+				<extensions>
+					<speed>3.3526792526245117</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006415077458458" lon="-84.20407716589675">
+				<ele>941.3785915542394</ele>
+				<time>2017-10-30T17:45:18Z</time>
+				<extensions>
+					<speed>4.287944793701172</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006453020574412" lon="-84.20410048049557">
+				<ele>941.4106175927445</ele>
+				<time>2017-10-30T17:45:19Z</time>
+				<extensions>
+					<speed>4.95628023147583</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00649121404268" lon="-84.20412902139543">
+				<ele>941.3727657422423</ele>
+				<time>2017-10-30T17:45:20Z</time>
+				<extensions>
+					<speed>5.160379886627197</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00652697488434" lon="-84.20416024414583">
+				<ele>941.106766260229</ele>
+				<time>2017-10-30T17:45:21Z</time>
+				<extensions>
+					<speed>5.230660915374756</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006562414624222" lon="-84.20418951651392">
+				<ele>941.1200837735087</ele>
+				<time>2017-10-30T17:45:22Z</time>
+				<extensions>
+					<speed>4.95875358581543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006596727999034" lon="-84.20422200333205">
+				<ele>940.9569946462288</ele>
+				<time>2017-10-30T17:45:23Z</time>
+				<extensions>
+					<speed>5.336915016174316</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006630515466753" lon="-84.20425477975311">
+				<ele>940.8540246607736</ele>
+				<time>2017-10-30T17:45:24Z</time>
+				<extensions>
+					<speed>5.178382873535156</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00666382246584" lon="-84.20428634314457">
+				<ele>940.7660853145644</ele>
+				<time>2017-10-30T17:45:25Z</time>
+				<extensions>
+					<speed>5.120955944061279</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006697995902163" lon="-84.20431287699178">
+				<ele>940.7501293811947</ele>
+				<time>2017-10-30T17:45:26Z</time>
+				<extensions>
+					<speed>4.7575459480285645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006731729931632" lon="-84.20434033811644">
+				<ele>940.7731141541153</ele>
+				<time>2017-10-30T17:45:27Z</time>
+				<extensions>
+					<speed>4.79951286315918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006763824477602" lon="-84.20436794337259">
+				<ele>940.6729322429746</ele>
+				<time>2017-10-30T17:45:28Z</time>
+				<extensions>
+					<speed>4.764443397521973</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006794244283265" lon="-84.20439349555737">
+				<ele>940.5989491939545</ele>
+				<time>2017-10-30T17:45:29Z</time>
+				<extensions>
+					<speed>4.479615211486816</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006824846959914" lon="-84.20442102531233">
+				<ele>940.6980374148116</ele>
+				<time>2017-10-30T17:45:30Z</time>
+				<extensions>
+					<speed>4.630569934844971</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006855900239087" lon="-84.20445061711217">
+				<ele>940.9030450033024</ele>
+				<time>2017-10-30T17:45:31Z</time>
+				<extensions>
+					<speed>4.720489978790283</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006887984967126" lon="-84.20447923054716">
+				<ele>941.1462173238397</ele>
+				<time>2017-10-30T17:45:32Z</time>
+				<extensions>
+					<speed>4.757631778717041</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006917410479563" lon="-84.20450512871498">
+				<ele>941.539140317589</ele>
+				<time>2017-10-30T17:45:33Z</time>
+				<extensions>
+					<speed>4.287327289581299</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006947605147882" lon="-84.20453476497823">
+				<ele>941.7077767848969</ele>
+				<time>2017-10-30T17:45:34Z</time>
+				<extensions>
+					<speed>4.550374507904053</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006976885944926" lon="-84.2045639497617">
+				<ele>941.2960124677047</ele>
+				<time>2017-10-30T17:45:35Z</time>
+				<extensions>
+					<speed>4.155139446258545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007004816316412" lon="-84.20459553560885">
+				<ele>941.0290278624743</ele>
+				<time>2017-10-30T17:45:36Z</time>
+				<extensions>
+					<speed>4.023106575012207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0070308040836" lon="-84.20462730105946">
+				<ele>940.7587600937113</ele>
+				<time>2017-10-30T17:45:37Z</time>
+				<extensions>
+					<speed>3.952155828475952</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00705083379931" lon="-84.204658438821">
+				<ele>940.6830800585449</ele>
+				<time>2017-10-30T17:45:38Z</time>
+				<extensions>
+					<speed>3.6677603721618652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00707117901654" lon="-84.20468046014793">
+				<ele>940.3545263316482</ele>
+				<time>2017-10-30T17:45:39Z</time>
+				<extensions>
+					<speed>2.874520778656006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00709124191379" lon="-84.2046941959307">
+				<ele>940.3774244170636</ele>
+				<time>2017-10-30T17:45:40Z</time>
+				<extensions>
+					<speed>2.432945966720581</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007109762291305" lon="-84.20470619699017">
+				<ele>940.8573445314541</ele>
+				<time>2017-10-30T17:45:41Z</time>
+				<extensions>
+					<speed>2.4813032150268555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007131923994308" lon="-84.20471222527084">
+				<ele>941.6513869157061</ele>
+				<time>2017-10-30T17:45:42Z</time>
+				<extensions>
+					<speed>2.7554023265838623</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007158055074402" lon="-84.2047115064113">
+				<ele>942.0879550883546</ele>
+				<time>2017-10-30T17:45:43Z</time>
+				<extensions>
+					<speed>3.0996599197387695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007188147830744" lon="-84.2047016662973">
+				<ele>942.4988459907472</ele>
+				<time>2017-10-30T17:45:44Z</time>
+				<extensions>
+					<speed>3.7749786376953125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007222220981756" lon="-84.2046869121277">
+				<ele>942.8664008509368</ele>
+				<time>2017-10-30T17:45:45Z</time>
+				<extensions>
+					<speed>4.453824996948242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007259566582215" lon="-84.20466353666669">
+				<ele>943.0082582272589</ele>
+				<time>2017-10-30T17:45:46Z</time>
+				<extensions>
+					<speed>5.067541122436523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007295215211824" lon="-84.20463160150786">
+				<ele>943.0640810066834</ele>
+				<time>2017-10-30T17:45:47Z</time>
+				<extensions>
+					<speed>5.166263103485107</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007330879041106" lon="-84.20459508006863">
+				<ele>943.0090745454654</ele>
+				<time>2017-10-30T17:45:48Z</time>
+				<extensions>
+					<speed>5.0989603996276855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007363447799074" lon="-84.20456163071238">
+				<ele>942.9240492749959</ele>
+				<time>2017-10-30T17:45:49Z</time>
+				<extensions>
+					<speed>4.522420406341553</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007386205444" lon="-84.20453568803913">
+				<ele>943.0417192429304</ele>
+				<time>2017-10-30T17:45:50Z</time>
+				<extensions>
+					<speed>3.052302598953247</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007400612275024" lon="-84.20451790021777">
+				<ele>943.1110675195232</ele>
+				<time>2017-10-30T17:45:51Z</time>
+				<extensions>
+					<speed>1.8011863231658936</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007406339606522" lon="-84.20451263994391">
+				<ele>943.2441431786865</ele>
+				<time>2017-10-30T17:45:52Z</time>
+				<extensions>
+					<speed>0.16392603516578674</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00740651075519" lon="-84.20451324539603">
+				<ele>943.407468656078</ele>
+				<time>2017-10-30T17:45:53Z</time>
+				<extensions>
+					<speed>0.04844212904572487</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00740651075519" lon="-84.20451324539603">
+				<ele>943.407468656078</ele>
+				<time>2017-10-30T17:45:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007403151983821" lon="-84.20452558500929">
+				<ele>943.3355543185025</ele>
+				<time>2017-10-30T17:45:55Z</time>
+				<extensions>
+					<speed>0.901191771030426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00740651075519" lon="-84.20451324539603">
+				<ele>943.407468656078</ele>
+				<time>2017-10-30T17:45:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00740651075519" lon="-84.20451324539603">
+				<ele>943.407468656078</ele>
+				<time>2017-10-30T17:45:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00740651075519" lon="-84.20451324539603">
+				<ele>943.407468656078</ele>
+				<time>2017-10-30T17:45:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00740651075519" lon="-84.20451324539603">
+				<ele>943.407468656078</ele>
+				<time>2017-10-30T17:45:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00740651075519" lon="-84.20451324539603">
+				<ele>943.407468656078</ele>
+				<time>2017-10-30T17:46:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00740651075519" lon="-84.20451324539603">
+				<ele>943.407468656078</ele>
+				<time>2017-10-30T17:46:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00740651075519" lon="-84.20451324539603">
+				<ele>943.407468656078</ele>
+				<time>2017-10-30T17:46:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00740651075519" lon="-84.20451324539603">
+				<ele>943.407468656078</ele>
+				<time>2017-10-30T17:46:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00740651075519" lon="-84.20451324539603">
+				<ele>943.407468656078</ele>
+				<time>2017-10-30T17:46:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00740651075519" lon="-84.20451324539603">
+				<ele>943.407468656078</ele>
+				<time>2017-10-30T17:46:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00740651075519" lon="-84.20451324539603">
+				<ele>943.407468656078</ele>
+				<time>2017-10-30T17:46:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00740651075519" lon="-84.20451324539603">
+				<ele>943.407468656078</ele>
+				<time>2017-10-30T17:46:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00740651075519" lon="-84.20451324539603">
+				<ele>943.407468656078</ele>
+				<time>2017-10-30T17:46:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00740651075519" lon="-84.20451324539603">
+				<ele>943.407468656078</ele>
+				<time>2017-10-30T17:46:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00740651075519" lon="-84.20451324539603">
+				<ele>943.407468656078</ele>
+				<time>2017-10-30T17:46:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00740651075519" lon="-84.20451324539603">
+				<ele>943.407468656078</ele>
+				<time>2017-10-30T17:46:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00740651075519" lon="-84.20451324539603">
+				<ele>943.407468656078</ele>
+				<time>2017-10-30T17:46:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007408051867893" lon="-84.20451220192437">
+				<ele>943.536942650564</ele>
+				<time>2017-10-30T17:46:13Z</time>
+				<extensions>
+					<speed>0.7794567942619324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007414496035832" lon="-84.2045066648371">
+				<ele>943.5863278163597</ele>
+				<time>2017-10-30T17:46:14Z</time>
+				<extensions>
+					<speed>1.1503262519836426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00742468414287" lon="-84.20449585016026">
+				<ele>943.2568232556805</ele>
+				<time>2017-10-30T17:46:15Z</time>
+				<extensions>
+					<speed>2.257652521133423</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007443129693517" lon="-84.20447685599713">
+				<ele>942.9886931357905</ele>
+				<time>2017-10-30T17:46:16Z</time>
+				<extensions>
+					<speed>3.173509359359741</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00746945309836" lon="-84.20445144978699">
+				<ele>942.6272829538211</ele>
+				<time>2017-10-30T17:46:17Z</time>
+				<extensions>
+					<speed>4.0940961837768555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00750385710981" lon="-84.20442083485955">
+				<ele>942.8990276120603</ele>
+				<time>2017-10-30T17:46:18Z</time>
+				<extensions>
+					<speed>4.966522216796875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007543689313502" lon="-84.20438739794439">
+				<ele>943.1273129070178</ele>
+				<time>2017-10-30T17:46:19Z</time>
+				<extensions>
+					<speed>6.09730863571167</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007588663565198" lon="-84.20434888321547">
+				<ele>943.564743607305</ele>
+				<time>2017-10-30T17:46:20Z</time>
+				<extensions>
+					<speed>6.349851608276367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007640885483063" lon="-84.2043067713113">
+				<ele>944.2439188100398</ele>
+				<time>2017-10-30T17:46:21Z</time>
+				<extensions>
+					<speed>7.59643030166626</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007697781806913" lon="-84.20425745454892">
+				<ele>944.8472370607778</ele>
+				<time>2017-10-30T17:46:22Z</time>
+				<extensions>
+					<speed>8.433176040649414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007757534176376" lon="-84.20420841148147">
+				<ele>946.2391268704087</ele>
+				<time>2017-10-30T17:46:23Z</time>
+				<extensions>
+					<speed>8.038610458374023</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007815407736842" lon="-84.20415868350256">
+				<ele>947.1257171668112</ele>
+				<time>2017-10-30T17:46:24Z</time>
+				<extensions>
+					<speed>8.306714057922363</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007873203661319" lon="-84.2041064107146">
+				<ele>947.7782073291019</ele>
+				<time>2017-10-30T17:46:25Z</time>
+				<extensions>
+					<speed>8.579421997070313</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007931584265398" lon="-84.20405130217182">
+				<ele>948.3566734800115</ele>
+				<time>2017-10-30T17:46:26Z</time>
+				<extensions>
+					<speed>8.853036880493164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00799056309071" lon="-84.20399519139596">
+				<ele>948.9871616605669</ele>
+				<time>2017-10-30T17:46:27Z</time>
+				<extensions>
+					<speed>8.685121536254883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008049190249082" lon="-84.20394059005393">
+				<ele>949.6646873280406</ele>
+				<time>2017-10-30T17:46:28Z</time>
+				<extensions>
+					<speed>8.611956596374512</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008106729974203" lon="-84.2038879671755">
+				<ele>949.873910301365</ele>
+				<time>2017-10-30T17:46:29Z</time>
+				<extensions>
+					<speed>8.336074829101563</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008164613047454" lon="-84.20383971759613">
+				<ele>949.9355761371553</ele>
+				<time>2017-10-30T17:46:30Z</time>
+				<extensions>
+					<speed>8.167946815490723</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008222244277574" lon="-84.20379276615718">
+				<ele>949.9246264537796</ele>
+				<time>2017-10-30T17:46:31Z</time>
+				<extensions>
+					<speed>7.999710559844971</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008278668169948" lon="-84.20374636139468">
+				<ele>949.9894068911672</ele>
+				<time>2017-10-30T17:46:32Z</time>
+				<extensions>
+					<speed>7.964409828186035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008333235015769" lon="-84.20370093361281">
+				<ele>950.1315879523754</ele>
+				<time>2017-10-30T17:46:33Z</time>
+				<extensions>
+					<speed>7.779351234436035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008385015482151" lon="-84.20365642727968">
+				<ele>950.368465510197</ele>
+				<time>2017-10-30T17:46:34Z</time>
+				<extensions>
+					<speed>7.365426063537598</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008432152750105" lon="-84.20361692381286">
+				<ele>950.5976435458288</ele>
+				<time>2017-10-30T17:46:35Z</time>
+				<extensions>
+					<speed>6.29660701751709</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008470068189228" lon="-84.20358663388491">
+				<ele>950.7242614710703</ele>
+				<time>2017-10-30T17:46:36Z</time>
+				<extensions>
+					<speed>4.579587459564209</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008495073237388" lon="-84.20356739960995">
+				<ele>951.0631659617648</ele>
+				<time>2017-10-30T17:46:37Z</time>
+				<extensions>
+					<speed>2.480818271636963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008507915306875" lon="-84.2035569678798">
+				<ele>951.4791683983058</ele>
+				<time>2017-10-30T17:46:38Z</time>
+				<extensions>
+					<speed>0.9878029227256775</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008513671977521" lon="-84.20355052490505">
+				<ele>951.5274969050661</ele>
+				<time>2017-10-30T17:46:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00851754556966" lon="-84.20354509843602">
+				<ele>951.7463917424902</ele>
+				<time>2017-10-30T17:46:40Z</time>
+				<extensions>
+					<speed>1.1218477487564087</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008529060357983" lon="-84.20353597011261">
+				<ele>951.8658821871504</ele>
+				<time>2017-10-30T17:46:41Z</time>
+				<extensions>
+					<speed>2.1323986053466797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008549588941388" lon="-84.20352139720507">
+				<ele>951.9541125586256</ele>
+				<time>2017-10-30T17:46:42Z</time>
+				<extensions>
+					<speed>3.3759851455688477</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00857777279715" lon="-84.20349740380568">
+				<ele>951.9585055354983</ele>
+				<time>2017-10-30T17:46:43Z</time>
+				<extensions>
+					<speed>4.76361083984375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00861413772466" lon="-84.20346676742881">
+				<ele>952.0347849661484</ele>
+				<time>2017-10-30T17:46:44Z</time>
+				<extensions>
+					<speed>5.697302341461182</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008658894491223" lon="-84.20343068960923">
+				<ele>951.8753078365698</ele>
+				<time>2017-10-30T17:46:45Z</time>
+				<extensions>
+					<speed>6.587911605834961</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008708524998523" lon="-84.20339181677227">
+				<ele>951.6775610633194</ele>
+				<time>2017-10-30T17:46:46Z</time>
+				<extensions>
+					<speed>7.223817825317383</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008758788333898" lon="-84.20335069523708">
+				<ele>951.5284929154441</ele>
+				<time>2017-10-30T17:46:47Z</time>
+				<extensions>
+					<speed>7.158700942993164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008807611455012" lon="-84.20331116719056">
+				<ele>951.4083538260311</ele>
+				<time>2017-10-30T17:46:48Z</time>
+				<extensions>
+					<speed>7.016209602355957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008854616875766" lon="-84.20327406638296">
+				<ele>951.3963802615181</ele>
+				<time>2017-10-30T17:46:49Z</time>
+				<extensions>
+					<speed>6.395553112030029</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008895829084603" lon="-84.20324206984262">
+				<ele>951.4680854128674</ele>
+				<time>2017-10-30T17:46:50Z</time>
+				<extensions>
+					<speed>5.1783270835876465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008926666311819" lon="-84.20321639103528">
+				<ele>951.4318770850077</ele>
+				<time>2017-10-30T17:46:51Z</time>
+				<extensions>
+					<speed>3.5320136547088623</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008945414329162" lon="-84.2031997487215">
+				<ele>951.4117808286101</ele>
+				<time>2017-10-30T17:46:52Z</time>
+				<extensions>
+					<speed>1.8464912176132202</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00895094895176" lon="-84.20319381025259">
+				<ele>951.4860269501805</ele>
+				<time>2017-10-30T17:46:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00894629583891" lon="-84.20319703972592">
+				<ele>951.481323050335</ele>
+				<time>2017-10-30T17:46:54Z</time>
+				<extensions>
+					<speed>1.1075900793075562</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00893811328807" lon="-84.20320690889108">
+				<ele>951.6328541422263</ele>
+				<time>2017-10-30T17:46:55Z</time>
+				<extensions>
+					<speed>1.2328227758407593</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008931063657315" lon="-84.20322085332997">
+				<ele>951.6862366804853</ele>
+				<time>2017-10-30T17:46:56Z</time>
+				<extensions>
+					<speed>0.9311639070510864</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008931063657315" lon="-84.20322085332997">
+				<ele>951.6862366804853</ele>
+				<time>2017-10-30T17:46:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008928959325736" lon="-84.2032216980143">
+				<ele>951.6120636789128</ele>
+				<time>2017-10-30T17:46:58Z</time>
+				<extensions>
+					<speed>0.39430180191993713</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008934530079577" lon="-84.20320964488333">
+				<ele>951.4544651322067</ele>
+				<time>2017-10-30T17:46:59Z</time>
+				<extensions>
+					<speed>1.9913620948791504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008951956779201" lon="-84.20318868354242">
+				<ele>951.1617169007659</ele>
+				<time>2017-10-30T17:47:00Z</time>
+				<extensions>
+					<speed>3.7022488117218018</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008978342049609" lon="-84.20316069614519">
+				<ele>951.1090659573674</ele>
+				<time>2017-10-30T17:47:01Z</time>
+				<extensions>
+					<speed>4.5559563636779785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009013528313687" lon="-84.20312626699148">
+				<ele>951.1354517266154</ele>
+				<time>2017-10-30T17:47:02Z</time>
+				<extensions>
+					<speed>5.773004055023193</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009053920315546" lon="-84.20309037871345">
+				<ele>951.2021457822993</ele>
+				<time>2017-10-30T17:47:03Z</time>
+				<extensions>
+					<speed>5.952348232269287</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009095270555237" lon="-84.2030550632086">
+				<ele>951.2332870615646</ele>
+				<time>2017-10-30T17:47:04Z</time>
+				<extensions>
+					<speed>5.918828964233398</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009128486523828" lon="-84.2030265609016">
+				<ele>951.3704126253724</ele>
+				<time>2017-10-30T17:47:05Z</time>
+				<extensions>
+					<speed>4.439931392669678</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009151863924332" lon="-84.20300536521474">
+				<ele>951.4201694186777</ele>
+				<time>2017-10-30T17:47:06Z</time>
+				<extensions>
+					<speed>2.769136905670166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009166463942774" lon="-84.20298773207418">
+				<ele>951.4380932627246</ele>
+				<time>2017-10-30T17:47:07Z</time>
+				<extensions>
+					<speed>2.170011281967163</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009178168796465" lon="-84.20297199507318">
+				<ele>951.2688786936924</ele>
+				<time>2017-10-30T17:47:08Z</time>
+				<extensions>
+					<speed>1.9763103723526</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009191312916279" lon="-84.20295483611338">
+				<ele>951.2343821637332</ele>
+				<time>2017-10-30T17:47:09Z</time>
+				<extensions>
+					<speed>2.7823805809020996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009209803645494" lon="-84.20293395282303">
+				<ele>951.0507473079488</ele>
+				<time>2017-10-30T17:47:10Z</time>
+				<extensions>
+					<speed>3.5074408054351807</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009235632883525" lon="-84.20290873123083">
+				<ele>950.7877905918285</ele>
+				<time>2017-10-30T17:47:11Z</time>
+				<extensions>
+					<speed>4.314515590667725</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009269005324677" lon="-84.20288265460181">
+				<ele>950.6337977778167</ele>
+				<time>2017-10-30T17:47:12Z</time>
+				<extensions>
+					<speed>5.103153705596924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009311152892584" lon="-84.20285120941695">
+				<ele>950.4252762980759</ele>
+				<time>2017-10-30T17:47:13Z</time>
+				<extensions>
+					<speed>5.830776214599609</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009357937473224" lon="-84.20281170515544">
+				<ele>950.4389847544953</ele>
+				<time>2017-10-30T17:47:14Z</time>
+				<extensions>
+					<speed>6.741000175476074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009409645483162" lon="-84.20276536430566">
+				<ele>950.3760912232101</ele>
+				<time>2017-10-30T17:47:15Z</time>
+				<extensions>
+					<speed>7.356104373931885</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009466449749016" lon="-84.20271799064548">
+				<ele>950.3667474519461</ele>
+				<time>2017-10-30T17:47:16Z</time>
+				<extensions>
+					<speed>8.102753639221191</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009530709598888" lon="-84.20266603849826">
+				<ele>950.5877842176706</ele>
+				<time>2017-10-30T17:47:17Z</time>
+				<extensions>
+					<speed>9.120134353637695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009598477750938" lon="-84.20260877275597">
+				<ele>950.6141305249184</ele>
+				<time>2017-10-30T17:47:18Z</time>
+				<extensions>
+					<speed>9.86928653717041</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00966824740537" lon="-84.2025536685876">
+				<ele>950.2765462929383</ele>
+				<time>2017-10-30T17:47:19Z</time>
+				<extensions>
+					<speed>9.557544708251953</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009738705214737" lon="-84.20249731575656">
+				<ele>950.1800074875355</ele>
+				<time>2017-10-30T17:47:20Z</time>
+				<extensions>
+					<speed>9.988758087158203</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009808342626823" lon="-84.20243854658256">
+				<ele>950.0665689045563</ele>
+				<time>2017-10-30T17:47:21Z</time>
+				<extensions>
+					<speed>9.725720405578613</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009876234841673" lon="-84.2023805610449">
+				<ele>950.0644194064662</ele>
+				<time>2017-10-30T17:47:22Z</time>
+				<extensions>
+					<speed>9.301956176757813</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009941208114494" lon="-84.20232498236649">
+				<ele>950.3606634717435</ele>
+				<time>2017-10-30T17:47:23Z</time>
+				<extensions>
+					<speed>9.053487777709961</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010002874861586" lon="-84.20227141582019">
+				<ele>950.7015885990113</ele>
+				<time>2017-10-30T17:47:24Z</time>
+				<extensions>
+					<speed>8.509696006774902</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010059776059146" lon="-84.20222567983303">
+				<ele>951.1387841552496</ele>
+				<time>2017-10-30T17:47:25Z</time>
+				<extensions>
+					<speed>7.361094951629639</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010110822279234" lon="-84.20218955855837">
+				<ele>951.5861027091742</ele>
+				<time>2017-10-30T17:47:26Z</time>
+				<extensions>
+					<speed>6.086156368255615</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01015282451272" lon="-84.20216342375441">
+				<ele>951.903978840448</ele>
+				<time>2017-10-30T17:47:27Z</time>
+				<extensions>
+					<speed>4.562870979309082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010185059124549" lon="-84.20214544052858">
+				<ele>952.0802741926163</ele>
+				<time>2017-10-30T17:47:28Z</time>
+				<extensions>
+					<speed>3.1039063930511475</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010204513078703" lon="-84.20213440737798">
+				<ele>952.3346220282838</ele>
+				<time>2017-10-30T17:47:29Z</time>
+				<extensions>
+					<speed>1.3477189540863037</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01021342011525" lon="-84.2021319753577">
+				<ele>952.8665957525373</ele>
+				<time>2017-10-30T17:47:30Z</time>
+				<extensions>
+					<speed>0.5650492310523987</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010212673602453" lon="-84.20213932391303">
+				<ele>953.1826245328411</ele>
+				<time>2017-10-30T17:47:31Z</time>
+				<extensions>
+					<speed>1.3605893850326538</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010207466249211" lon="-84.20215223906523">
+				<ele>953.1498962678015</ele>
+				<time>2017-10-30T17:47:32Z</time>
+				<extensions>
+					<speed>1.590899109840393</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010199726549585" lon="-84.20216546263504">
+				<ele>953.0595341138542</ele>
+				<time>2017-10-30T17:47:33Z</time>
+				<extensions>
+					<speed>1.5119997262954712</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010193698952309" lon="-84.20217629457133">
+				<ele>953.0558504723012</ele>
+				<time>2017-10-30T17:47:34Z</time>
+				<extensions>
+					<speed>0.8991059064865112</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010191470628708" lon="-84.2021844356346">
+				<ele>952.420689644292</ele>
+				<time>2017-10-30T17:47:35Z</time>
+				<extensions>
+					<speed>0.6206525564193726</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010191470628708" lon="-84.2021844356346">
+				<ele>952.420689644292</ele>
+				<time>2017-10-30T17:47:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010196710864578" lon="-84.20218699756722">
+				<ele>952.4362426027656</ele>
+				<time>2017-10-30T17:47:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010196710864578" lon="-84.20218699756722">
+				<ele>952.4362426027656</ele>
+				<time>2017-10-30T17:47:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010196710864578" lon="-84.20218699756722">
+				<ele>952.4362426027656</ele>
+				<time>2017-10-30T17:47:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010196710864578" lon="-84.20218699756722">
+				<ele>952.4362426027656</ele>
+				<time>2017-10-30T17:47:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010196710864578" lon="-84.20218699756722">
+				<ele>952.4362426027656</ele>
+				<time>2017-10-30T17:47:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010196710864578" lon="-84.20218699756722">
+				<ele>952.4362426027656</ele>
+				<time>2017-10-30T17:47:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010196710864578" lon="-84.20218699756722">
+				<ele>952.4362426027656</ele>
+				<time>2017-10-30T17:47:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010196710864578" lon="-84.20218699756722">
+				<ele>952.4362426027656</ele>
+				<time>2017-10-30T17:47:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010196710864578" lon="-84.20218699756722">
+				<ele>952.4362426027656</ele>
+				<time>2017-10-30T17:47:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010196710864578" lon="-84.20218699756722">
+				<ele>952.4362426027656</ele>
+				<time>2017-10-30T17:47:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010196710864578" lon="-84.20218699756722">
+				<ele>952.4362426027656</ele>
+				<time>2017-10-30T17:47:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010196710864578" lon="-84.20218699756722">
+				<ele>952.4362426027656</ele>
+				<time>2017-10-30T17:47:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01020153785647" lon="-84.20218211263841">
+				<ele>952.7553413119167</ele>
+				<time>2017-10-30T17:47:49Z</time>
+				<extensions>
+					<speed>0.9876269102096558</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010216893181733" lon="-84.20216850249012">
+				<ele>952.9358674949035</ele>
+				<time>2017-10-30T17:47:50Z</time>
+				<extensions>
+					<speed>2.196578025817871</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010234240348263" lon="-84.20214679678533">
+				<ele>953.0884020878002</ele>
+				<time>2017-10-30T17:47:51Z</time>
+				<extensions>
+					<speed>3.5794734954833984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01026391952447" lon="-84.2021178533523">
+				<ele>953.3214723663405</ele>
+				<time>2017-10-30T17:47:52Z</time>
+				<extensions>
+					<speed>4.79799222946167</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0103042512146" lon="-84.20208311987591">
+				<ele>953.8618246018887</ele>
+				<time>2017-10-30T17:47:53Z</time>
+				<extensions>
+					<speed>5.7026872634887695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010351991000828" lon="-84.20204617237559">
+				<ele>954.5781256854534</ele>
+				<time>2017-10-30T17:47:54Z</time>
+				<extensions>
+					<speed>6.49202823638916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010402265255868" lon="-84.2020052644388">
+				<ele>955.3757571047172</ele>
+				<time>2017-10-30T17:47:55Z</time>
+				<extensions>
+					<speed>6.871829509735107</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01045703915746" lon="-84.20196532791776">
+				<ele>956.1408124249429</ele>
+				<time>2017-10-30T17:47:56Z</time>
+				<extensions>
+					<speed>7.201871395111084</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01051847239497" lon="-84.20192887939552">
+				<ele>956.4919438874349</ele>
+				<time>2017-10-30T17:47:57Z</time>
+				<extensions>
+					<speed>7.665947914123535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010579333759923" lon="-84.20189359862226">
+				<ele>956.9320964738727</ele>
+				<time>2017-10-30T17:47:58Z</time>
+				<extensions>
+					<speed>7.580341815948486</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01064022550761" lon="-84.20186183481442">
+				<ele>957.2769439173862</ele>
+				<time>2017-10-30T17:47:59Z</time>
+				<extensions>
+					<speed>7.4554948806762695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010704012242561" lon="-84.20183043629174">
+				<ele>957.8730274802074</ele>
+				<time>2017-10-30T17:48:00Z</time>
+				<extensions>
+					<speed>7.911559104919434</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010772991666688" lon="-84.20180075213915">
+				<ele>958.1087651746348</ele>
+				<time>2017-10-30T17:48:01Z</time>
+				<extensions>
+					<speed>8.127952575683594</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010840030600383" lon="-84.20176983397354">
+				<ele>958.266052801162</ele>
+				<time>2017-10-30T17:48:02Z</time>
+				<extensions>
+					<speed>7.858031272888184</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010902972665177" lon="-84.20173824708279">
+				<ele>958.5648627448827</ele>
+				<time>2017-10-30T17:48:03Z</time>
+				<extensions>
+					<speed>7.475487232208252</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01095979675054" lon="-84.2017094772034">
+				<ele>958.6276027122512</ele>
+				<time>2017-10-30T17:48:04Z</time>
+				<extensions>
+					<speed>6.64693021774292</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011005679020244" lon="-84.20168776593215">
+				<ele>958.6883903415874</ele>
+				<time>2017-10-30T17:48:05Z</time>
+				<extensions>
+					<speed>4.730236053466797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011033928583048" lon="-84.20167148336263">
+				<ele>958.710170859471</ele>
+				<time>2017-10-30T17:48:06Z</time>
+				<extensions>
+					<speed>2.5457990169525146</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011048619971476" lon="-84.20166133532182">
+				<ele>958.7138112932444</ele>
+				<time>2017-10-30T17:48:07Z</time>
+				<extensions>
+					<speed>1.2813469171524048</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011057918083662" lon="-84.20165553499075">
+				<ele>958.9421423561871</ele>
+				<time>2017-10-30T17:48:08Z</time>
+				<extensions>
+					<speed>1.1945466995239258</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011062299125983" lon="-84.20164663836302">
+				<ele>958.2097852258012</ele>
+				<time>2017-10-30T17:48:09Z</time>
+				<extensions>
+					<speed>1.1560593843460083</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011071189229073" lon="-84.20163406882709">
+				<ele>957.9008332425728</ele>
+				<time>2017-10-30T17:48:10Z</time>
+				<extensions>
+					<speed>2.2202370166778564</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01109109885336" lon="-84.20161837208761">
+				<ele>957.9668232602999</ele>
+				<time>2017-10-30T17:48:11Z</time>
+				<extensions>
+					<speed>3.1506614685058594</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011124513365083" lon="-84.20159995412006">
+				<ele>958.3747465312481</ele>
+				<time>2017-10-30T17:48:12Z</time>
+				<extensions>
+					<speed>5.008818626403809</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011169400643944" lon="-84.20158225712092">
+				<ele>958.6826711473987</ele>
+				<time>2017-10-30T17:48:13Z</time>
+				<extensions>
+					<speed>5.833444595336914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011223263634484" lon="-84.20156787367279">
+				<ele>958.8316135006025</ele>
+				<time>2017-10-30T17:48:14Z</time>
+				<extensions>
+					<speed>6.689490795135498</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011284788775331" lon="-84.20154243094296">
+				<ele>958.6999987298623</ele>
+				<time>2017-10-30T17:48:15Z</time>
+				<extensions>
+					<speed>7.4600396156311035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011348251581248" lon="-84.20150737685708">
+				<ele>958.5048067290336</ele>
+				<time>2017-10-30T17:48:16Z</time>
+				<extensions>
+					<speed>6.90057897567749</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01140373820465" lon="-84.20147516151489">
+				<ele>958.6279571540654</ele>
+				<time>2017-10-30T17:48:17Z</time>
+				<extensions>
+					<speed>5.834675312042236</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011446031373177" lon="-84.20145019634364">
+				<ele>958.6120996326208</ele>
+				<time>2017-10-30T17:48:18Z</time>
+				<extensions>
+					<speed>3.888437509536743</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011471533379751" lon="-84.20143569114803">
+				<ele>958.5840690433979</ele>
+				<time>2017-10-30T17:48:19Z</time>
+				<extensions>
+					<speed>1.6219229698181152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01148187400372" lon="-84.20142856777954">
+				<ele>958.7158510377631</ele>
+				<time>2017-10-30T17:48:20Z</time>
+				<extensions>
+					<speed>0.23306100070476532</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011483372584605" lon="-84.2014243869893">
+				<ele>959.0564930709079</ele>
+				<time>2017-10-30T17:48:21Z</time>
+				<extensions>
+					<speed>0.23066997528076172</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011483372584605" lon="-84.2014243869893">
+				<ele>959.0564930709079</ele>
+				<time>2017-10-30T17:48:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011473881568586" lon="-84.20142834198327">
+				<ele>958.6649681646377</ele>
+				<time>2017-10-30T17:48:23Z</time>
+				<extensions>
+					<speed>1.3033688068389893</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01146112853204" lon="-84.20142874669786">
+				<ele>958.308708883822</ele>
+				<time>2017-10-30T17:48:24Z</time>
+				<extensions>
+					<speed>1.3959952592849731</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011447351785392" lon="-84.20143273655493">
+				<ele>957.9836751641706</ele>
+				<time>2017-10-30T17:48:25Z</time>
+				<extensions>
+					<speed>1.3482416868209839</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011438594101636" lon="-84.20143454081696">
+				<ele>957.8707959521562</ele>
+				<time>2017-10-30T17:48:26Z</time>
+				<extensions>
+					<speed>0.5756065845489502</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011438594101636" lon="-84.20143454081696">
+				<ele>957.8707959521562</ele>
+				<time>2017-10-30T17:48:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011434133918671" lon="-84.20143293309457">
+				<ele>957.8046242203563</ele>
+				<time>2017-10-30T17:48:28Z</time>
+				<extensions>
+					<speed>0.3589687645435333</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011434133918671" lon="-84.20143293309457">
+				<ele>957.8046242203563</ele>
+				<time>2017-10-30T17:48:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011434133918671" lon="-84.20143293309457">
+				<ele>957.8046242203563</ele>
+				<time>2017-10-30T17:48:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011434133918671" lon="-84.20143293309457">
+				<ele>957.8046242203563</ele>
+				<time>2017-10-30T17:48:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011434133918671" lon="-84.20143293309457">
+				<ele>957.8046242203563</ele>
+				<time>2017-10-30T17:48:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011434133918671" lon="-84.20143293309457">
+				<ele>957.8046242203563</ele>
+				<time>2017-10-30T17:48:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01143908167386" lon="-84.20143042198457">
+				<ele>957.4815679406747</ele>
+				<time>2017-10-30T17:48:34Z</time>
+				<extensions>
+					<speed>0.6931207776069641</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011447344959985" lon="-84.20142556036473">
+				<ele>957.3936678664759</ele>
+				<time>2017-10-30T17:48:35Z</time>
+				<extensions>
+					<speed>1.37056565284729</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0114634393062" lon="-84.20141824196585">
+				<ele>956.9345232499763</ele>
+				<time>2017-10-30T17:48:36Z</time>
+				<extensions>
+					<speed>2.2294931411743164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011488402574996" lon="-84.20141259207828">
+				<ele>956.903282170184</ele>
+				<time>2017-10-30T17:48:37Z</time>
+				<extensions>
+					<speed>2.8521413803100586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011525035918822" lon="-84.20140328452176">
+				<ele>956.6214632615447</ele>
+				<time>2017-10-30T17:48:38Z</time>
+				<extensions>
+					<speed>4.325016498565674</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01156704074797" lon="-84.2013876092899">
+				<ele>956.1965064955875</ele>
+				<time>2017-10-30T17:48:39Z</time>
+				<extensions>
+					<speed>5.357324123382568</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011615540216306" lon="-84.2013636384874">
+				<ele>955.6582248546183</ele>
+				<time>2017-10-30T17:48:40Z</time>
+				<extensions>
+					<speed>6.2735915184021</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011673013879626" lon="-84.2013339930725">
+				<ele>955.2140112742782</ele>
+				<time>2017-10-30T17:48:41Z</time>
+				<extensions>
+					<speed>7.496068954467773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011738136084297" lon="-84.20130300479045">
+				<ele>954.620025944896</ele>
+				<time>2017-10-30T17:48:42Z</time>
+				<extensions>
+					<speed>7.957003593444824</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011805694670887" lon="-84.20126834122297">
+				<ele>954.3601707192138</ele>
+				<time>2017-10-30T17:48:43Z</time>
+				<extensions>
+					<speed>8.270475387573242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011875970361992" lon="-84.20123005949746">
+				<ele>953.854995473288</ele>
+				<time>2017-10-30T17:48:44Z</time>
+				<extensions>
+					<speed>8.166200637817383</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011943574825002" lon="-84.20119339691065">
+				<ele>953.0393613679335</ele>
+				<time>2017-10-30T17:48:45Z</time>
+				<extensions>
+					<speed>7.84593391418457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01200597612347" lon="-84.20116182736324">
+				<ele>952.7774141626433</ele>
+				<time>2017-10-30T17:48:46Z</time>
+				<extensions>
+					<speed>7.0465922355651855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012063269011628" lon="-84.20113342546337">
+				<ele>952.6264314195141</ele>
+				<time>2017-10-30T17:48:47Z</time>
+				<extensions>
+					<speed>6.681495666503906</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012117685903887" lon="-84.20110566612455">
+				<ele>952.537476751022</ele>
+				<time>2017-10-30T17:48:48Z</time>
+				<extensions>
+					<speed>6.289172649383545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012162360557097" lon="-84.20108146163163">
+				<ele>952.2938976734877</ele>
+				<time>2017-10-30T17:48:49Z</time>
+				<extensions>
+					<speed>4.46602725982666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012193338702566" lon="-84.20106547154727">
+				<ele>951.9755067545921</ele>
+				<time>2017-10-30T17:48:50Z</time>
+				<extensions>
+					<speed>2.5876145362854004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012213244084652" lon="-84.20105784190373">
+				<ele>951.8421061364934</ele>
+				<time>2017-10-30T17:48:51Z</time>
+				<extensions>
+					<speed>1.5250738859176636</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012227716804919" lon="-84.20105334832733">
+				<ele>951.9866486815736</ele>
+				<time>2017-10-30T17:48:52Z</time>
+				<extensions>
+					<speed>1.082454800605774</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012240090806241" lon="-84.20104671442908">
+				<ele>952.3686482319608</ele>
+				<time>2017-10-30T17:48:53Z</time>
+				<extensions>
+					<speed>1.362009882926941</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01225774659058" lon="-84.20103394464896">
+				<ele>952.689270333387</ele>
+				<time>2017-10-30T17:48:54Z</time>
+				<extensions>
+					<speed>2.5395569801330566</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012283479984184" lon="-84.20101461214219">
+				<ele>952.6976356301457</ele>
+				<time>2017-10-30T17:48:55Z</time>
+				<extensions>
+					<speed>4.007577896118164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01232220761172" lon="-84.20098908697119">
+				<ele>952.6757950177416</ele>
+				<time>2017-10-30T17:48:56Z</time>
+				<extensions>
+					<speed>5.428229331970215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012373876014692" lon="-84.20096333216041">
+				<ele>952.5802305601537</ele>
+				<time>2017-10-30T17:48:57Z</time>
+				<extensions>
+					<speed>6.731479644775391</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012432361237856" lon="-84.20093271047811">
+				<ele>952.5616995263845</ele>
+				<time>2017-10-30T17:48:58Z</time>
+				<extensions>
+					<speed>7.481996536254883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012494443639447" lon="-84.20089614251764">
+				<ele>952.3713920423761</ele>
+				<time>2017-10-30T17:48:59Z</time>
+				<extensions>
+					<speed>7.8483710289001465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012558017945596" lon="-84.2008545187767">
+				<ele>952.4011215027422</ele>
+				<time>2017-10-30T17:49:00Z</time>
+				<extensions>
+					<speed>7.928517818450928</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012624401011761" lon="-84.20081355902109">
+				<ele>952.6036441614851</ele>
+				<time>2017-10-30T17:49:01Z</time>
+				<extensions>
+					<speed>7.865422248840332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01269001385657" lon="-84.20077219072303">
+				<ele>953.5243716519326</ele>
+				<time>2017-10-30T17:49:02Z</time>
+				<extensions>
+					<speed>7.776738166809082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012747579224735" lon="-84.20073082673565">
+				<ele>954.5614759651944</ele>
+				<time>2017-10-30T17:49:03Z</time>
+				<extensions>
+					<speed>7.256366729736328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012800958009828" lon="-84.20069743343478">
+				<ele>954.9060385553166</ele>
+				<time>2017-10-30T17:49:04Z</time>
+				<extensions>
+					<speed>6.42638635635376</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012850096628227" lon="-84.20067392763765">
+				<ele>955.1379795446992</ele>
+				<time>2017-10-30T17:49:05Z</time>
+				<extensions>
+					<speed>5.161294937133789</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012892534720264" lon="-84.20065603326195">
+				<ele>955.5273645156994</ele>
+				<time>2017-10-30T17:49:06Z</time>
+				<extensions>
+					<speed>4.390858173370361</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012930919253764" lon="-84.20064350953099">
+				<ele>955.6854247879237</ele>
+				<time>2017-10-30T17:49:07Z</time>
+				<extensions>
+					<speed>3.527217388153076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012964481866835" lon="-84.2006379128328">
+				<ele>955.7032333845273</ele>
+				<time>2017-10-30T17:49:08Z</time>
+				<extensions>
+					<speed>3.060119152069092</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012991804902084" lon="-84.20064039381657">
+				<ele>955.4567048884928</ele>
+				<time>2017-10-30T17:49:09Z</time>
+				<extensions>
+					<speed>2.410280466079712</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013014396730933" lon="-84.20064971984092">
+				<ele>955.2395732300356</ele>
+				<time>2017-10-30T17:49:10Z</time>
+				<extensions>
+					<speed>2.4743144512176514</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013033550380623" lon="-84.20066960269187">
+				<ele>954.9282869501039</ele>
+				<time>2017-10-30T17:49:11Z</time>
+				<extensions>
+					<speed>3.1193525791168213</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013052578468782" lon="-84.20070173477556">
+				<ele>954.6814228761941</ele>
+				<time>2017-10-30T17:49:12Z</time>
+				<extensions>
+					<speed>4.5203447341918945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01307575971971" lon="-84.2007490741784">
+				<ele>954.0807585110888</ele>
+				<time>2017-10-30T17:49:13Z</time>
+				<extensions>
+					<speed>5.98382568359375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013103954526702" lon="-84.2008075975599">
+				<ele>953.4281757436693</ele>
+				<time>2017-10-30T17:49:14Z</time>
+				<extensions>
+					<speed>7.159423828125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013135347811373" lon="-84.20086915379261">
+				<ele>952.9828108539805</ele>
+				<time>2017-10-30T17:49:15Z</time>
+				<extensions>
+					<speed>7.1744585037231445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013166529684243" lon="-84.20092898162734">
+				<ele>952.672112967819</ele>
+				<time>2017-10-30T17:49:16Z</time>
+				<extensions>
+					<speed>7.119142532348633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013198392206526" lon="-84.20098580204527">
+				<ele>952.4391091093421</ele>
+				<time>2017-10-30T17:49:17Z</time>
+				<extensions>
+					<speed>7.083821773529053</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01323125373928" lon="-84.20104563014434">
+				<ele>952.2461522230878</ele>
+				<time>2017-10-30T17:49:18Z</time>
+				<extensions>
+					<speed>7.416434288024902</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01327200256428" lon="-84.20110553452069">
+				<ele>951.9683190090582</ele>
+				<time>2017-10-30T17:49:19Z</time>
+				<extensions>
+					<speed>7.788542747497559</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013320823520427" lon="-84.201163268215">
+				<ele>951.4996282802895</ele>
+				<time>2017-10-30T17:49:20Z</time>
+				<extensions>
+					<speed>7.6437554359436035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013368131471912" lon="-84.20121913171624">
+				<ele>951.1638709669933</ele>
+				<time>2017-10-30T17:49:21Z</time>
+				<extensions>
+					<speed>7.856963157653809</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01341352307934" lon="-84.2012699857487">
+				<ele>950.9131300291047</ele>
+				<time>2017-10-30T17:49:22Z</time>
+				<extensions>
+					<speed>6.919752597808838</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01345491471106" lon="-84.2013113803937">
+				<ele>950.8354406896979</ele>
+				<time>2017-10-30T17:49:23Z</time>
+				<extensions>
+					<speed>5.762434959411621</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013494347904096" lon="-84.20134654404379">
+				<ele>950.7670045737177</ele>
+				<time>2017-10-30T17:49:24Z</time>
+				<extensions>
+					<speed>5.583822727203369</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013534368315897" lon="-84.20138088429027">
+				<ele>950.7125198477879</ele>
+				<time>2017-10-30T17:49:25Z</time>
+				<extensions>
+					<speed>5.773679256439209</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013575546483695" lon="-84.2014211392681">
+				<ele>950.6545155169442</ele>
+				<time>2017-10-30T17:49:26Z</time>
+				<extensions>
+					<speed>6.412940979003906</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013620737647518" lon="-84.20146832220514">
+				<ele>950.4518403774127</ele>
+				<time>2017-10-30T17:49:27Z</time>
+				<extensions>
+					<speed>7.20862340927124</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013671309359738" lon="-84.20152018098132">
+				<ele>950.1783820725977</ele>
+				<time>2017-10-30T17:49:28Z</time>
+				<extensions>
+					<speed>7.880180358886719</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013722985442666" lon="-84.20157661533241">
+				<ele>949.8675551153719</ele>
+				<time>2017-10-30T17:49:29Z</time>
+				<extensions>
+					<speed>8.681440353393555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013776028385598" lon="-84.20163847631912">
+				<ele>949.6305579487234</ele>
+				<time>2017-10-30T17:49:30Z</time>
+				<extensions>
+					<speed>8.756503105163574</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013830067130542" lon="-84.20170546315276">
+				<ele>948.893051173538</ele>
+				<time>2017-10-30T17:49:31Z</time>
+				<extensions>
+					<speed>9.185995101928711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013879339128097" lon="-84.20177882982267">
+				<ele>948.803325260058</ele>
+				<time>2017-10-30T17:49:32Z</time>
+				<extensions>
+					<speed>9.11167049407959</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013922710351894" lon="-84.20185094304497">
+				<ele>948.83677077014</ele>
+				<time>2017-10-30T17:49:33Z</time>
+				<extensions>
+					<speed>8.903757095336914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01396054298055" lon="-84.20192095062554">
+				<ele>948.7163039576262</ele>
+				<time>2017-10-30T17:49:34Z</time>
+				<extensions>
+					<speed>8.428837776184082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013993277820154" lon="-84.20198896479728">
+				<ele>948.6470263358206</ele>
+				<time>2017-10-30T17:49:35Z</time>
+				<extensions>
+					<speed>7.867644309997559</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014022945462791" lon="-84.20205067522332">
+				<ele>948.469274786301</ele>
+				<time>2017-10-30T17:49:36Z</time>
+				<extensions>
+					<speed>7.183412075042725</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014050877510305" lon="-84.20210879609886">
+				<ele>948.2132673775777</ele>
+				<time>2017-10-30T17:49:37Z</time>
+				<extensions>
+					<speed>6.689363479614258</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014074464190571" lon="-84.2021597529128">
+				<ele>947.6150204697624</ele>
+				<time>2017-10-30T17:49:38Z</time>
+				<extensions>
+					<speed>5.509006977081299</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014092498954206" lon="-84.2022007968106">
+				<ele>947.2905185157433</ele>
+				<time>2017-10-30T17:49:39Z</time>
+				<extensions>
+					<speed>4.362257957458496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014106796703185" lon="-84.2022292321577">
+				<ele>946.9291903274134</ele>
+				<time>2017-10-30T17:49:40Z</time>
+				<extensions>
+					<speed>2.711855173110962</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014114967710864" lon="-84.2022427903256">
+				<ele>946.7046907749027</ele>
+				<time>2017-10-30T17:49:41Z</time>
+				<extensions>
+					<speed>1.0626131296157837</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014117409039365" lon="-84.20224297220467">
+				<ele>946.9174525868148</ele>
+				<time>2017-10-30T17:49:42Z</time>
+				<extensions>
+					<speed>0.40864473581314087</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014117409039365" lon="-84.20224297220467">
+				<ele>946.9174525868148</ele>
+				<time>2017-10-30T17:49:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014114233905966" lon="-84.20223180074933">
+				<ele>947.0301535688341</ele>
+				<time>2017-10-30T17:49:44Z</time>
+				<extensions>
+					<speed>1.5352959632873535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014109981428128" lon="-84.2022183330527">
+				<ele>947.1309783011675</ele>
+				<time>2017-10-30T17:49:45Z</time>
+				<extensions>
+					<speed>1.3898582458496094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014107974029958" lon="-84.20221127572577">
+				<ele>947.0386117305607</ele>
+				<time>2017-10-30T17:49:46Z</time>
+				<extensions>
+					<speed>0.6433512568473816</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014107974029958" lon="-84.20221127572577">
+				<ele>947.0386117305607</ele>
+				<time>2017-10-30T17:49:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014107829142947" lon="-84.20221135796662">
+				<ele>946.790593589656</ele>
+				<time>2017-10-30T17:49:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014107829142947" lon="-84.20221135796662">
+				<ele>946.790593589656</ele>
+				<time>2017-10-30T17:49:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014107829142947" lon="-84.20221135796662">
+				<ele>946.790593589656</ele>
+				<time>2017-10-30T17:49:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014107829142947" lon="-84.20221135796662">
+				<ele>946.790593589656</ele>
+				<time>2017-10-30T17:49:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014107829142947" lon="-84.20221135796662">
+				<ele>946.790593589656</ele>
+				<time>2017-10-30T17:49:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014107829142947" lon="-84.20221135796662">
+				<ele>946.790593589656</ele>
+				<time>2017-10-30T17:49:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014107829142947" lon="-84.20221135796662">
+				<ele>946.790593589656</ele>
+				<time>2017-10-30T17:49:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014107829142947" lon="-84.20221135796662">
+				<ele>946.790593589656</ele>
+				<time>2017-10-30T17:49:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014107829142947" lon="-84.20221135796662">
+				<ele>946.790593589656</ele>
+				<time>2017-10-30T17:49:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014107829142947" lon="-84.20221135796662">
+				<ele>946.790593589656</ele>
+				<time>2017-10-30T17:49:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014108805351013" lon="-84.20222014794099">
+				<ele>947.1041501900181</ele>
+				<time>2017-10-30T17:49:58Z</time>
+				<extensions>
+					<speed>1.0235790014266968</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014112488958238" lon="-84.2022323721952">
+				<ele>947.2097368631512</ele>
+				<time>2017-10-30T17:49:59Z</time>
+				<extensions>
+					<speed>1.489040493965149</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014120478838588" lon="-84.2022542985985">
+				<ele>947.1304537346587</ele>
+				<time>2017-10-30T17:50:00Z</time>
+				<extensions>
+					<speed>3.273784637451172</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014135351429998" lon="-84.20228823247709">
+				<ele>946.9973803460598</ele>
+				<time>2017-10-30T17:50:01Z</time>
+				<extensions>
+					<speed>4.667932987213135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014155734388686" lon="-84.20233121975937">
+				<ele>946.8257354041561</ele>
+				<time>2017-10-30T17:50:02Z</time>
+				<extensions>
+					<speed>5.478481292724609</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01418017951244" lon="-84.20237459882073">
+				<ele>946.8875141199678</ele>
+				<time>2017-10-30T17:50:03Z</time>
+				<extensions>
+					<speed>5.277094841003418</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014209956146582" lon="-84.20241205080676">
+				<ele>947.0101912189275</ele>
+				<time>2017-10-30T17:50:04Z</time>
+				<extensions>
+					<speed>5.333934783935547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014246058293535" lon="-84.20244299703118">
+				<ele>947.1030544433743</ele>
+				<time>2017-10-30T17:50:05Z</time>
+				<extensions>
+					<speed>5.109076976776123</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014289872447875" lon="-84.20245855904906">
+				<ele>947.0326170520857</ele>
+				<time>2017-10-30T17:50:06Z</time>
+				<extensions>
+					<speed>5.200993061065674</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014342038293933" lon="-84.2024566595756">
+				<ele>946.9131335765123</ele>
+				<time>2017-10-30T17:50:07Z</time>
+				<extensions>
+					<speed>5.973491191864014</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01440040197816" lon="-84.20243636543289">
+				<ele>946.7948078708723</ele>
+				<time>2017-10-30T17:50:08Z</time>
+				<extensions>
+					<speed>7.317296981811523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014463774762064" lon="-84.2024038273912">
+				<ele>946.9468928845599</ele>
+				<time>2017-10-30T17:50:09Z</time>
+				<extensions>
+					<speed>8.206018447875977</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014530502903556" lon="-84.20236417968069">
+				<ele>946.7981923930347</ele>
+				<time>2017-10-30T17:50:10Z</time>
+				<extensions>
+					<speed>8.754290580749512</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014598642418582" lon="-84.20232063090167">
+				<ele>946.8080985285342</ele>
+				<time>2017-10-30T17:50:11Z</time>
+				<extensions>
+					<speed>9.065351486206055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014671420724687" lon="-84.20227739065335">
+				<ele>946.9764440897852</ele>
+				<time>2017-10-30T17:50:12Z</time>
+				<extensions>
+					<speed>9.505289077758789</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014748499706931" lon="-84.20223570752333">
+				<ele>947.2158474037424</ele>
+				<time>2017-10-30T17:50:13Z</time>
+				<extensions>
+					<speed>9.709485054016113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825037607801" lon="-84.20219513254163">
+				<ele>947.4859592830762</ele>
+				<time>2017-10-30T17:50:14Z</time>
+				<extensions>
+					<speed>9.55859375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014900444460311" lon="-84.20215471108853">
+				<ele>947.6120721893385</ele>
+				<time>2017-10-30T17:50:15Z</time>
+				<extensions>
+					<speed>9.35144329071045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014974632886215" lon="-84.20211511022781">
+				<ele>947.9895955268294</ele>
+				<time>2017-10-30T17:50:16Z</time>
+				<extensions>
+					<speed>9.235889434814453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015042802607354" lon="-84.20207766308836">
+				<ele>948.20481006708</ele>
+				<time>2017-10-30T17:50:17Z</time>
+				<extensions>
+					<speed>8.220821380615234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015102303985019" lon="-84.20204415741311">
+				<ele>948.4825175106525</ele>
+				<time>2017-10-30T17:50:18Z</time>
+				<extensions>
+					<speed>7.286430358886719</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01515416174521" lon="-84.20201373081497">
+				<ele>948.6307898573577</ele>
+				<time>2017-10-30T17:50:19Z</time>
+				<extensions>
+					<speed>6.402259826660156</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015197813439356" lon="-84.20198255400685">
+				<ele>948.8020715648308</ele>
+				<time>2017-10-30T17:50:20Z</time>
+				<extensions>
+					<speed>5.489706993103027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015236964590018" lon="-84.20197061889404">
+				<ele>949.3460491467267</ele>
+				<time>2017-10-30T17:50:21Z</time>
+				<extensions>
+					<speed>4.361176013946533</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01526158038357" lon="-84.20194905868303">
+				<ele>949.5576771134511</ele>
+				<time>2017-10-30T17:50:22Z</time>
+				<extensions>
+					<speed>2.877610921859741</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015274383545329" lon="-84.20193373140003">
+				<ele>949.5347539931536</ele>
+				<time>2017-10-30T17:50:23Z</time>
+				<extensions>
+					<speed>1.551988959312439</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01527623067863" lon="-84.20192248874324">
+				<ele>949.5007237205282</ele>
+				<time>2017-10-30T17:50:24Z</time>
+				<extensions>
+					<speed>0.29993048310279846</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015267120589387" lon="-84.20192419665942">
+				<ele>949.5098825357854</ele>
+				<time>2017-10-30T17:50:25Z</time>
+				<extensions>
+					<speed>1.1558077335357666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525144666536" lon="-84.20192511682457">
+				<ele>949.7753966106102</ele>
+				<time>2017-10-30T17:50:26Z</time>
+				<extensions>
+					<speed>1.376571774482727</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01523777767595" lon="-84.20192446309065">
+				<ele>949.7830364713445</ele>
+				<time>2017-10-30T17:50:27Z</time>
+				<extensions>
+					<speed>1.160197377204895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015227422579535" lon="-84.20192055111117">
+				<ele>949.7043603416532</ele>
+				<time>2017-10-30T17:50:28Z</time>
+				<extensions>
+					<speed>0.9190371036529541</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015227422579535" lon="-84.20192055111117">
+				<ele>949.7043603416532</ele>
+				<time>2017-10-30T17:50:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015223555972993" lon="-84.20192070637273">
+				<ele>949.3387958128005</ele>
+				<time>2017-10-30T17:50:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015223555972993" lon="-84.20192070637273">
+				<ele>949.3387958128005</ele>
+				<time>2017-10-30T17:50:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015223555972993" lon="-84.20192070637273">
+				<ele>949.3387958128005</ele>
+				<time>2017-10-30T17:50:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015223555972993" lon="-84.20192070637273">
+				<ele>949.3387958128005</ele>
+				<time>2017-10-30T17:50:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015223555972993" lon="-84.20192070637273">
+				<ele>949.3387958128005</ele>
+				<time>2017-10-30T17:50:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015223555972993" lon="-84.20192070637273">
+				<ele>949.3387958128005</ele>
+				<time>2017-10-30T17:50:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015223555972993" lon="-84.20192070637273">
+				<ele>949.3387958128005</ele>
+				<time>2017-10-30T17:50:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015223555972993" lon="-84.20192070637273">
+				<ele>949.3387958128005</ele>
+				<time>2017-10-30T17:50:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015223555972993" lon="-84.20192070637273">
+				<ele>949.3387958128005</ele>
+				<time>2017-10-30T17:50:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015223555972993" lon="-84.20192070637273">
+				<ele>949.3387958128005</ele>
+				<time>2017-10-30T17:50:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015223555972993" lon="-84.20192070637273">
+				<ele>949.3387958128005</ele>
+				<time>2017-10-30T17:50:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015223555972993" lon="-84.20192070637273">
+				<ele>949.3387958128005</ele>
+				<time>2017-10-30T17:50:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015223555972993" lon="-84.20192070637273">
+				<ele>949.3387958128005</ele>
+				<time>2017-10-30T17:50:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015223555972993" lon="-84.20192070637273">
+				<ele>949.3387958128005</ele>
+				<time>2017-10-30T17:50:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015223555972993" lon="-84.20192070637273">
+				<ele>949.3387958128005</ele>
+				<time>2017-10-30T17:50:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015223555972993" lon="-84.20192070637273">
+				<ele>949.3387958128005</ele>
+				<time>2017-10-30T17:50:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015232694841382" lon="-84.20191471274559">
+				<ele>949.4737857989967</ele>
+				<time>2017-10-30T17:50:46Z</time>
+				<extensions>
+					<speed>1.6261348724365234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525018641786" lon="-84.20190079601575">
+				<ele>950.1631508683786</ele>
+				<time>2017-10-30T17:50:47Z</time>
+				<extensions>
+					<speed>2.9100828170776367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015272054049746" lon="-84.20187749307998">
+				<ele>951.4041032344103</ele>
+				<time>2017-10-30T17:50:48Z</time>
+				<extensions>
+					<speed>3.7795941829681396</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015299587616006" lon="-84.20184603104467">
+				<ele>952.7873044516891</ele>
+				<time>2017-10-30T17:50:49Z</time>
+				<extensions>
+					<speed>4.697282314300537</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015331460621452" lon="-84.20181140363586">
+				<ele>954.2673420533538</ele>
+				<time>2017-10-30T17:50:50Z</time>
+				<extensions>
+					<speed>5.289520740509033</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015368737706659" lon="-84.20177467724007">
+				<ele>955.4336476661265</ele>
+				<time>2017-10-30T17:50:51Z</time>
+				<extensions>
+					<speed>5.326369285583496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015400933985594" lon="-84.20174267658598">
+				<ele>955.8929186109453</ele>
+				<time>2017-10-30T17:50:52Z</time>
+				<extensions>
+					<speed>4.318240165710449</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015423864605616" lon="-84.20171983685385">
+				<ele>955.9171132361516</ele>
+				<time>2017-10-30T17:50:53Z</time>
+				<extensions>
+					<speed>2.503085136413574</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01543528305799" lon="-84.20171000296259">
+				<ele>956.4947068272159</ele>
+				<time>2017-10-30T17:50:54Z</time>
+				<extensions>
+					<speed>0.5563845634460449</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015440043412365" lon="-84.20170998607668">
+				<ele>956.8610034044832</ele>
+				<time>2017-10-30T17:50:55Z</time>
+				<extensions>
+					<speed>0.021773947402834892</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015440043412365" lon="-84.20170998607668">
+				<ele>956.8418432697654</ele>
+				<time>2017-10-30T17:50:56Z</time>
+				<extensions>
+					<speed>1.2542279958724976</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015440043412365" lon="-84.20170998607668">
+				<ele>956.6196701107547</ele>
+				<time>2017-10-30T17:50:57Z</time>
+				<extensions>
+					<speed>1.6119158267974854</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015440043412365" lon="-84.20170998607668">
+				<ele>956.4325715554878</ele>
+				<time>2017-10-30T17:50:58Z</time>
+				<extensions>
+					<speed>1.4348783493041992</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015413674223375" lon="-84.20173766327774">
+				<ele>955.4041888993233</ele>
+				<time>2017-10-30T17:50:59Z</time>
+				<extensions>
+					<speed>1.4652022123336792</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015403807490706" lon="-84.20174783481805">
+				<ele>955.006494326517</ele>
+				<time>2017-10-30T17:51:00Z</time>
+				<extensions>
+					<speed>1.547519564628601</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015392770097048" lon="-84.20175682229392">
+				<ele>954.7904319483787</ele>
+				<time>2017-10-30T17:51:01Z</time>
+				<extensions>
+					<speed>1.5117377042770386</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015380914769631" lon="-84.20176234363898">
+				<ele>954.6208506189287</ele>
+				<time>2017-10-30T17:51:02Z</time>
+				<extensions>
+					<speed>1.298895001411438</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015368723427711" lon="-84.20176507287641">
+				<ele>954.3349878815934</ele>
+				<time>2017-10-30T17:51:03Z</time>
+				<extensions>
+					<speed>1.477669358253479</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015359949084155" lon="-84.20176752427979">
+				<ele>953.3860656032339</ele>
+				<time>2017-10-30T17:51:04Z</time>
+				<extensions>
+					<speed>1.4826511144638062</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01535182959074" lon="-84.20176810383043">
+				<ele>952.8146804114804</ele>
+				<time>2017-10-30T17:51:05Z</time>
+				<extensions>
+					<speed>1.1119322776794434</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015345429356199" lon="-84.20176733895774">
+				<ele>952.3406343357638</ele>
+				<time>2017-10-30T17:51:06Z</time>
+				<extensions>
+					<speed>0.8906244039535522</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015341099169898" lon="-84.20176740232799">
+				<ele>952.3998439330608</ele>
+				<time>2017-10-30T17:51:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015338707383318" lon="-84.20176821873554">
+				<ele>951.9394450290129</ele>
+				<time>2017-10-30T17:51:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015338707383318" lon="-84.20176821873554">
+				<ele>951.9394450290129</ele>
+				<time>2017-10-30T17:51:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015338707383318" lon="-84.20176821873554">
+				<ele>951.9394450290129</ele>
+				<time>2017-10-30T17:51:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015338707383318" lon="-84.20176821873554">
+				<ele>951.9394450290129</ele>
+				<time>2017-10-30T17:51:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015340624664061" lon="-84.20177248257892">
+				<ele>952.1829215735197</ele>
+				<time>2017-10-30T17:51:12Z</time>
+				<extensions>
+					<speed>0.730171799659729</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01534249201501" lon="-84.20177752608606">
+				<ele>952.2719257790595</ele>
+				<time>2017-10-30T17:51:13Z</time>
+				<extensions>
+					<speed>0.8438094258308411</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01534523839446" lon="-84.20178353397044">
+				<ele>951.9003823306412</ele>
+				<time>2017-10-30T17:51:14Z</time>
+				<extensions>
+					<speed>0.712192177772522</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015348807171563" lon="-84.20178967949077">
+				<ele>951.626760601066</ele>
+				<time>2017-10-30T17:51:15Z</time>
+				<extensions>
+					<speed>0.877062201499939</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01535196532031" lon="-84.20179819087065">
+				<ele>951.3680515838787</ele>
+				<time>2017-10-30T17:51:16Z</time>
+				<extensions>
+					<speed>1.0631115436553955</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015359760735633" lon="-84.2018040887812">
+				<ele>950.7173279700801</ele>
+				<time>2017-10-30T17:51:17Z</time>
+				<extensions>
+					<speed>1.2613639831542969</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01536420416839" lon="-84.20181647844004">
+				<ele>950.7489284640178</ele>
+				<time>2017-10-30T17:51:18Z</time>
+				<extensions>
+					<speed>1.9029572010040283</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015365653183663" lon="-84.20183505186871">
+				<ele>950.4981759069487</ele>
+				<time>2017-10-30T17:51:19Z</time>
+				<extensions>
+					<speed>2.199570894241333</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015360222111294" lon="-84.2018583451709">
+				<ele>950.6229367256165</ele>
+				<time>2017-10-30T17:51:20Z</time>
+				<extensions>
+					<speed>2.9684953689575195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015344702076996" lon="-84.20189073289907">
+				<ele>950.6992472158745</ele>
+				<time>2017-10-30T17:51:21Z</time>
+				<extensions>
+					<speed>4.7805914878845215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015313630175163" lon="-84.20193210656402">
+				<ele>950.7980260858312</ele>
+				<time>2017-10-30T17:51:22Z</time>
+				<extensions>
+					<speed>6.380279541015625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015267570848737" lon="-84.20197848232222">
+				<ele>950.7499862033874</ele>
+				<time>2017-10-30T17:51:23Z</time>
+				<extensions>
+					<speed>7.597446441650391</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015204825876298" lon="-84.20202281669087">
+				<ele>950.6289233695716</ele>
+				<time>2017-10-30T17:51:24Z</time>
+				<extensions>
+					<speed>8.74147891998291</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015128855420725" lon="-84.20206252391478">
+				<ele>950.6923300055787</ele>
+				<time>2017-10-30T17:51:25Z</time>
+				<extensions>
+					<speed>9.838888168334961</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015046128752134" lon="-84.20210273726165">
+				<ele>950.7477466184646</ele>
+				<time>2017-10-30T17:51:26Z</time>
+				<extensions>
+					<speed>10.204394340515137</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014964557180111" lon="-84.20214098328755">
+				<ele>950.7759220385924</ele>
+				<time>2017-10-30T17:51:27Z</time>
+				<extensions>
+					<speed>9.641518592834473</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014888675389008" lon="-84.20217392574001">
+				<ele>950.6912649627775</ele>
+				<time>2017-10-30T17:51:28Z</time>
+				<extensions>
+					<speed>8.588302612304688</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014819145208488" lon="-84.20220262612706">
+				<ele>950.7318979827687</ele>
+				<time>2017-10-30T17:51:29Z</time>
+				<extensions>
+					<speed>7.908724784851074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014756198583155" lon="-84.2022288971109">
+				<ele>950.8997584795579</ele>
+				<time>2017-10-30T17:51:30Z</time>
+				<extensions>
+					<speed>7.141716480255127</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01469820794675" lon="-84.20225181297266">
+				<ele>951.1131406463683</ele>
+				<time>2017-10-30T17:51:31Z</time>
+				<extensions>
+					<speed>6.469364166259766</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014643647169658" lon="-84.20227612345272">
+				<ele>951.0352387661114</ele>
+				<time>2017-10-30T17:51:32Z</time>
+				<extensions>
+					<speed>6.626023292541504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01459042386825" lon="-84.2023023955913">
+				<ele>951.2264847597107</ele>
+				<time>2017-10-30T17:51:33Z</time>
+				<extensions>
+					<speed>6.308387279510498</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014541800315957" lon="-84.20232819535593">
+				<ele>951.4316986938938</ele>
+				<time>2017-10-30T17:51:34Z</time>
+				<extensions>
+					<speed>5.868349075317383</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014498127270555" lon="-84.20235446338027">
+				<ele>951.622576257214</ele>
+				<time>2017-10-30T17:51:35Z</time>
+				<extensions>
+					<speed>5.493402004241943</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01446034424968" lon="-84.20238079236881">
+				<ele>951.75022558216</ele>
+				<time>2017-10-30T17:51:36Z</time>
+				<extensions>
+					<speed>5.007800579071045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0144269088628" lon="-84.20240564439737">
+				<ele>951.9036398679018</ele>
+				<time>2017-10-30T17:51:37Z</time>
+				<extensions>
+					<speed>4.527032375335693</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01439831481776" lon="-84.20243007547693">
+				<ele>951.7853974644095</ele>
+				<time>2017-10-30T17:51:38Z</time>
+				<extensions>
+					<speed>4.012081146240234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014373022756502" lon="-84.20244881309596">
+				<ele>951.4910287987441</ele>
+				<time>2017-10-30T17:51:39Z</time>
+				<extensions>
+					<speed>3.1084346771240234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014354527656257" lon="-84.20245827944501">
+				<ele>951.3322882307693</ele>
+				<time>2017-10-30T17:51:40Z</time>
+				<extensions>
+					<speed>1.8971517086029053</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014339712822322" lon="-84.2024593152213">
+				<ele>951.4400354679674</ele>
+				<time>2017-10-30T17:51:41Z</time>
+				<extensions>
+					<speed>1.223814606666565</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337032234765" lon="-84.20246098461459">
+				<ele>951.3482816694304</ele>
+				<time>2017-10-30T17:51:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337032234765" lon="-84.20246098461459">
+				<ele>951.3482816694304</ele>
+				<time>2017-10-30T17:51:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345327503232" lon="-84.20245683923766">
+				<ele>951.4161701509729</ele>
+				<time>2017-10-30T17:51:44Z</time>
+				<extensions>
+					<speed>0.7258090972900391</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345327503232" lon="-84.20245683923766">
+				<ele>951.4161701509729</ele>
+				<time>2017-10-30T17:51:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014346286397938" lon="-84.20245551567714">
+				<ele>951.3786373296753</ele>
+				<time>2017-10-30T17:51:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014346286397938" lon="-84.20245551567714">
+				<ele>951.3786373296753</ele>
+				<time>2017-10-30T17:51:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014346286397938" lon="-84.20245551567714">
+				<ele>951.3786373296753</ele>
+				<time>2017-10-30T17:51:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014336520870463" lon="-84.20245630193735">
+				<ele>951.1179971760139</ele>
+				<time>2017-10-30T17:51:49Z</time>
+				<extensions>
+					<speed>1.0863999128341675</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01431903394283" lon="-84.20245828334838">
+				<ele>950.5057713966817</ele>
+				<time>2017-10-30T17:51:50Z</time>
+				<extensions>
+					<speed>2.108039379119873</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014296311284086" lon="-84.20245465810363">
+				<ele>950.1555085582659</ele>
+				<time>2017-10-30T17:51:51Z</time>
+				<extensions>
+					<speed>2.879987955093384</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014268454598737" lon="-84.2024404855469">
+				<ele>949.6867651017383</ele>
+				<time>2017-10-30T17:51:52Z</time>
+				<extensions>
+					<speed>4.171065330505371</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014237869278878" lon="-84.20241279877777">
+				<ele>949.2059932360426</ele>
+				<time>2017-10-30T17:51:53Z</time>
+				<extensions>
+					<speed>5.0511956214904785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014204442400642" lon="-84.2023689444908">
+				<ele>948.8311386033893</ele>
+				<time>2017-10-30T17:51:54Z</time>
+				<extensions>
+					<speed>6.800552845001221</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014163519912408" lon="-84.2023062674157">
+				<ele>948.9677583789453</ele>
+				<time>2017-10-30T17:51:55Z</time>
+				<extensions>
+					<speed>7.895564556121826</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014122523685392" lon="-84.2022375462944">
+				<ele>949.1545970095322</ele>
+				<time>2017-10-30T17:51:56Z</time>
+				<extensions>
+					<speed>8.151248931884766</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014085544004711" lon="-84.20216385822349">
+				<ele>949.5895879287273</ele>
+				<time>2017-10-30T17:51:57Z</time>
+				<extensions>
+					<speed>8.799979209899902</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014047562490232" lon="-84.20208782037811">
+				<ele>949.879471280612</ele>
+				<time>2017-10-30T17:51:58Z</time>
+				<extensions>
+					<speed>9.192510604858398</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014009645882018" lon="-84.20201361180658">
+				<ele>950.0155747216195</ele>
+				<time>2017-10-30T17:51:59Z</time>
+				<extensions>
+					<speed>9.005560874938965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013974759280785" lon="-84.201937773525">
+				<ele>950.43244123552</ele>
+				<time>2017-10-30T17:52:00Z</time>
+				<extensions>
+					<speed>8.972365379333496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013943504145495" lon="-84.20186233466266">
+				<ele>950.7948353346437</ele>
+				<time>2017-10-30T17:52:01Z</time>
+				<extensions>
+					<speed>8.537853240966797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013915202579437" lon="-84.201793514933">
+				<ele>951.1226597661152</ele>
+				<time>2017-10-30T17:52:02Z</time>
+				<extensions>
+					<speed>7.687682151794434</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013887536316814" lon="-84.2017314058607">
+				<ele>951.2434635376558</ele>
+				<time>2017-10-30T17:52:03Z</time>
+				<extensions>
+					<speed>7.131008625030518</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013857032465902" lon="-84.20167720317588">
+				<ele>951.452218956314</ele>
+				<time>2017-10-30T17:52:04Z</time>
+				<extensions>
+					<speed>6.691354274749756</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013822951534044" lon="-84.20162875793439">
+				<ele>951.6682964330539</ele>
+				<time>2017-10-30T17:52:05Z</time>
+				<extensions>
+					<speed>6.486529350280762</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013786040108174" lon="-84.20158513763452">
+				<ele>951.833134024404</ele>
+				<time>2017-10-30T17:52:06Z</time>
+				<extensions>
+					<speed>6.19394063949585</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013747013529834" lon="-84.20154464290265">
+				<ele>952.111205467023</ele>
+				<time>2017-10-30T17:52:07Z</time>
+				<extensions>
+					<speed>6.209936141967773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013705501096593" lon="-84.20150517811348">
+				<ele>952.665805529803</ele>
+				<time>2017-10-30T17:52:08Z</time>
+				<extensions>
+					<speed>6.568946838378906</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01366360552869" lon="-84.20146293972745">
+				<ele>952.913932910189</ele>
+				<time>2017-10-30T17:52:09Z</time>
+				<extensions>
+					<speed>6.6984405517578125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013623716482966" lon="-84.20141998371071">
+				<ele>953.1775107039139</ele>
+				<time>2017-10-30T17:52:10Z</time>
+				<extensions>
+					<speed>6.559175491333008</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013583201626938" lon="-84.20137825956502">
+				<ele>953.5150233358145</ele>
+				<time>2017-10-30T17:52:11Z</time>
+				<extensions>
+					<speed>6.358378887176514</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013544305972738" lon="-84.20133830087413">
+				<ele>953.8007985213771</ele>
+				<time>2017-10-30T17:52:12Z</time>
+				<extensions>
+					<speed>5.933962345123291</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013507453200912" lon="-84.20130028579983">
+				<ele>953.8436132157221</ele>
+				<time>2017-10-30T17:52:13Z</time>
+				<extensions>
+					<speed>5.997251987457275</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013468829350263" lon="-84.20126210494892">
+				<ele>954.117255252786</ele>
+				<time>2017-10-30T17:52:14Z</time>
+				<extensions>
+					<speed>6.284413814544678</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013430221503574" lon="-84.20122447027097">
+				<ele>954.1096973558888</ele>
+				<time>2017-10-30T17:52:15Z</time>
+				<extensions>
+					<speed>6.540099620819092</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013391147321084" lon="-84.20118070791462">
+				<ele>954.8654868640006</ele>
+				<time>2017-10-30T17:52:16Z</time>
+				<extensions>
+					<speed>6.720491886138916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013353718099868" lon="-84.20113224709776">
+				<ele>954.9367115972564</ele>
+				<time>2017-10-30T17:52:17Z</time>
+				<extensions>
+					<speed>7.042233943939209</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01331507666714" lon="-84.20108304269571">
+				<ele>955.0626779748127</ele>
+				<time>2017-10-30T17:52:18Z</time>
+				<extensions>
+					<speed>6.481749534606934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013277606798866" lon="-84.20103771756847">
+				<ele>955.5637615444139</ele>
+				<time>2017-10-30T17:52:19Z</time>
+				<extensions>
+					<speed>5.768842697143555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013245367554998" lon="-84.20099391087501">
+				<ele>956.0397277418524</ele>
+				<time>2017-10-30T17:52:20Z</time>
+				<extensions>
+					<speed>5.568093776702881</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013219480325112" lon="-84.20095239140467">
+				<ele>956.2378334077075</ele>
+				<time>2017-10-30T17:52:21Z</time>
+				<extensions>
+					<speed>5.028141021728516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01319541230772" lon="-84.20091599752334">
+				<ele>956.653063104488</ele>
+				<time>2017-10-30T17:52:22Z</time>
+				<extensions>
+					<speed>4.458696365356445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013174511551298" lon="-84.2008873137722">
+				<ele>957.1704810364172</ele>
+				<time>2017-10-30T17:52:23Z</time>
+				<extensions>
+					<speed>3.4280052185058594</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013155827585775" lon="-84.20085941387892">
+				<ele>957.5728243226185</ele>
+				<time>2017-10-30T17:52:24Z</time>
+				<extensions>
+					<speed>3.6682448387145996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013136699072017" lon="-84.20083010179556">
+				<ele>958.111384822987</ele>
+				<time>2017-10-30T17:52:25Z</time>
+				<extensions>
+					<speed>3.607013463973999</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01311805036502" lon="-84.20080303261997">
+				<ele>958.84239330329</ele>
+				<time>2017-10-30T17:52:26Z</time>
+				<extensions>
+					<speed>3.2965283393859863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013101979107411" lon="-84.20078064256636">
+				<ele>959.3837531460449</ele>
+				<time>2017-10-30T17:52:27Z</time>
+				<extensions>
+					<speed>2.7377021312713623</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013089961018284" lon="-84.20076731357685">
+				<ele>959.808845593594</ele>
+				<time>2017-10-30T17:52:28Z</time>
+				<extensions>
+					<speed>1.3217335939407349</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013081554737116" lon="-84.20076211183179">
+				<ele>960.3500321200117</ele>
+				<time>2017-10-30T17:52:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013081554737116" lon="-84.20076211183179">
+				<ele>960.3500321200117</ele>
+				<time>2017-10-30T17:52:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013081554737116" lon="-84.20076211183179">
+				<ele>960.3500321200117</ele>
+				<time>2017-10-30T17:52:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01308077409396" lon="-84.20075504417613">
+				<ele>960.3710598535836</ele>
+				<time>2017-10-30T17:52:32Z</time>
+				<extensions>
+					<speed>1.014583706855774</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013078964684581" lon="-84.20074597882461">
+				<ele>960.957820569165</ele>
+				<time>2017-10-30T17:52:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013078964684581" lon="-84.20074597882461">
+				<ele>960.957820569165</ele>
+				<time>2017-10-30T17:52:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013078964684581" lon="-84.20074597882461">
+				<ele>960.957820569165</ele>
+				<time>2017-10-30T17:52:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013078964684581" lon="-84.20074597882461">
+				<ele>960.957820569165</ele>
+				<time>2017-10-30T17:52:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013078964684581" lon="-84.20074597882461">
+				<ele>960.957820569165</ele>
+				<time>2017-10-30T17:52:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013069329691993" lon="-84.20074291202074">
+				<ele>960.6404840936884</ele>
+				<time>2017-10-30T17:52:38Z</time>
+				<extensions>
+					<speed>0.7121683955192566</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013062171862822" lon="-84.20073412245353">
+				<ele>960.4297071518376</ele>
+				<time>2017-10-30T17:52:39Z</time>
+				<extensions>
+					<speed>1.6092785596847534</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013056993016873" lon="-84.20071761552468">
+				<ele>960.1259652636945</ele>
+				<time>2017-10-30T17:52:40Z</time>
+				<extensions>
+					<speed>2.5282342433929443</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013058056850426" lon="-84.20069259292727">
+				<ele>960.0771012892947</ele>
+				<time>2017-10-30T17:52:41Z</time>
+				<extensions>
+					<speed>3.586357593536377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013071099978836" lon="-84.2006582761424">
+				<ele>960.5896870950237</ele>
+				<time>2017-10-30T17:52:42Z</time>
+				<extensions>
+					<speed>4.743772983551025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01309678969931" lon="-84.20062042958239">
+				<ele>960.8529210481793</ele>
+				<time>2017-10-30T17:52:43Z</time>
+				<extensions>
+					<speed>5.3521013259887695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013139051944805" lon="-84.20057660884969">
+				<ele>961.2789175119251</ele>
+				<time>2017-10-30T17:52:44Z</time>
+				<extensions>
+					<speed>7.534440994262695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013194616740686" lon="-84.20053072184155">
+				<ele>961.5259353630245</ele>
+				<time>2017-10-30T17:52:45Z</time>
+				<extensions>
+					<speed>8.267969131469727</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01325953916141" lon="-84.20048848401163">
+				<ele>961.9392618415877</ele>
+				<time>2017-10-30T17:52:46Z</time>
+				<extensions>
+					<speed>8.586694717407227</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013329223078344" lon="-84.20044553022444">
+				<ele>962.0950569687411</ele>
+				<time>2017-10-30T17:52:47Z</time>
+				<extensions>
+					<speed>8.8339204788208</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0133971965599" lon="-84.2004028394524">
+				<ele>962.4980308217928</ele>
+				<time>2017-10-30T17:52:48Z</time>
+				<extensions>
+					<speed>8.48322868347168</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013464200393484" lon="-84.2003632379521">
+				<ele>963.080008697696</ele>
+				<time>2017-10-30T17:52:49Z</time>
+				<extensions>
+					<speed>8.36871337890625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013528470822166" lon="-84.20032711012276">
+				<ele>963.3653075993061</ele>
+				<time>2017-10-30T17:52:50Z</time>
+				<extensions>
+					<speed>7.906912803649902</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013590274491717" lon="-84.20028943764393">
+				<ele>963.2423795815557</ele>
+				<time>2017-10-30T17:52:51Z</time>
+				<extensions>
+					<speed>8.062204360961914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013653601626546" lon="-84.2002483894156">
+				<ele>963.2496401071548</ele>
+				<time>2017-10-30T17:52:52Z</time>
+				<extensions>
+					<speed>8.210427284240723</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013718501474218" lon="-84.20020483320074">
+				<ele>963.3290764335543</ele>
+				<time>2017-10-30T17:52:53Z</time>
+				<extensions>
+					<speed>8.526321411132813</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013784344650803" lon="-84.2001571222746">
+				<ele>962.8127665286884</ele>
+				<time>2017-10-30T17:52:54Z</time>
+				<extensions>
+					<speed>8.637996673583984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013845792122842" lon="-84.20010534515228">
+				<ele>962.934979384765</ele>
+				<time>2017-10-30T17:52:55Z</time>
+				<extensions>
+					<speed>8.718082427978516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013904201649193" lon="-84.20005239396052">
+				<ele>962.973596827127</ele>
+				<time>2017-10-30T17:52:56Z</time>
+				<extensions>
+					<speed>8.797746658325195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013960793552908" lon="-84.19999663871548">
+				<ele>963.1546048820019</ele>
+				<time>2017-10-30T17:52:57Z</time>
+				<extensions>
+					<speed>8.985790252685547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014017440630584" lon="-84.19993689172438">
+				<ele>963.9292226498947</ele>
+				<time>2017-10-30T17:52:58Z</time>
+				<extensions>
+					<speed>9.189942359924316</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01407207510517" lon="-84.19987584113898">
+				<ele>964.5889775557443</ele>
+				<time>2017-10-30T17:52:59Z</time>
+				<extensions>
+					<speed>8.77680492401123</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014123794033264" lon="-84.19981519721095">
+				<ele>965.2237270371988</ele>
+				<time>2017-10-30T17:53:00Z</time>
+				<extensions>
+					<speed>8.761518478393555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014175048733772" lon="-84.19975490835988">
+				<ele>965.7352136429399</ele>
+				<time>2017-10-30T17:53:01Z</time>
+				<extensions>
+					<speed>8.76533031463623</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014226568634598" lon="-84.19969529070806">
+				<ele>966.6287862099707</ele>
+				<time>2017-10-30T17:53:02Z</time>
+				<extensions>
+					<speed>8.859898567199707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281545619822" lon="-84.19963791854093">
+				<ele>967.5529526313767</ele>
+				<time>2017-10-30T17:53:03Z</time>
+				<extensions>
+					<speed>8.780296325683594</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014339620806554" lon="-84.19958601982323">
+				<ele>968.1114255487919</ele>
+				<time>2017-10-30T17:53:04Z</time>
+				<extensions>
+					<speed>8.403728485107422</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014397332495202" lon="-84.19953724063826">
+				<ele>968.9830600079149</ele>
+				<time>2017-10-30T17:53:05Z</time>
+				<extensions>
+					<speed>7.911543846130371</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014450462639449" lon="-84.19949469716201">
+				<ele>969.3919596886262</ele>
+				<time>2017-10-30T17:53:06Z</time>
+				<extensions>
+					<speed>6.853755950927734</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014495954280264" lon="-84.19946388978006">
+				<ele>969.5593328131363</ele>
+				<time>2017-10-30T17:53:07Z</time>
+				<extensions>
+					<speed>5.10264253616333</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014528822792881" lon="-84.19944690344659">
+				<ele>969.6601916672662</ele>
+				<time>2017-10-30T17:53:08Z</time>
+				<extensions>
+					<speed>3.0170891284942627</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014545752257677" lon="-84.19944239331299">
+				<ele>969.6714297840372</ele>
+				<time>2017-10-30T17:53:09Z</time>
+				<extensions>
+					<speed>0.7292989492416382</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01454702396105" lon="-84.19944692068599">
+				<ele>969.6572512267157</ele>
+				<time>2017-10-30T17:53:10Z</time>
+				<extensions>
+					<speed>1.030794620513916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01453626190725" lon="-84.19945097944692">
+				<ele>970.2543016579002</ele>
+				<time>2017-10-30T17:53:11Z</time>
+				<extensions>
+					<speed>1.3467943668365479</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014529432414069" lon="-84.19945703751094">
+				<ele>970.5683981711045</ele>
+				<time>2017-10-30T17:53:12Z</time>
+				<extensions>
+					<speed>1.1425760984420776</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014522703971362" lon="-84.19946392848455">
+				<ele>971.0036778189242</ele>
+				<time>2017-10-30T17:53:13Z</time>
+				<extensions>
+					<speed>1.3914448022842407</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014514357579678" lon="-84.19947060591116">
+				<ele>971.403631276451</ele>
+				<time>2017-10-30T17:53:14Z</time>
+				<extensions>
+					<speed>1.2488535642623901</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450814098691" lon="-84.19947726154939">
+				<ele>971.3966323724017</ele>
+				<time>2017-10-30T17:53:15Z</time>
+				<extensions>
+					<speed>0.7653849720954895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450814098691" lon="-84.19947726154939">
+				<ele>971.3966323724017</ele>
+				<time>2017-10-30T17:53:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450555935554" lon="-84.19948044312055">
+				<ele>971.0609685136005</ele>
+				<time>2017-10-30T17:53:17Z</time>
+				<extensions>
+					<speed>0.5089314579963684</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450555935554" lon="-84.19948044312055">
+				<ele>971.0609685136005</ele>
+				<time>2017-10-30T17:53:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014508572625179" lon="-84.19948397011424">
+				<ele>970.0380164962262</ele>
+				<time>2017-10-30T17:53:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014508572625179" lon="-84.19948397011424">
+				<ele>970.0380164962262</ele>
+				<time>2017-10-30T17:53:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014521214032108" lon="-84.1994716516456">
+				<ele>969.2963605066761</ele>
+				<time>2017-10-30T17:53:21Z</time>
+				<extensions>
+					<speed>1.8624778985977173</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014540275485913" lon="-84.19945353605017">
+				<ele>968.7660734364763</ele>
+				<time>2017-10-30T17:53:22Z</time>
+				<extensions>
+					<speed>2.9897077083587646</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014565753669537" lon="-84.19942896882652">
+				<ele>968.3950875885785</ele>
+				<time>2017-10-30T17:53:23Z</time>
+				<extensions>
+					<speed>4.231363296508789</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014599618850324" lon="-84.19940267051024">
+				<ele>968.4596666432917</ele>
+				<time>2017-10-30T17:53:24Z</time>
+				<extensions>
+					<speed>5.171513557434082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014647040714191" lon="-84.19938103154085">
+				<ele>968.6190120149404</ele>
+				<time>2017-10-30T17:53:25Z</time>
+				<extensions>
+					<speed>5.973362922668457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014691422053964" lon="-84.19934253491513">
+				<ele>968.5240035485476</ele>
+				<time>2017-10-30T17:53:26Z</time>
+				<extensions>
+					<speed>6.664952754974365</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014738469448629" lon="-84.19930014282882">
+				<ele>968.3155926140025</ele>
+				<time>2017-10-30T17:53:27Z</time>
+				<extensions>
+					<speed>6.989065170288086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01478882032847" lon="-84.19925781981436">
+				<ele>968.3239310514182</ele>
+				<time>2017-10-30T17:53:28Z</time>
+				<extensions>
+					<speed>7.2350335121154785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843045345627" lon="-84.19921173282611">
+				<ele>968.8740908941254</ele>
+				<time>2017-10-30T17:53:29Z</time>
+				<extensions>
+					<speed>7.728704929351807</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014901900562455" lon="-84.19916269026486">
+				<ele>969.5601098947227</ele>
+				<time>2017-10-30T17:53:30Z</time>
+				<extensions>
+					<speed>8.251850128173828</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014964339541612" lon="-84.19911386990326">
+				<ele>970.2209764039144</ele>
+				<time>2017-10-30T17:53:31Z</time>
+				<extensions>
+					<speed>8.478023529052734</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015025056940278" lon="-84.19906245660623">
+				<ele>970.8254134273157</ele>
+				<time>2017-10-30T17:53:32Z</time>
+				<extensions>
+					<speed>8.556001663208008</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015087402634807" lon="-84.19901150871216">
+				<ele>971.6262026475742</ele>
+				<time>2017-10-30T17:53:33Z</time>
+				<extensions>
+					<speed>8.70300579071045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01515013586314" lon="-84.19895877327818">
+				<ele>972.0330335665494</ele>
+				<time>2017-10-30T17:53:34Z</time>
+				<extensions>
+					<speed>8.831944465637207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01521149558794" lon="-84.19890655852585">
+				<ele>972.400609604083</ele>
+				<time>2017-10-30T17:53:35Z</time>
+				<extensions>
+					<speed>8.552088737487793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015271140094736" lon="-84.19885237589499">
+				<ele>972.7360598770902</ele>
+				<time>2017-10-30T17:53:36Z</time>
+				<extensions>
+					<speed>8.612668991088867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015329477873733" lon="-84.19879588538643">
+				<ele>973.2795875985175</ele>
+				<time>2017-10-30T17:53:37Z</time>
+				<extensions>
+					<speed>8.743460655212402</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015385130292978" lon="-84.19873606626086">
+				<ele>973.7946236133575</ele>
+				<time>2017-10-30T17:53:38Z</time>
+				<extensions>
+					<speed>8.762760162353516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015439264475933" lon="-84.19867297285958">
+				<ele>973.9797678012401</ele>
+				<time>2017-10-30T17:53:39Z</time>
+				<extensions>
+					<speed>8.843642234802246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015487449591545" lon="-84.19860801592564">
+				<ele>973.8516906630248</ele>
+				<time>2017-10-30T17:53:40Z</time>
+				<extensions>
+					<speed>8.885908126831055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015527525963805" lon="-84.19853860319702">
+				<ele>973.8997439686209</ele>
+				<time>2017-10-30T17:53:41Z</time>
+				<extensions>
+					<speed>8.66189193725586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015561530330329" lon="-84.19846505806595">
+				<ele>974.3200909579173</ele>
+				<time>2017-10-30T17:53:42Z</time>
+				<extensions>
+					<speed>8.845955848693848</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015591033459698" lon="-84.19838495302257">
+				<ele>974.6703125778586</ele>
+				<time>2017-10-30T17:53:43Z</time>
+				<extensions>
+					<speed>9.60006332397461</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015616372841722" lon="-84.19829981641885">
+				<ele>975.2101782020181</ele>
+				<time>2017-10-30T17:53:44Z</time>
+				<extensions>
+					<speed>9.919510841369629</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015643507136746" lon="-84.1982119568706">
+				<ele>975.7282792776823</ele>
+				<time>2017-10-30T17:53:45Z</time>
+				<extensions>
+					<speed>10.428565979003906</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015676172241218" lon="-84.19811991787404">
+				<ele>976.3092534672469</ele>
+				<time>2017-10-30T17:53:46Z</time>
+				<extensions>
+					<speed>10.578536033630371</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015709462358679" lon="-84.19803118095801">
+				<ele>976.6757036540657</ele>
+				<time>2017-10-30T17:53:47Z</time>
+				<extensions>
+					<speed>10.458683967590332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015745568526112" lon="-84.19794542796507">
+				<ele>977.0345224225894</ele>
+				<time>2017-10-30T17:53:48Z</time>
+				<extensions>
+					<speed>10.330660820007324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015783337518497" lon="-84.1978604950479">
+				<ele>977.48829757981</ele>
+				<time>2017-10-30T17:53:49Z</time>
+				<extensions>
+					<speed>10.349117279052734</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015823942055547" lon="-84.19777540819906">
+				<ele>977.8048028964549</ele>
+				<time>2017-10-30T17:53:50Z</time>
+				<extensions>
+					<speed>10.533440589904785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015864162994228" lon="-84.19768962369444">
+				<ele>977.9494888810441</ele>
+				<time>2017-10-30T17:53:51Z</time>
+				<extensions>
+					<speed>10.527400016784668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015903495926901" lon="-84.19760289578294">
+				<ele>978.1347829755396</ele>
+				<time>2017-10-30T17:53:52Z</time>
+				<extensions>
+					<speed>10.608986854553223</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015943810921057" lon="-84.19751764670328">
+				<ele>978.499614850618</ele>
+				<time>2017-10-30T17:53:53Z</time>
+				<extensions>
+					<speed>10.291402816772461</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01598498554221" lon="-84.19743288757127">
+				<ele>978.9786800723523</ele>
+				<time>2017-10-30T17:53:54Z</time>
+				<extensions>
+					<speed>10.459433555603027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016027830017483" lon="-84.19734758662139">
+				<ele>979.2900893455371</ele>
+				<time>2017-10-30T17:53:55Z</time>
+				<extensions>
+					<speed>10.43086051940918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016072059847103" lon="-84.19726313121978">
+				<ele>979.7278537414968</ele>
+				<time>2017-10-30T17:53:56Z</time>
+				<extensions>
+					<speed>10.314016342163086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016114620064622" lon="-84.19718334250308">
+				<ele>979.6225418820977</ele>
+				<time>2017-10-30T17:53:57Z</time>
+				<extensions>
+					<speed>9.865418434143066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016157169342142" lon="-84.19710674962066">
+				<ele>979.677530518733</ele>
+				<time>2017-10-30T17:53:58Z</time>
+				<extensions>
+					<speed>9.640430450439453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016203428162568" lon="-84.19702922386458">
+				<ele>979.9447026876733</ele>
+				<time>2017-10-30T17:53:59Z</time>
+				<extensions>
+					<speed>9.913793563842773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016251471923962" lon="-84.19695209833732">
+				<ele>980.2702068742365</ele>
+				<time>2017-10-30T17:54:00Z</time>
+				<extensions>
+					<speed>9.817720413208008</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016295887635831" lon="-84.19687565536553">
+				<ele>980.7804300803691</ele>
+				<time>2017-10-30T17:54:01Z</time>
+				<extensions>
+					<speed>9.380728721618652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016343848472234" lon="-84.19680321348982">
+				<ele>981.0573502574116</ele>
+				<time>2017-10-30T17:54:02Z</time>
+				<extensions>
+					<speed>9.444503784179688</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016395913626813" lon="-84.19673092906393">
+				<ele>981.5311955576763</ele>
+				<time>2017-10-30T17:54:03Z</time>
+				<extensions>
+					<speed>9.5482816696167</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016450798574205" lon="-84.19666141339853">
+				<ele>982.0315154371783</ele>
+				<time>2017-10-30T17:54:04Z</time>
+				<extensions>
+					<speed>9.68179702758789</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01650787275318" lon="-84.19659560054">
+				<ele>982.0628614136949</ele>
+				<time>2017-10-30T17:54:05Z</time>
+				<extensions>
+					<speed>9.268838882446289</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016563912104127" lon="-84.19653675851468">
+				<ele>982.0813766596839</ele>
+				<time>2017-10-30T17:54:06Z</time>
+				<extensions>
+					<speed>8.501988410949707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01661231840677" lon="-84.19648449106444">
+				<ele>982.3528641276062</ele>
+				<time>2017-10-30T17:54:07Z</time>
+				<extensions>
+					<speed>7.175627708435059</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016654021513935" lon="-84.19644039518612">
+				<ele>982.9189800117165</ele>
+				<time>2017-10-30T17:54:08Z</time>
+				<extensions>
+					<speed>6.254508018493652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016689038231053" lon="-84.19640160734619">
+				<ele>983.0381574705243</ele>
+				<time>2017-10-30T17:54:09Z</time>
+				<extensions>
+					<speed>5.154799461364746</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016720010195685" lon="-84.19636925268074">
+				<ele>982.7906797891483</ele>
+				<time>2017-10-30T17:54:10Z</time>
+				<extensions>
+					<speed>4.59958553314209</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016750789715575" lon="-84.19634017678179">
+				<ele>982.4397481037304</ele>
+				<time>2017-10-30T17:54:11Z</time>
+				<extensions>
+					<speed>4.531611442565918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016777748710124" lon="-84.19631662647024">
+				<ele>982.4346885979176</ele>
+				<time>2017-10-30T17:54:12Z</time>
+				<extensions>
+					<speed>3.2226548194885254</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016794384182182" lon="-84.19630644889769">
+				<ele>982.2883841879666</ele>
+				<time>2017-10-30T17:54:13Z</time>
+				<extensions>
+					<speed>1.2755719423294067</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016802465850883" lon="-84.19630188124177">
+				<ele>981.8216784177348</ele>
+				<time>2017-10-30T17:54:14Z</time>
+				<extensions>
+					<speed>0.6328456401824951</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016802465850883" lon="-84.19630188124177">
+				<ele>981.8216784177348</ele>
+				<time>2017-10-30T17:54:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016809654336603" lon="-84.19629477865183">
+				<ele>981.9564286889508</ele>
+				<time>2017-10-30T17:54:16Z</time>
+				<extensions>
+					<speed>1.2192429304122925</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01681936090749" lon="-84.19628340993744">
+				<ele>981.7014290448278</ele>
+				<time>2017-10-30T17:54:17Z</time>
+				<extensions>
+					<speed>2.111943244934082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016836101275743" lon="-84.19626684289761">
+				<ele>981.5452290922403</ele>
+				<time>2017-10-30T17:54:18Z</time>
+				<extensions>
+					<speed>3.078401803970337</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016862584922405" lon="-84.19624495871591">
+				<ele>981.5535622667521</ele>
+				<time>2017-10-30T17:54:19Z</time>
+				<extensions>
+					<speed>4.43919563293457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016901730787406" lon="-84.19621477827309">
+				<ele>981.4958190442994</ele>
+				<time>2017-10-30T17:54:20Z</time>
+				<extensions>
+					<speed>6.159256935119629</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016949001819441" lon="-84.19617474538197">
+				<ele>981.5814159587026</ele>
+				<time>2017-10-30T17:54:21Z</time>
+				<extensions>
+					<speed>6.96957540512085</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017000665439099" lon="-84.19613090059156">
+				<ele>982.0308095477521</ele>
+				<time>2017-10-30T17:54:22Z</time>
+				<extensions>
+					<speed>7.008001327514648</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017051480487961" lon="-84.196091265688">
+				<ele>982.4362731622532</ele>
+				<time>2017-10-30T17:54:23Z</time>
+				<extensions>
+					<speed>6.682736396789551</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01709730633925" lon="-84.19605776656371">
+				<ele>982.889729687944</ele>
+				<time>2017-10-30T17:54:24Z</time>
+				<extensions>
+					<speed>6.143974781036377</speed>
+				</extensions>
+			</trkpt>
+		</trkseg>
+	</trk>
+</gpx>

--- a/bus_alajuela-targuases/asistentes/fran_2017_10_9.gpx
+++ b/bus_alajuela-targuases/asistentes/fran_2017_10_9.gpx
@@ -1,0 +1,15014 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="OSMTracker for Android™ - https://github.com/nguillaumin/osmtracker-android" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd ">
+	<wpt lat="10.014379066767402" lon="-84.21664895965138">
+		<ele>967.936199140735</ele>
+		<time>2017-10-09T18:50:54Z</time>
+		<name><![CDATA[Grabación de voz]]></name>
+		<link href="2017-10-09_12-51-01.3gpp">
+			<text>2017-10-09_12-51-01.3gpp</text>
+		</link>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015226721269903" lon="-84.2134238482824">
+		<ele>962.8926337426528</ele>
+		<time>2017-10-09T18:55:27Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015226721269903" lon="-84.2134238482824">
+		<ele>962.8926337426528</ele>
+		<time>2017-10-09T18:55:27Z</time>
+		<name><![CDATA[3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015776629023009" lon="-84.21172951317929">
+		<ele>961.4243749845773</ele>
+		<time>2017-10-09T18:56:55Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015749084964721" lon="-84.21176032871077">
+		<ele>961.6799943763763</ele>
+		<time>2017-10-09T18:56:56Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.012798260848369" lon="-84.21025437733617">
+		<ele>950.071956907399</ele>
+		<time>2017-10-09T19:00:10Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.01021408764433" lon="-84.21319932984842">
+		<ele>948.7723305337131</ele>
+		<time>2017-10-09T19:03:34Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.010235219327985" lon="-84.21305808756344">
+		<ele>947.3366168597713</ele>
+		<time>2017-10-09T19:03:35Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008589887824261" lon="-84.21016498634579">
+		<ele>937.702021821402</ele>
+		<time>2017-10-09T19:04:34Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008590323068033" lon="-84.21016094276051">
+		<ele>937.4734490886331</ele>
+		<time>2017-10-09T19:04:36Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.005802354069955" lon="-84.20596127163897">
+		<ele>915.1380694331601</ele>
+		<time>2017-10-09T19:06:50Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.005802354069955" lon="-84.20596127163897">
+		<ele>915.1380694331601</ele>
+		<time>2017-10-09T19:06:50Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.005034352140617" lon="-84.20537099358798">
+		<ele>929.8298989636824</ele>
+		<time>2017-10-09T19:08:27Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.00503552769512" lon="-84.2053775632546">
+		<ele>929.3491018665954</ele>
+		<time>2017-10-09T19:08:28Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.00592694487021" lon="-84.20439390984158">
+		<ele>930.3708841204643</ele>
+		<time>2017-10-09T19:09:34Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.005938498316702" lon="-84.20438409918876">
+		<ele>930.7054223353043</ele>
+		<time>2017-10-09T19:09:35Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.00738185395789" lon="-84.20464929804484">
+		<ele>934.4132235031575</ele>
+		<time>2017-10-09T19:10:28Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.00738185395789" lon="-84.20464929804484">
+		<ele>934.4132235031575</ele>
+		<time>2017-10-09T19:10:28Z</time>
+		<name><![CDATA[3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008878399772321" lon="-84.2031666020374">
+		<ele>945.871002140455</ele>
+		<time>2017-10-09T19:11:22Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008878399772321" lon="-84.2031666020374">
+		<ele>945.871002140455</ele>
+		<time>2017-10-09T19:11:23Z</time>
+		<name><![CDATA[3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.01150110241863" lon="-84.20138848156434">
+		<ele>952.3772102557123</ele>
+		<time>2017-10-09T19:12:42Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.011454213057121" lon="-84.20140766781063">
+		<ele>951.1680371183902</ele>
+		<time>2017-10-09T19:12:43Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.012911575628156" lon="-84.20066618019177">
+		<ele>946.8256319202483</ele>
+		<time>2017-10-09T19:13:29Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.013158910949873" lon="-84.20086154174571">
+		<ele>946.8821265595034</ele>
+		<time>2017-10-09T19:13:41Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.013644033502988" lon="-84.20142984988235">
+		<ele>940.9266872666776</ele>
+		<time>2017-10-09T19:14:13Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.013644033502988" lon="-84.20142984988235">
+		<ele>940.9266872666776</ele>
+		<time>2017-10-09T19:14:14Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<trk>
+		<name><![CDATA[Trazado con OSMTracker para Android™]]></name>
+		<trkseg>
+			<trkpt lat="10.01423999928043" lon="-84.21702809053662">
+				<ele>970.2665827991441</ele>
+				<time>2017-10-09T18:44:36Z</time>
+				<extensions>
+					<speed>0.16268940269947052</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014292629359902" lon="-84.21700246540951">
+				<ele>970.1866942523047</ele>
+				<time>2017-10-09T18:44:37Z</time>
+				<extensions>
+					<speed>0.4807312786579132</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:44:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281512244464" lon="-84.2169415919342">
+				<ele>985.4619375905022</ele>
+				<time>2017-10-09T18:45:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014278236077814" lon="-84.21693438974708">
+				<ele>985.3742399858311</ele>
+				<time>2017-10-09T18:45:38Z</time>
+				<extensions>
+					<speed>0.639274001121521</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014276435613773" lon="-84.2169281117023">
+				<ele>985.2775147147477</ele>
+				<time>2017-10-09T18:45:39Z</time>
+				<extensions>
+					<speed>0.7680527567863464</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014273417197154" lon="-84.21692118309161">
+				<ele>985.1824348336086</ele>
+				<time>2017-10-09T18:45:40Z</time>
+				<extensions>
+					<speed>0.8674511313438416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014270435134705" lon="-84.21691542301348">
+				<ele>985.0793195553124</ele>
+				<time>2017-10-09T18:45:41Z</time>
+				<extensions>
+					<speed>0.7404475808143616</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01426573527601" lon="-84.21690866621215">
+				<ele>984.9980861414224</ele>
+				<time>2017-10-09T18:45:42Z</time>
+				<extensions>
+					<speed>0.8166725635528564</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01426250275495" lon="-84.21690419789807">
+				<ele>984.988159770146</ele>
+				<time>2017-10-09T18:45:43Z</time>
+				<extensions>
+					<speed>0.7764994502067566</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014261078301665" lon="-84.21690624037853">
+				<ele>985.004600616172</ele>
+				<time>2017-10-09T18:45:44Z</time>
+				<extensions>
+					<speed>0.5679275393486023</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014258053057736" lon="-84.2169054121313">
+				<ele>985.0037551727146</ele>
+				<time>2017-10-09T18:45:45Z</time>
+				<extensions>
+					<speed>0.3588644564151764</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014258053057736" lon="-84.2169054121313">
+				<ele>985.0037551727146</ele>
+				<time>2017-10-09T18:45:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014258053057736" lon="-84.2169054121313">
+				<ele>985.0037551727146</ele>
+				<time>2017-10-09T18:45:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014258053057736" lon="-84.2169054121313">
+				<ele>985.0037551727146</ele>
+				<time>2017-10-09T18:45:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014258053057736" lon="-84.2169054121313">
+				<ele>985.0037551727146</ele>
+				<time>2017-10-09T18:45:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014258053057736" lon="-84.2169054121313">
+				<ele>985.0037551727146</ele>
+				<time>2017-10-09T18:45:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014258053057736" lon="-84.2169054121313">
+				<ele>985.0037551727146</ele>
+				<time>2017-10-09T18:45:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014258053057736" lon="-84.2169054121313">
+				<ele>985.0037551727146</ele>
+				<time>2017-10-09T18:45:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01426339196647" lon="-84.21690019648058">
+				<ele>984.829980042763</ele>
+				<time>2017-10-09T18:45:53Z</time>
+				<extensions>
+					<speed>0.6117911338806152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01427006790943" lon="-84.21689766502801">
+				<ele>984.5907882936299</ele>
+				<time>2017-10-09T18:45:54Z</time>
+				<extensions>
+					<speed>0.6420300006866455</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0142789877155" lon="-84.21689720189585">
+				<ele>984.4672152521089</ele>
+				<time>2017-10-09T18:45:55Z</time>
+				<extensions>
+					<speed>0.8765944242477417</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014288257855684" lon="-84.21689846077078">
+				<ele>984.3510038293898</ele>
+				<time>2017-10-09T18:45:56Z</time>
+				<extensions>
+					<speed>0.9764329195022583</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014295678155493" lon="-84.21690022922901">
+				<ele>984.1982065336779</ele>
+				<time>2017-10-09T18:45:57Z</time>
+				<extensions>
+					<speed>0.7324948906898499</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014299809315059" lon="-84.2169019770526">
+				<ele>983.9805824132636</ele>
+				<time>2017-10-09T18:45:58Z</time>
+				<extensions>
+					<speed>0.5171231627464294</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:45:59Z</time>
+				<extensions>
+					<speed>0.0824987143278122</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:46:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:47:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:47:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:47:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:47:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:47:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:47:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014300130861828" lon="-84.21690275626807">
+				<ele>983.7711364431307</ele>
+				<time>2017-10-09T18:47:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014294123923838" lon="-84.21690553561687">
+				<ele>983.4734982037917</ele>
+				<time>2017-10-09T18:47:07Z</time>
+				<extensions>
+					<speed>0.6049516797065735</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014299060515892" lon="-84.21691196003694">
+				<ele>983.1972853736952</ele>
+				<time>2017-10-09T18:47:08Z</time>
+				<extensions>
+					<speed>0.5735386610031128</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430265008501" lon="-84.21691738111181">
+				<ele>983.1069639474154</ele>
+				<time>2017-10-09T18:47:09Z</time>
+				<extensions>
+					<speed>0.5243092179298401</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014306305996252" lon="-84.21692321803349">
+				<ele>982.8932191422209</ele>
+				<time>2017-10-09T18:47:10Z</time>
+				<extensions>
+					<speed>0.53182053565979</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014312274262029" lon="-84.21692918901579">
+				<ele>982.6770165199414</ele>
+				<time>2017-10-09T18:47:11Z</time>
+				<extensions>
+					<speed>0.5042207837104797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:12Z</time>
+				<extensions>
+					<speed>0.3941028416156769</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:47:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:48:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316777701694" lon="-84.21693852854354">
+				<ele>982.4829049566761</ele>
+				<time>2017-10-09T18:49:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316948738283" lon="-84.21693209969364">
+				<ele>981.7530294582248</ele>
+				<time>2017-10-09T18:49:43Z</time>
+				<extensions>
+					<speed>0.985080361366272</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01431578511317" lon="-84.21692445516096">
+				<ele>981.0662150979042</ele>
+				<time>2017-10-09T18:49:44Z</time>
+				<extensions>
+					<speed>0.5579473376274109</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014315349382493" lon="-84.21692247515513">
+				<ele>980.7854563239962</ele>
+				<time>2017-10-09T18:49:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014315349382493" lon="-84.21692247515513">
+				<ele>980.7854563239962</ele>
+				<time>2017-10-09T18:49:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014315349382493" lon="-84.21692247515513">
+				<ele>980.7854563239962</ele>
+				<time>2017-10-09T18:49:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014315349382493" lon="-84.21692247515513">
+				<ele>980.7854563239962</ele>
+				<time>2017-10-09T18:49:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014315349382493" lon="-84.21692247515513">
+				<ele>980.7854563239962</ele>
+				<time>2017-10-09T18:49:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014315349382493" lon="-84.21692247515513">
+				<ele>980.7854563239962</ele>
+				<time>2017-10-09T18:49:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014315349382493" lon="-84.21692247515513">
+				<ele>980.7854563239962</ele>
+				<time>2017-10-09T18:49:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014315349382493" lon="-84.21692247515513">
+				<ele>980.7854563239962</ele>
+				<time>2017-10-09T18:49:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014315317328428" lon="-84.21691879736055">
+				<ele>980.55007978715</ele>
+				<time>2017-10-09T18:49:53Z</time>
+				<extensions>
+					<speed>0.6559398770332336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318385586238" lon="-84.2169108064387">
+				<ele>980.256318253465</ele>
+				<time>2017-10-09T18:49:54Z</time>
+				<extensions>
+					<speed>1.1382931470870972</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432194027954" lon="-84.21689950224984">
+				<ele>980.0395524119958</ele>
+				<time>2017-10-09T18:49:55Z</time>
+				<extensions>
+					<speed>1.424519658088684</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014324759755299" lon="-84.21688673911117">
+				<ele>979.9002383658662</ele>
+				<time>2017-10-09T18:49:56Z</time>
+				<extensions>
+					<speed>1.3620851039886475</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014326990432812" lon="-84.21687703227553">
+				<ele>979.5862048352137</ele>
+				<time>2017-10-09T18:49:57Z</time>
+				<extensions>
+					<speed>0.9796285629272461</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014328556403973" lon="-84.21687282788932">
+				<ele>979.4341177921742</ele>
+				<time>2017-10-09T18:49:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014329266308538" lon="-84.2168727972414">
+				<ele>979.3042015172541</ele>
+				<time>2017-10-09T18:49:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014329266308538" lon="-84.2168727972414">
+				<ele>979.3042015172541</ele>
+				<time>2017-10-09T18:50:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014329266308538" lon="-84.2168727972414">
+				<ele>979.3042015172541</ele>
+				<time>2017-10-09T18:50:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014329266308538" lon="-84.2168727972414">
+				<ele>979.3042015172541</ele>
+				<time>2017-10-09T18:50:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014329266308538" lon="-84.2168727972414">
+				<ele>979.3042015172541</ele>
+				<time>2017-10-09T18:50:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014329266308538" lon="-84.2168727972414">
+				<ele>979.3042015172541</ele>
+				<time>2017-10-09T18:50:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014329266308538" lon="-84.2168727972414">
+				<ele>979.3042015172541</ele>
+				<time>2017-10-09T18:50:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01433350256681" lon="-84.21686588870138">
+				<ele>978.8789121676236</ele>
+				<time>2017-10-09T18:50:06Z</time>
+				<extensions>
+					<speed>1.090209722518921</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014338680728278" lon="-84.21685280228246">
+				<ele>978.1761242551729</ele>
+				<time>2017-10-09T18:50:07Z</time>
+				<extensions>
+					<speed>1.732699990272522</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014342508619531" lon="-84.21684201176814">
+				<ele>977.8392291106284</ele>
+				<time>2017-10-09T18:50:08Z</time>
+				<extensions>
+					<speed>0.9644113779067993</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014343154710486" lon="-84.21683552816931">
+				<ele>977.5466028125957</ele>
+				<time>2017-10-09T18:50:09Z</time>
+				<extensions>
+					<speed>0.7483505010604858</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014344415877263" lon="-84.21683178895842">
+				<ele>977.3881253693253</ele>
+				<time>2017-10-09T18:50:10Z</time>
+				<extensions>
+					<speed>0.44339656829833984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014348387968836" lon="-84.21682853270535">
+				<ele>977.007928702049</ele>
+				<time>2017-10-09T18:50:11Z</time>
+				<extensions>
+					<speed>0.39232879877090454</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014351646556003" lon="-84.21681931856108">
+				<ele>976.2264233715832</ele>
+				<time>2017-10-09T18:50:12Z</time>
+				<extensions>
+					<speed>0.5984304547309875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01435280097914" lon="-84.21680806763219">
+				<ele>975.2937917327508</ele>
+				<time>2017-10-09T18:50:13Z</time>
+				<extensions>
+					<speed>0.6296952962875366</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01435186011957" lon="-84.21679480929397">
+				<ele>974.4759190939367</ele>
+				<time>2017-10-09T18:50:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014348652605335" lon="-84.21678755928976">
+				<ele>974.0693330056965</ele>
+				<time>2017-10-09T18:50:15Z</time>
+				<extensions>
+					<speed>0.71271151304245</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014344387077244" lon="-84.21678149259932">
+				<ele>973.8320950726047</ele>
+				<time>2017-10-09T18:50:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345675210878" lon="-84.21677998490159">
+				<ele>973.4351922189817</ele>
+				<time>2017-10-09T18:50:17Z</time>
+				<extensions>
+					<speed>0.3955867290496826</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345675210878" lon="-84.21677998490159">
+				<ele>973.4351922189817</ele>
+				<time>2017-10-09T18:50:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345675210878" lon="-84.21677998490159">
+				<ele>973.4351922189817</ele>
+				<time>2017-10-09T18:50:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345675210878" lon="-84.21677998490159">
+				<ele>973.4351922189817</ele>
+				<time>2017-10-09T18:50:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345675210878" lon="-84.21677998490159">
+				<ele>973.4351922189817</ele>
+				<time>2017-10-09T18:50:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345675210878" lon="-84.21677998490159">
+				<ele>973.4351922189817</ele>
+				<time>2017-10-09T18:50:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345675210878" lon="-84.21677998490159">
+				<ele>973.4351922189817</ele>
+				<time>2017-10-09T18:50:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345675210878" lon="-84.21677998490159">
+				<ele>973.4351922189817</ele>
+				<time>2017-10-09T18:50:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345675210878" lon="-84.21677998490159">
+				<ele>973.4351922189817</ele>
+				<time>2017-10-09T18:50:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345675210878" lon="-84.21677998490159">
+				<ele>973.4351922189817</ele>
+				<time>2017-10-09T18:50:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345675210878" lon="-84.21677998490159">
+				<ele>973.4351922189817</ele>
+				<time>2017-10-09T18:50:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345675210878" lon="-84.21677998490159">
+				<ele>973.4351922189817</ele>
+				<time>2017-10-09T18:50:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345675210878" lon="-84.21677998490159">
+				<ele>973.4351922189817</ele>
+				<time>2017-10-09T18:50:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345675210878" lon="-84.21677998490159">
+				<ele>973.4351922189817</ele>
+				<time>2017-10-09T18:50:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345675210878" lon="-84.21677998490159">
+				<ele>973.4351922189817</ele>
+				<time>2017-10-09T18:50:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345675210878" lon="-84.21677998490159">
+				<ele>973.4351922189817</ele>
+				<time>2017-10-09T18:50:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345675210878" lon="-84.21677998490159">
+				<ele>973.4351922189817</ele>
+				<time>2017-10-09T18:50:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345675210878" lon="-84.21677998490159">
+				<ele>973.4351922189817</ele>
+				<time>2017-10-09T18:50:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345675210878" lon="-84.21677998490159">
+				<ele>973.4351922189817</ele>
+				<time>2017-10-09T18:50:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014347407871798" lon="-84.21677322214">
+				<ele>972.9740330120549</ele>
+				<time>2017-10-09T18:50:36Z</time>
+				<extensions>
+					<speed>0.7274162173271179</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014344703094487" lon="-84.2167640499213">
+				<ele>972.449244257994</ele>
+				<time>2017-10-09T18:50:37Z</time>
+				<extensions>
+					<speed>0.9980064630508423</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014344383583865" lon="-84.21675355960963">
+				<ele>972.0054400544614</ele>
+				<time>2017-10-09T18:50:38Z</time>
+				<extensions>
+					<speed>1.1238837242126465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014344254660683" lon="-84.21674209820088">
+				<ele>971.629827615805</ele>
+				<time>2017-10-09T18:50:39Z</time>
+				<extensions>
+					<speed>1.1652719974517822</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01434483399462" lon="-84.21673246148754">
+				<ele>971.2780466871336</ele>
+				<time>2017-10-09T18:50:40Z</time>
+				<extensions>
+					<speed>0.865888237953186</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014347343667271" lon="-84.21672493708074">
+				<ele>970.7683177860454</ele>
+				<time>2017-10-09T18:50:41Z</time>
+				<extensions>
+					<speed>0.9889447093009949</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350140065497" lon="-84.21671830396556">
+				<ele>970.5363638764247</ele>
+				<time>2017-10-09T18:50:42Z</time>
+				<extensions>
+					<speed>0.6885290741920471</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014349775027139" lon="-84.21671373165852">
+				<ele>970.2563121719286</ele>
+				<time>2017-10-09T18:50:43Z</time>
+				<extensions>
+					<speed>0.4342658221721649</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014348130057293" lon="-84.2167104352522">
+				<ele>969.9690459715202</ele>
+				<time>2017-10-09T18:50:44Z</time>
+				<extensions>
+					<speed>0.12521721422672272</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014348130057293" lon="-84.2167104352522">
+				<ele>969.9690459715202</ele>
+				<time>2017-10-09T18:50:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014348130057293" lon="-84.2167104352522">
+				<ele>969.9690459715202</ele>
+				<time>2017-10-09T18:50:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014348130057293" lon="-84.2167104352522">
+				<ele>969.9690459715202</ele>
+				<time>2017-10-09T18:50:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014348130057293" lon="-84.2167104352522">
+				<ele>969.9690459715202</ele>
+				<time>2017-10-09T18:50:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014348130057293" lon="-84.2167104352522">
+				<ele>969.9690459715202</ele>
+				<time>2017-10-09T18:50:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014348130057293" lon="-84.2167104352522">
+				<ele>969.9690459715202</ele>
+				<time>2017-10-09T18:50:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014358820950465" lon="-84.21669966021572">
+				<ele>968.987918606028</ele>
+				<time>2017-10-09T18:50:51Z</time>
+				<extensions>
+					<speed>1.2385109663009644</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014368371800556" lon="-84.21668502799982">
+				<ele>968.5495136696845</ele>
+				<time>2017-10-09T18:50:52Z</time>
+				<extensions>
+					<speed>1.6468284130096436</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014374463544177" lon="-84.21666796120456">
+				<ele>968.2817839942873</ele>
+				<time>2017-10-09T18:50:53Z</time>
+				<extensions>
+					<speed>1.6008479595184326</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014379066767402" lon="-84.21664895965138">
+				<ele>967.936199140735</ele>
+				<time>2017-10-09T18:50:54Z</time>
+				<extensions>
+					<speed>1.6723592281341553</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01438047547419" lon="-84.2166307096076">
+				<ele>967.5440088463947</ele>
+				<time>2017-10-09T18:50:55Z</time>
+				<extensions>
+					<speed>1.6152691841125488</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014379621854312" lon="-84.21661198580723">
+				<ele>967.3940359670669</ele>
+				<time>2017-10-09T18:50:56Z</time>
+				<extensions>
+					<speed>1.5611778497695923</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014380825452148" lon="-84.21659733244923">
+				<ele>967.4048491893336</ele>
+				<time>2017-10-09T18:50:57Z</time>
+				<extensions>
+					<speed>1.1071652173995972</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014382874523397" lon="-84.21658636260617">
+				<ele>967.6065162587911</ele>
+				<time>2017-10-09T18:50:58Z</time>
+				<extensions>
+					<speed>0.5500953197479248</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014388612636296" lon="-84.21657871993861">
+				<ele>967.486486081034</ele>
+				<time>2017-10-09T18:50:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014388612636296" lon="-84.21657871993861">
+				<ele>967.486486081034</ele>
+				<time>2017-10-09T18:51:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014388612636296" lon="-84.21657871993861">
+				<ele>967.486486081034</ele>
+				<time>2017-10-09T18:51:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014388612636296" lon="-84.21657871993861">
+				<ele>967.486486081034</ele>
+				<time>2017-10-09T18:51:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014388612636296" lon="-84.21657871993861">
+				<ele>967.486486081034</ele>
+				<time>2017-10-09T18:51:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014388612636296" lon="-84.21657871993861">
+				<ele>967.486486081034</ele>
+				<time>2017-10-09T18:51:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014388612636296" lon="-84.21657871993861">
+				<ele>967.486486081034</ele>
+				<time>2017-10-09T18:51:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014388612636296" lon="-84.21657871993861">
+				<ele>967.486486081034</ele>
+				<time>2017-10-09T18:51:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014388612636296" lon="-84.21657871993861">
+				<ele>967.486486081034</ele>
+				<time>2017-10-09T18:51:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014388612636296" lon="-84.21657871993861">
+				<ele>967.486486081034</ele>
+				<time>2017-10-09T18:51:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014388612636296" lon="-84.21657871993861">
+				<ele>967.486486081034</ele>
+				<time>2017-10-09T18:51:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01439392780617" lon="-84.21657204168129">
+				<ele>967.2100619114935</ele>
+				<time>2017-10-09T18:51:10Z</time>
+				<extensions>
+					<speed>0.7008342742919922</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01439641770236" lon="-84.21656290823954">
+				<ele>967.13539702259</ele>
+				<time>2017-10-09T18:51:11Z</time>
+				<extensions>
+					<speed>0.7792081236839294</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014398355655414" lon="-84.21654904579893">
+				<ele>967.3008722346276</ele>
+				<time>2017-10-09T18:51:12Z</time>
+				<extensions>
+					<speed>1.3503106832504272</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01439936930482" lon="-84.21653296106412">
+				<ele>967.4281201530248</ele>
+				<time>2017-10-09T18:51:13Z</time>
+				<extensions>
+					<speed>1.2239561080932617</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014403240623253" lon="-84.21651585251357">
+				<ele>967.867489173077</ele>
+				<time>2017-10-09T18:51:14Z</time>
+				<extensions>
+					<speed>1.7066264152526855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014408619101197" lon="-84.21650015148559">
+				<ele>968.402684090659</ele>
+				<time>2017-10-09T18:51:15Z</time>
+				<extensions>
+					<speed>1.5564497709274292</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014412724839485" lon="-84.21648462954303">
+				<ele>968.3762030834332</ele>
+				<time>2017-10-09T18:51:16Z</time>
+				<extensions>
+					<speed>1.6973899602890015</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014417777008058" lon="-84.2164678380538">
+				<ele>968.4695818200707</ele>
+				<time>2017-10-09T18:51:17Z</time>
+				<extensions>
+					<speed>1.7170759439468384</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014424963703895" lon="-84.21644931262117">
+				<ele>968.4437318230048</ele>
+				<time>2017-10-09T18:51:18Z</time>
+				<extensions>
+					<speed>1.6035972833633423</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014432259148858" lon="-84.21643191395842">
+				<ele>967.3099007857963</ele>
+				<time>2017-10-09T18:51:19Z</time>
+				<extensions>
+					<speed>1.4058330059051514</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0144383126975" lon="-84.21641641928429">
+				<ele>966.5040341010317</ele>
+				<time>2017-10-09T18:51:20Z</time>
+				<extensions>
+					<speed>1.5138483047485352</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014444329520861" lon="-84.21640513496058">
+				<ele>965.6595638394356</ele>
+				<time>2017-10-09T18:51:21Z</time>
+				<extensions>
+					<speed>1.084078311920166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014450161517047" lon="-84.21639374023277">
+				<ele>965.2867450108752</ele>
+				<time>2017-10-09T18:51:22Z</time>
+				<extensions>
+					<speed>1.115551471710205</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445447978063" lon="-84.21637844178278">
+				<ele>964.8283740570769</ele>
+				<time>2017-10-09T18:51:23Z</time>
+				<extensions>
+					<speed>1.4672825336456299</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014458927501996" lon="-84.21635974387613">
+				<ele>964.6731902668253</ele>
+				<time>2017-10-09T18:51:24Z</time>
+				<extensions>
+					<speed>2.0904934406280518</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01446528907276" lon="-84.21633494430053">
+				<ele>964.2638571038842</ele>
+				<time>2017-10-09T18:51:25Z</time>
+				<extensions>
+					<speed>2.3314287662506104</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014470729937967" lon="-84.21630785762618">
+				<ele>964.5193780567497</ele>
+				<time>2017-10-09T18:51:26Z</time>
+				<extensions>
+					<speed>2.65488338470459</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014478577597911" lon="-84.21627825971193">
+				<ele>964.9331156956032</ele>
+				<time>2017-10-09T18:51:27Z</time>
+				<extensions>
+					<speed>2.704577684402466</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01448861166813" lon="-84.21625131812259">
+				<ele>965.9202723586932</ele>
+				<time>2017-10-09T18:51:28Z</time>
+				<extensions>
+					<speed>2.2994155883789063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01449615538364" lon="-84.21623000854049">
+				<ele>966.270547808148</ele>
+				<time>2017-10-09T18:51:29Z</time>
+				<extensions>
+					<speed>1.9354469776153564</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450235286084" lon="-84.21621452524182">
+				<ele>966.4623119058087</ele>
+				<time>2017-10-09T18:51:30Z</time>
+				<extensions>
+					<speed>1.224241018295288</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014508030163277" lon="-84.21620465836378">
+				<ele>966.5034081647173</ele>
+				<time>2017-10-09T18:51:31Z</time>
+				<extensions>
+					<speed>0.804237961769104</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014510248746552" lon="-84.21619928317799">
+				<ele>966.9159299302846</ele>
+				<time>2017-10-09T18:51:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014510910409278" lon="-84.21619831052294">
+				<ele>967.222817976959</ele>
+				<time>2017-10-09T18:51:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014510910409278" lon="-84.21619831052294">
+				<ele>967.222817976959</ele>
+				<time>2017-10-09T18:51:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014510910409278" lon="-84.21619831052294">
+				<ele>967.222817976959</ele>
+				<time>2017-10-09T18:51:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014510910409278" lon="-84.21619831052294">
+				<ele>967.222817976959</ele>
+				<time>2017-10-09T18:51:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014510910409278" lon="-84.21619831052294">
+				<ele>967.222817976959</ele>
+				<time>2017-10-09T18:51:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014510879660024" lon="-84.21619979414741">
+				<ele>967.0809763399884</ele>
+				<time>2017-10-09T18:51:38Z</time>
+				<extensions>
+					<speed>0.6057026386260986</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014510182841168" lon="-84.2162031836315">
+				<ele>967.0350525937974</ele>
+				<time>2017-10-09T18:51:39Z</time>
+				<extensions>
+					<speed>0.5166839957237244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014511420566823" lon="-84.21620489626036">
+				<ele>967.5169048178941</ele>
+				<time>2017-10-09T18:51:40Z</time>
+				<extensions>
+					<speed>0.15868982672691345</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014511420566823" lon="-84.21620489626036">
+				<ele>967.5169048178941</ele>
+				<time>2017-10-09T18:51:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014511420566823" lon="-84.21620489626036">
+				<ele>967.5169048178941</ele>
+				<time>2017-10-09T18:51:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014511420566823" lon="-84.21620489626036">
+				<ele>967.5169048178941</ele>
+				<time>2017-10-09T18:51:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014511420566823" lon="-84.21620489626036">
+				<ele>967.5169048178941</ele>
+				<time>2017-10-09T18:51:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014511420566823" lon="-84.21620489626036">
+				<ele>967.5169048178941</ele>
+				<time>2017-10-09T18:51:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014511420566823" lon="-84.21620489626036">
+				<ele>967.5169048178941</ele>
+				<time>2017-10-09T18:51:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014511420566823" lon="-84.21620489626036">
+				<ele>967.5169048178941</ele>
+				<time>2017-10-09T18:51:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014511420566823" lon="-84.21620489626036">
+				<ele>967.5169048178941</ele>
+				<time>2017-10-09T18:51:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014511420566823" lon="-84.21620489626036">
+				<ele>967.5169048178941</ele>
+				<time>2017-10-09T18:51:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014511227948244" lon="-84.21620020950753">
+				<ele>967.1574708633125</ele>
+				<time>2017-10-09T18:51:50Z</time>
+				<extensions>
+					<speed>0.6757489442825317</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014512803077784" lon="-84.21618890765869">
+				<ele>966.7092505404726</ele>
+				<time>2017-10-09T18:51:51Z</time>
+				<extensions>
+					<speed>1.132841944694519</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01451865589347" lon="-84.21617177393914">
+				<ele>965.8761183749884</ele>
+				<time>2017-10-09T18:51:52Z</time>
+				<extensions>
+					<speed>1.7957549095153809</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014529361523913" lon="-84.21614981885469">
+				<ele>965.1325425878167</ele>
+				<time>2017-10-09T18:51:53Z</time>
+				<extensions>
+					<speed>2.417595386505127</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01453963080066" lon="-84.21612224193642">
+				<ele>964.8679407900199</ele>
+				<time>2017-10-09T18:51:54Z</time>
+				<extensions>
+					<speed>3.2606260776519775</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01455016911231" lon="-84.21608948875034">
+				<ele>964.286862552166</ele>
+				<time>2017-10-09T18:51:55Z</time>
+				<extensions>
+					<speed>3.682976007461548</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014563636540032" lon="-84.21605347572918">
+				<ele>963.4784271428362</ele>
+				<time>2017-10-09T18:51:56Z</time>
+				<extensions>
+					<speed>3.8076725006103516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014575598250184" lon="-84.21601613490859">
+				<ele>962.968292769976</ele>
+				<time>2017-10-09T18:51:57Z</time>
+				<extensions>
+					<speed>3.9192278385162354</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014588351807435" lon="-84.21597753396331">
+				<ele>962.4282172480598</ele>
+				<time>2017-10-09T18:51:58Z</time>
+				<extensions>
+					<speed>4.219576358795166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014601640847049" lon="-84.21593699223067">
+				<ele>961.9268885692582</ele>
+				<time>2017-10-09T18:51:59Z</time>
+				<extensions>
+					<speed>4.619379043579102</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01461501094411" lon="-84.21589405486938">
+				<ele>961.7953957431018</ele>
+				<time>2017-10-09T18:52:00Z</time>
+				<extensions>
+					<speed>4.871975421905518</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014629265930886" lon="-84.21585383889526">
+				<ele>961.7682908624411</ele>
+				<time>2017-10-09T18:52:01Z</time>
+				<extensions>
+					<speed>4.404518127441406</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014640440300509" lon="-84.21582299524259">
+				<ele>961.849812743254</ele>
+				<time>2017-10-09T18:52:02Z</time>
+				<extensions>
+					<speed>2.4529688358306885</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014646570978558" lon="-84.21580515568823">
+				<ele>962.0399286728352</ele>
+				<time>2017-10-09T18:52:03Z</time>
+				<extensions>
+					<speed>0.8302030563354492</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:04Z</time>
+				<extensions>
+					<speed>0.30707618594169617</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648623174953" lon="-84.2157996221312">
+				<ele>962.3592762127519</ele>
+				<time>2017-10-09T18:52:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014657669010392" lon="-84.21579314338805">
+				<ele>961.9804381961003</ele>
+				<time>2017-10-09T18:52:31Z</time>
+				<extensions>
+					<speed>1.1784697771072388</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014669439240597" lon="-84.21578026881689">
+				<ele>961.1603148141876</ele>
+				<time>2017-10-09T18:52:32Z</time>
+				<extensions>
+					<speed>1.7384024858474731</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014679478168835" lon="-84.21576014657019">
+				<ele>960.5939292805269</ele>
+				<time>2017-10-09T18:52:33Z</time>
+				<extensions>
+					<speed>2.627708911895752</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014689352613663" lon="-84.2157333527348">
+				<ele>960.0273255128413</ele>
+				<time>2017-10-09T18:52:34Z</time>
+				<extensions>
+					<speed>3.3687806129455566</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014696817623706" lon="-84.21570227778487">
+				<ele>959.3995441570878</ele>
+				<time>2017-10-09T18:52:35Z</time>
+				<extensions>
+					<speed>3.5823111534118652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014701267560868" lon="-84.2156656852467">
+				<ele>958.9702213546261</ele>
+				<time>2017-10-09T18:52:36Z</time>
+				<extensions>
+					<speed>4.161250114440918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014707633551081" lon="-84.21562329785789">
+				<ele>958.881991523318</ele>
+				<time>2017-10-09T18:52:37Z</time>
+				<extensions>
+					<speed>4.692066669464111</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014714888105017" lon="-84.21557667853249">
+				<ele>958.812133111991</ele>
+				<time>2017-10-09T18:52:38Z</time>
+				<extensions>
+					<speed>4.684648036956787</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01472005665197" lon="-84.2155348484537">
+				<ele>958.6875140164047</ele>
+				<time>2017-10-09T18:52:39Z</time>
+				<extensions>
+					<speed>3.9507081508636475</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014722921896784" lon="-84.21550112428825">
+				<ele>958.6663414025679</ele>
+				<time>2017-10-09T18:52:40Z</time>
+				<extensions>
+					<speed>2.9433493614196777</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01472214536705" lon="-84.21547789228005">
+				<ele>958.615507488139</ele>
+				<time>2017-10-09T18:52:41Z</time>
+				<extensions>
+					<speed>1.6972531080245972</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014724001383902" lon="-84.21546731010564">
+				<ele>958.9641639385372</ele>
+				<time>2017-10-09T18:52:42Z</time>
+				<extensions>
+					<speed>0.06052771210670471</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014727589637051" lon="-84.21546642948937">
+				<ele>959.4692725036293</ele>
+				<time>2017-10-09T18:52:43Z</time>
+				<extensions>
+					<speed>0.9715158343315125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014730694249508" lon="-84.2154675201798">
+				<ele>960.2208739351481</ele>
+				<time>2017-10-09T18:52:44Z</time>
+				<extensions>
+					<speed>1.0501549243927002</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014730873730551" lon="-84.21547002794843">
+				<ele>960.8085136553273</ele>
+				<time>2017-10-09T18:52:45Z</time>
+				<extensions>
+					<speed>1.1005316972732544</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01473145649871" lon="-84.2154718418925">
+				<ele>961.4474338414147</ele>
+				<time>2017-10-09T18:52:46Z</time>
+				<extensions>
+					<speed>0.8915449976921082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01473145649871" lon="-84.2154718418925">
+				<ele>961.4474338414147</ele>
+				<time>2017-10-09T18:52:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01472885812972" lon="-84.21546780949572">
+				<ele>961.9671350196004</ele>
+				<time>2017-10-09T18:52:48Z</time>
+				<extensions>
+					<speed>0.19642706215381622</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01472885812972" lon="-84.21546780949572">
+				<ele>961.9671350196004</ele>
+				<time>2017-10-09T18:52:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01472885812972" lon="-84.21546780949572">
+				<ele>961.9671350196004</ele>
+				<time>2017-10-09T18:52:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01472885812972" lon="-84.21546780949572">
+				<ele>961.9671350196004</ele>
+				<time>2017-10-09T18:52:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01472885812972" lon="-84.21546780949572">
+				<ele>961.9671350196004</ele>
+				<time>2017-10-09T18:52:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01472885812972" lon="-84.21546780949572">
+				<ele>961.9671350196004</ele>
+				<time>2017-10-09T18:52:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01472885812972" lon="-84.21546780949572">
+				<ele>961.9671350196004</ele>
+				<time>2017-10-09T18:52:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01472885812972" lon="-84.21546780949572">
+				<ele>961.9671350196004</ele>
+				<time>2017-10-09T18:52:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01472885812972" lon="-84.21546780949572">
+				<ele>961.9671350196004</ele>
+				<time>2017-10-09T18:52:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01472885812972" lon="-84.21546780949572">
+				<ele>961.9671350196004</ele>
+				<time>2017-10-09T18:52:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01472885812972" lon="-84.21546780949572">
+				<ele>961.9671350196004</ele>
+				<time>2017-10-09T18:52:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01472885812972" lon="-84.21546780949572">
+				<ele>961.9671350196004</ele>
+				<time>2017-10-09T18:52:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01472885812972" lon="-84.21546780949572">
+				<ele>961.9671350196004</ele>
+				<time>2017-10-09T18:53:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014727130516029" lon="-84.2154610631726">
+				<ele>962.1354301609099</ele>
+				<time>2017-10-09T18:53:01Z</time>
+				<extensions>
+					<speed>0.7122472524642944</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014722333939229" lon="-84.21544949263819">
+				<ele>962.2745055612177</ele>
+				<time>2017-10-09T18:53:02Z</time>
+				<extensions>
+					<speed>1.2950477600097656</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014718584129584" lon="-84.21543522005533">
+				<ele>962.6086633196101</ele>
+				<time>2017-10-09T18:53:03Z</time>
+				<extensions>
+					<speed>1.370314598083496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01471545066539" lon="-84.21541879949179">
+				<ele>963.0710421223193</ele>
+				<time>2017-10-09T18:53:04Z</time>
+				<extensions>
+					<speed>1.1823501586914063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014712082073066" lon="-84.21540332820815">
+				<ele>963.3502951422706</ele>
+				<time>2017-10-09T18:53:05Z</time>
+				<extensions>
+					<speed>1.011910319328308</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708401076982" lon="-84.2153938111952">
+				<ele>963.60151511617</ele>
+				<time>2017-10-09T18:53:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014711509800067" lon="-84.21538582601747">
+				<ele>963.6477640010417</ele>
+				<time>2017-10-09T18:53:36Z</time>
+				<extensions>
+					<speed>0.6467611193656921</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01471927844394" lon="-84.21537534350996">
+				<ele>964.0305992951617</ele>
+				<time>2017-10-09T18:53:37Z</time>
+				<extensions>
+					<speed>0.9257768988609314</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014725326568179" lon="-84.21536392686589">
+				<ele>963.8364536901936</ele>
+				<time>2017-10-09T18:53:38Z</time>
+				<extensions>
+					<speed>0.9837228655815125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014731467708799" lon="-84.21535068554361">
+				<ele>963.2475862335414</ele>
+				<time>2017-10-09T18:53:39Z</time>
+				<extensions>
+					<speed>1.1229784488677979</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014737381441485" lon="-84.21533619011679">
+				<ele>962.9115651138127</ele>
+				<time>2017-10-09T18:53:40Z</time>
+				<extensions>
+					<speed>1.391967535018921</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014740806623967" lon="-84.21531991159794">
+				<ele>962.5475967656821</ele>
+				<time>2017-10-09T18:53:41Z</time>
+				<extensions>
+					<speed>1.6041748523712158</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014743469067485" lon="-84.21530087209592">
+				<ele>962.1008747518063</ele>
+				<time>2017-10-09T18:53:42Z</time>
+				<extensions>
+					<speed>1.810899257659912</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014747896020651" lon="-84.21527827378637">
+				<ele>961.6827967399731</ele>
+				<time>2017-10-09T18:53:43Z</time>
+				<extensions>
+					<speed>2.2024147510528564</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014755092448725" lon="-84.21525486554967">
+				<ele>961.6296425340697</ele>
+				<time>2017-10-09T18:53:44Z</time>
+				<extensions>
+					<speed>2.5306198596954346</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014759469996324" lon="-84.21522831737747">
+				<ele>961.6575827701017</ele>
+				<time>2017-10-09T18:53:45Z</time>
+				<extensions>
+					<speed>2.6519381999969482</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014765364600603" lon="-84.21520061989442">
+				<ele>961.8072878038511</ele>
+				<time>2017-10-09T18:53:46Z</time>
+				<extensions>
+					<speed>2.9484121799468994</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014772783143856" lon="-84.21516590277793">
+				<ele>961.9263608735055</ele>
+				<time>2017-10-09T18:53:47Z</time>
+				<extensions>
+					<speed>3.825741767883301</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01477775505712" lon="-84.21512500567981">
+				<ele>961.8684891490266</ele>
+				<time>2017-10-09T18:53:48Z</time>
+				<extensions>
+					<speed>4.128122329711914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014787325872083" lon="-84.21508526355856">
+				<ele>961.9152690861374</ele>
+				<time>2017-10-09T18:53:49Z</time>
+				<extensions>
+					<speed>3.958796977996826</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014792885610158" lon="-84.21505509646865">
+				<ele>962.0634711459279</ele>
+				<time>2017-10-09T18:53:50Z</time>
+				<extensions>
+					<speed>2.7553956508636475</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014797571019217" lon="-84.21503456490943">
+				<ele>962.274456041865</ele>
+				<time>2017-10-09T18:53:51Z</time>
+				<extensions>
+					<speed>1.355542540550232</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014803159629018" lon="-84.21502271680603">
+				<ele>962.5340950665995</ele>
+				<time>2017-10-09T18:53:52Z</time>
+				<extensions>
+					<speed>1.0893852710723877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014811005346017" lon="-84.21501621407253">
+				<ele>962.6781679578125</ele>
+				<time>2017-10-09T18:53:53Z</time>
+				<extensions>
+					<speed>0.7130898237228394</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014811005346017" lon="-84.21501621407253">
+				<ele>962.6781679578125</ele>
+				<time>2017-10-09T18:53:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014814032401077" lon="-84.21501476519884">
+				<ele>963.017681975849</ele>
+				<time>2017-10-09T18:53:55Z</time>
+				<extensions>
+					<speed>0.7504953145980835</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014814032401077" lon="-84.21501476519884">
+				<ele>963.017681975849</ele>
+				<time>2017-10-09T18:53:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014816407900112" lon="-84.21501300855984">
+				<ele>963.1064426098019</ele>
+				<time>2017-10-09T18:53:57Z</time>
+				<extensions>
+					<speed>0.35264354944229126</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014816407900112" lon="-84.21501300855984">
+				<ele>963.1064426098019</ele>
+				<time>2017-10-09T18:53:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014816407900112" lon="-84.21501300855984">
+				<ele>963.1064426098019</ele>
+				<time>2017-10-09T18:53:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014816407900112" lon="-84.21501300855984">
+				<ele>963.1064426098019</ele>
+				<time>2017-10-09T18:54:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014816407900112" lon="-84.21501300855984">
+				<ele>963.1064426098019</ele>
+				<time>2017-10-09T18:54:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014816407900112" lon="-84.21501300855984">
+				<ele>963.1064426098019</ele>
+				<time>2017-10-09T18:54:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014816407900112" lon="-84.21501300855984">
+				<ele>963.1064426098019</ele>
+				<time>2017-10-09T18:54:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014816407900112" lon="-84.21501300855984">
+				<ele>963.1064426098019</ele>
+				<time>2017-10-09T18:54:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014816407900112" lon="-84.21501300855984">
+				<ele>963.1064426098019</ele>
+				<time>2017-10-09T18:54:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014811145772438" lon="-84.21500893884101">
+				<ele>963.2044009687379</ele>
+				<time>2017-10-09T18:54:06Z</time>
+				<extensions>
+					<speed>0.6699994206428528</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014811145772438" lon="-84.21500893884101">
+				<ele>963.2044009687379</ele>
+				<time>2017-10-09T18:54:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01481226002531" lon="-84.2150036145107">
+				<ele>963.3419808372855</ele>
+				<time>2017-10-09T18:54:08Z</time>
+				<extensions>
+					<speed>0.09762849658727646</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01481226002531" lon="-84.2150036145107">
+				<ele>963.3419808372855</ele>
+				<time>2017-10-09T18:54:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01481226002531" lon="-84.2150036145107">
+				<ele>963.3419808372855</ele>
+				<time>2017-10-09T18:54:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01481226002531" lon="-84.2150036145107">
+				<ele>963.3419808372855</ele>
+				<time>2017-10-09T18:54:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01481226002531" lon="-84.2150036145107">
+				<ele>963.3419808372855</ele>
+				<time>2017-10-09T18:54:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01481226002531" lon="-84.2150036145107">
+				<ele>963.3419808372855</ele>
+				<time>2017-10-09T18:54:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01481226002531" lon="-84.2150036145107">
+				<ele>963.3419808372855</ele>
+				<time>2017-10-09T18:54:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01481226002531" lon="-84.2150036145107">
+				<ele>963.3419808372855</ele>
+				<time>2017-10-09T18:54:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01481226002531" lon="-84.2150036145107">
+				<ele>963.3419808372855</ele>
+				<time>2017-10-09T18:54:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01481226002531" lon="-84.2150036145107">
+				<ele>963.3419808372855</ele>
+				<time>2017-10-09T18:54:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01481226002531" lon="-84.2150036145107">
+				<ele>963.3419808372855</ele>
+				<time>2017-10-09T18:54:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01481226002531" lon="-84.2150036145107">
+				<ele>963.3419808372855</ele>
+				<time>2017-10-09T18:54:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01481226002531" lon="-84.2150036145107">
+				<ele>963.3419808372855</ele>
+				<time>2017-10-09T18:54:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01481248127236" lon="-84.21499900542094">
+				<ele>963.235481671989</ele>
+				<time>2017-10-09T18:54:21Z</time>
+				<extensions>
+					<speed>0.7373000383377075</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014814452052489" lon="-84.21498773475467">
+				<ele>962.9562517721206</ele>
+				<time>2017-10-09T18:54:22Z</time>
+				<extensions>
+					<speed>1.7578455209732056</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014819415779588" lon="-84.21497000940691">
+				<ele>962.7067598598078</ele>
+				<time>2017-10-09T18:54:23Z</time>
+				<extensions>
+					<speed>2.391120672225952</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825740570537" lon="-84.21494200887682">
+				<ele>962.4767663739622</ele>
+				<time>2017-10-09T18:54:24Z</time>
+				<extensions>
+					<speed>3.2290403842926025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014833271542571" lon="-84.21490996753424">
+				<ele>962.4465863220394</ele>
+				<time>2017-10-09T18:54:25Z</time>
+				<extensions>
+					<speed>3.440415382385254</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014840879798207" lon="-84.2148747921153">
+				<ele>962.4926035655662</ele>
+				<time>2017-10-09T18:54:26Z</time>
+				<extensions>
+					<speed>3.6205568313598633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014856866755196" lon="-84.21483979184343">
+				<ele>962.4184999223799</ele>
+				<time>2017-10-09T18:54:27Z</time>
+				<extensions>
+					<speed>4.133467674255371</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014869500429066" lon="-84.21479605525002">
+				<ele>962.2814226178452</ele>
+				<time>2017-10-09T18:54:28Z</time>
+				<extensions>
+					<speed>5.491701602935791</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014887997403331" lon="-84.21474012401819">
+				<ele>962.2006598552689</ele>
+				<time>2017-10-09T18:54:29Z</time>
+				<extensions>
+					<speed>6.690383434295654</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014911079521957" lon="-84.21467858035636">
+				<ele>962.1762739764526</ele>
+				<time>2017-10-09T18:54:30Z</time>
+				<extensions>
+					<speed>7.137720108032227</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014943587192546" lon="-84.21462218385001">
+				<ele>962.3196900589392</ele>
+				<time>2017-10-09T18:54:31Z</time>
+				<extensions>
+					<speed>7.150089740753174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014975543238142" lon="-84.21456194669209">
+				<ele>962.1943238275126</ele>
+				<time>2017-10-09T18:54:32Z</time>
+				<extensions>
+					<speed>7.232508659362793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014998175863045" lon="-84.21449036996665">
+				<ele>962.1556535214186</ele>
+				<time>2017-10-09T18:54:33Z</time>
+				<extensions>
+					<speed>8.06663703918457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015013156132039" lon="-84.21441177593921">
+				<ele>962.3194898860529</ele>
+				<time>2017-10-09T18:54:34Z</time>
+				<extensions>
+					<speed>8.492487907409668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015030720181418" lon="-84.21433278916984">
+				<ele>962.4315135041252</ele>
+				<time>2017-10-09T18:54:35Z</time>
+				<extensions>
+					<speed>8.107317924499512</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015049357637118" lon="-84.21426125978684">
+				<ele>962.5225020255893</ele>
+				<time>2017-10-09T18:54:36Z</time>
+				<extensions>
+					<speed>7.3202714920043945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015064135081515" lon="-84.21419937144373">
+				<ele>962.546810275875</ele>
+				<time>2017-10-09T18:54:37Z</time>
+				<extensions>
+					<speed>5.999119758605957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015073636241468" lon="-84.21414883582224">
+				<ele>962.5430263131857</ele>
+				<time>2017-10-09T18:54:38Z</time>
+				<extensions>
+					<speed>4.339311122894287</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015083179472317" lon="-84.2141128976917">
+				<ele>962.5624244036153</ele>
+				<time>2017-10-09T18:54:39Z</time>
+				<extensions>
+					<speed>2.713425636291504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015090186141064" lon="-84.21408952452248">
+				<ele>962.7306447671726</ele>
+				<time>2017-10-09T18:54:40Z</time>
+				<extensions>
+					<speed>1.5282808542251587</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015094267772481" lon="-84.214080287648">
+				<ele>962.7997281197459</ele>
+				<time>2017-10-09T18:54:41Z</time>
+				<extensions>
+					<speed>0.42588499188423157</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015097497529105" lon="-84.21408297254416">
+				<ele>962.7930436646566</ele>
+				<time>2017-10-09T18:54:42Z</time>
+				<extensions>
+					<speed>0.6576542258262634</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015100251903087" lon="-84.21409391377499">
+				<ele>962.65052572079</ele>
+				<time>2017-10-09T18:54:43Z</time>
+				<extensions>
+					<speed>1.0299804210662842</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0151011737402" lon="-84.21410185485327">
+				<ele>962.6697836769745</ele>
+				<time>2017-10-09T18:54:44Z</time>
+				<extensions>
+					<speed>1.0308408737182617</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015104186556643" lon="-84.2141108161082">
+				<ele>962.672451980412</ele>
+				<time>2017-10-09T18:54:45Z</time>
+				<extensions>
+					<speed>1.0889774560928345</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0151087235992" lon="-84.2141180180376">
+				<ele>962.6659240787849</ele>
+				<time>2017-10-09T18:54:46Z</time>
+				<extensions>
+					<speed>1.0624171495437622</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015110455152984" lon="-84.21412787593984">
+				<ele>962.8375370055437</ele>
+				<time>2017-10-09T18:54:47Z</time>
+				<extensions>
+					<speed>1.0867340564727783</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01511434716668" lon="-84.21414378816499">
+				<ele>962.871492437087</ele>
+				<time>2017-10-09T18:54:48Z</time>
+				<extensions>
+					<speed>1.1640573740005493</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015121231187509" lon="-84.21415993270594">
+				<ele>962.7830427894369</ele>
+				<time>2017-10-09T18:54:49Z</time>
+				<extensions>
+					<speed>1.1319705247879028</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015127211477793" lon="-84.21416780657242">
+				<ele>962.8904226170853</ele>
+				<time>2017-10-09T18:54:50Z</time>
+				<extensions>
+					<speed>0.9160208106040955</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015127211477793" lon="-84.21416780657242">
+				<ele>962.8904226170853</ele>
+				<time>2017-10-09T18:54:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01512814102443" lon="-84.214162761515">
+				<ele>963.0962409107015</ele>
+				<time>2017-10-09T18:54:52Z</time>
+				<extensions>
+					<speed>0.303126722574234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01512814102443" lon="-84.214162761515">
+				<ele>963.0962409107015</ele>
+				<time>2017-10-09T18:54:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01512814102443" lon="-84.214162761515">
+				<ele>963.0962409107015</ele>
+				<time>2017-10-09T18:54:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01512814102443" lon="-84.214162761515">
+				<ele>963.0962409107015</ele>
+				<time>2017-10-09T18:54:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01512814102443" lon="-84.214162761515">
+				<ele>963.0962409107015</ele>
+				<time>2017-10-09T18:54:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01512814102443" lon="-84.214162761515">
+				<ele>963.0962409107015</ele>
+				<time>2017-10-09T18:54:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01512814102443" lon="-84.214162761515">
+				<ele>963.0962409107015</ele>
+				<time>2017-10-09T18:54:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01512814102443" lon="-84.214162761515">
+				<ele>963.0962409107015</ele>
+				<time>2017-10-09T18:54:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01512814102443" lon="-84.214162761515">
+				<ele>963.0962409107015</ele>
+				<time>2017-10-09T18:55:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01512814102443" lon="-84.214162761515">
+				<ele>963.0962409107015</ele>
+				<time>2017-10-09T18:55:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01512814102443" lon="-84.214162761515">
+				<ele>963.0962409107015</ele>
+				<time>2017-10-09T18:55:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01512814102443" lon="-84.214162761515">
+				<ele>963.0962409107015</ele>
+				<time>2017-10-09T18:55:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01512814102443" lon="-84.214162761515">
+				<ele>963.0962409107015</ele>
+				<time>2017-10-09T18:55:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01512814102443" lon="-84.214162761515">
+				<ele>963.0962409107015</ele>
+				<time>2017-10-09T18:55:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01512814102443" lon="-84.214162761515">
+				<ele>963.0962409107015</ele>
+				<time>2017-10-09T18:55:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01512814102443" lon="-84.214162761515">
+				<ele>963.0962409107015</ele>
+				<time>2017-10-09T18:55:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015115500039784" lon="-84.21414294894443">
+				<ele>962.9512122180313</ele>
+				<time>2017-10-09T18:55:08Z</time>
+				<extensions>
+					<speed>0.7588663101196289</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01510774180242" lon="-84.21411789185332">
+				<ele>962.8348996974528</ele>
+				<time>2017-10-09T18:55:09Z</time>
+				<extensions>
+					<speed>1.3125230073928833</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015098614177846" lon="-84.21409311176211">
+				<ele>962.7914224127308</ele>
+				<time>2017-10-09T18:55:10Z</time>
+				<extensions>
+					<speed>1.65073561668396</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015089702418003" lon="-84.21407137968122">
+				<ele>962.8432380147278</ele>
+				<time>2017-10-09T18:55:11Z</time>
+				<extensions>
+					<speed>1.8834338188171387</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015077760986626" lon="-84.21404387685443">
+				<ele>962.8727687634528</ele>
+				<time>2017-10-09T18:55:12Z</time>
+				<extensions>
+					<speed>2.2816834449768066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015075384290288" lon="-84.2140175481484">
+				<ele>962.8256974834949</ele>
+				<time>2017-10-09T18:55:13Z</time>
+				<extensions>
+					<speed>2.5317580699920654</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015069022397553" lon="-84.21398221729459">
+				<ele>962.7486571408808</ele>
+				<time>2017-10-09T18:55:14Z</time>
+				<extensions>
+					<speed>3.1086924076080322</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01507253293328" lon="-84.21392065315405">
+				<ele>962.5874078720808</ele>
+				<time>2017-10-09T18:55:15Z</time>
+				<extensions>
+					<speed>4.424293041229248</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015083841880479" lon="-84.21386134579122">
+				<ele>962.4726325813681</ele>
+				<time>2017-10-09T18:55:16Z</time>
+				<extensions>
+					<speed>5.429805278778076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015112373033462" lon="-84.213806366627">
+				<ele>962.3436522893608</ele>
+				<time>2017-10-09T18:55:17Z</time>
+				<extensions>
+					<speed>5.987041473388672</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015143047163159" lon="-84.21374953559098">
+				<ele>962.416546179913</ele>
+				<time>2017-10-09T18:55:18Z</time>
+				<extensions>
+					<speed>6.447304725646973</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01516874408255" lon="-84.21369282279336">
+				<ele>962.3143353313208</ele>
+				<time>2017-10-09T18:55:19Z</time>
+				<extensions>
+					<speed>6.55415153503418</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015189915643445" lon="-84.21363972510736">
+				<ele>962.148786181584</ele>
+				<time>2017-10-09T18:55:20Z</time>
+				<extensions>
+					<speed>6.399071216583252</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015203564971946" lon="-84.21357495041944">
+				<ele>962.0464421063662</ele>
+				<time>2017-10-09T18:55:21Z</time>
+				<extensions>
+					<speed>6.192248821258545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015202433157816" lon="-84.21350911532382">
+				<ele>961.80059421435</ele>
+				<time>2017-10-09T18:55:22Z</time>
+				<extensions>
+					<speed>4.956542491912842</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015204879357551" lon="-84.21346195645323">
+				<ele>961.7961163753644</ele>
+				<time>2017-10-09T18:55:23Z</time>
+				<extensions>
+					<speed>4.421230792999268</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015205257767807" lon="-84.21342624326512">
+				<ele>961.7986794151366</ele>
+				<time>2017-10-09T18:55:24Z</time>
+				<extensions>
+					<speed>3.1592485904693604</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015208689251047" lon="-84.21341410032224">
+				<ele>962.0643925238401</ele>
+				<time>2017-10-09T18:55:25Z</time>
+				<extensions>
+					<speed>1.6702769994735718</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015217501084901" lon="-84.21341579772874">
+				<ele>962.3805460901931</ele>
+				<time>2017-10-09T18:55:26Z</time>
+				<extensions>
+					<speed>0.8802462816238403</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015226721269903" lon="-84.2134238482824">
+				<ele>962.8926337426528</ele>
+				<time>2017-10-09T18:55:27Z</time>
+				<extensions>
+					<speed>0.3985860347747803</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015226721269903" lon="-84.2134238482824">
+				<ele>962.8926337426528</ele>
+				<time>2017-10-09T18:55:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015230988323305" lon="-84.21343967956628">
+				<ele>963.4034559736028</ele>
+				<time>2017-10-09T18:55:29Z</time>
+				<extensions>
+					<speed>1.061998963356018</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233256444033" lon="-84.21344351488338">
+				<ele>964.2980128088966</ele>
+				<time>2017-10-09T18:55:30Z</time>
+				<extensions>
+					<speed>1.117218017578125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015233460423572" lon="-84.21345119828653">
+				<ele>964.7959082368761</ele>
+				<time>2017-10-09T18:55:31Z</time>
+				<extensions>
+					<speed>1.2621731758117676</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015234930535104" lon="-84.21345213876862">
+				<ele>965.3012509308755</ele>
+				<time>2017-10-09T18:55:32Z</time>
+				<extensions>
+					<speed>0.9392890930175781</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015234930535104" lon="-84.21345213876862">
+				<ele>965.3012509308755</ele>
+				<time>2017-10-09T18:55:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01523460584734" lon="-84.21346167828652">
+				<ele>965.1525907320902</ele>
+				<time>2017-10-09T18:55:34Z</time>
+				<extensions>
+					<speed>0.7665525078773499</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01523460584734" lon="-84.21346167828652">
+				<ele>965.1525907320902</ele>
+				<time>2017-10-09T18:55:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:36Z</time>
+				<extensions>
+					<speed>0.07868519425392151</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:55:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:56:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:56:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:56:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:56:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:56:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:56:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238046783312" lon="-84.21345004736011">
+				<ele>964.470060409978</ele>
+				<time>2017-10-09T18:56:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015238625671557" lon="-84.21344258867205">
+				<ele>964.036247911863</ele>
+				<time>2017-10-09T18:56:07Z</time>
+				<extensions>
+					<speed>1.0666308403015137</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015237849223473" lon="-84.21343402982436">
+				<ele>963.6562178153545</ele>
+				<time>2017-10-09T18:56:08Z</time>
+				<extensions>
+					<speed>1.1454964876174927</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015236222643907" lon="-84.21342441807552">
+				<ele>963.1204625898972</ele>
+				<time>2017-10-09T18:56:09Z</time>
+				<extensions>
+					<speed>1.1463212966918945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015234219945931" lon="-84.21341869402535">
+				<ele>962.8161859661341</ele>
+				<time>2017-10-09T18:56:10Z</time>
+				<extensions>
+					<speed>0.8786560297012329</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015234597827984" lon="-84.21341444375142">
+				<ele>962.683256926015</ele>
+				<time>2017-10-09T18:56:11Z</time>
+				<extensions>
+					<speed>0.7328246831893921</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015236065458668" lon="-84.21341562212689">
+				<ele>962.2508507799357</ele>
+				<time>2017-10-09T18:56:12Z</time>
+				<extensions>
+					<speed>0.3741063177585602</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015236838445714" lon="-84.21342106509505">
+				<ele>961.8854451030493</ele>
+				<time>2017-10-09T18:56:13Z</time>
+				<extensions>
+					<speed>0.08151503652334213</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015236838445714" lon="-84.21342106509505">
+				<ele>961.8854451030493</ele>
+				<time>2017-10-09T18:56:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015236838445714" lon="-84.21342106509505">
+				<ele>961.8854451030493</ele>
+				<time>2017-10-09T18:56:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015236838445714" lon="-84.21342106509505">
+				<ele>961.8854451030493</ele>
+				<time>2017-10-09T18:56:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015244329929644" lon="-84.21340778525438">
+				<ele>961.4414231777191</ele>
+				<time>2017-10-09T18:56:17Z</time>
+				<extensions>
+					<speed>1.5081480741500854</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015256379394792" lon="-84.21339427396103">
+				<ele>960.9243889600039</ele>
+				<time>2017-10-09T18:56:18Z</time>
+				<extensions>
+					<speed>2.2614009380340576</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015270989045579" lon="-84.21337745573408">
+				<ele>960.6595918005332</ele>
+				<time>2017-10-09T18:56:19Z</time>
+				<extensions>
+					<speed>3.3047597408294678</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01528481408115" lon="-84.21334617470397">
+				<ele>960.1336802355945</ele>
+				<time>2017-10-09T18:56:20Z</time>
+				<extensions>
+					<speed>4.3885416984558105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015296273522287" lon="-84.21330214759918">
+				<ele>960.2922755470499</ele>
+				<time>2017-10-09T18:56:21Z</time>
+				<extensions>
+					<speed>5.6122355461120605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015308021145957" lon="-84.21324685629027">
+				<ele>960.2530429931358</ele>
+				<time>2017-10-09T18:56:22Z</time>
+				<extensions>
+					<speed>6.218916416168213</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01532289326093" lon="-84.213181798515">
+				<ele>960.1361686047167</ele>
+				<time>2017-10-09T18:56:23Z</time>
+				<extensions>
+					<speed>6.393826961517334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015342122516769" lon="-84.21311466337333">
+				<ele>960.2957770749927</ele>
+				<time>2017-10-09T18:56:24Z</time>
+				<extensions>
+					<speed>6.953396797180176</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01536367806081" lon="-84.213047165513">
+				<ele>959.9824285488576</ele>
+				<time>2017-10-09T18:56:25Z</time>
+				<extensions>
+					<speed>7.50007963180542</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015385432258098" lon="-84.2129675307202">
+				<ele>959.3155329087749</ele>
+				<time>2017-10-09T18:56:26Z</time>
+				<extensions>
+					<speed>8.309051513671875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015404457158864" lon="-84.21288491000436">
+				<ele>958.7796881655231</ele>
+				<time>2017-10-09T18:56:27Z</time>
+				<extensions>
+					<speed>8.592528343200684</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015423262753309" lon="-84.21280397015632">
+				<ele>958.7076464993879</ele>
+				<time>2017-10-09T18:56:28Z</time>
+				<extensions>
+					<speed>8.634390830993652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015445722930131" lon="-84.2127208953776">
+				<ele>958.4415192613378</ele>
+				<time>2017-10-09T18:56:29Z</time>
+				<extensions>
+					<speed>8.771021842956543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01546816280486" lon="-84.21263770848317">
+				<ele>958.1295158797875</ele>
+				<time>2017-10-09T18:56:30Z</time>
+				<extensions>
+					<speed>9.05645751953125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015494316604958" lon="-84.21255824927185">
+				<ele>958.1067513991147</ele>
+				<time>2017-10-09T18:56:31Z</time>
+				<extensions>
+					<speed>8.995819091796875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015516342717884" lon="-84.21247386922742">
+				<ele>958.2115295380354</ele>
+				<time>2017-10-09T18:56:32Z</time>
+				<extensions>
+					<speed>8.98292350769043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015534179927384" lon="-84.21238937823921">
+				<ele>958.2460322603583</ele>
+				<time>2017-10-09T18:56:33Z</time>
+				<extensions>
+					<speed>9.227323532104492</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015550892124992" lon="-84.21230170698321">
+				<ele>958.2719938112423</ele>
+				<time>2017-10-09T18:56:34Z</time>
+				<extensions>
+					<speed>9.497106552124023</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01556756173414" lon="-84.21221189582747">
+				<ele>958.484096317552</ele>
+				<time>2017-10-09T18:56:35Z</time>
+				<extensions>
+					<speed>9.675286293029785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015579682874725" lon="-84.21211775392884">
+				<ele>958.4041665820405</ele>
+				<time>2017-10-09T18:56:36Z</time>
+				<extensions>
+					<speed>9.770384788513184</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015595596093249" lon="-84.21202479578125">
+				<ele>958.3104410786182</ele>
+				<time>2017-10-09T18:56:37Z</time>
+				<extensions>
+					<speed>9.959224700927734</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015612243422247" lon="-84.21193677275011">
+				<ele>958.2674141451716</ele>
+				<time>2017-10-09T18:56:38Z</time>
+				<extensions>
+					<speed>9.394556999206543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015632227371075" lon="-84.21185715908585">
+				<ele>958.3959986530244</ele>
+				<time>2017-10-09T18:56:39Z</time>
+				<extensions>
+					<speed>8.529088020324707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015651362917557" lon="-84.21178687367333">
+				<ele>958.7208266397938</ele>
+				<time>2017-10-09T18:56:40Z</time>
+				<extensions>
+					<speed>7.50715446472168</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015665934114574" lon="-84.21172489763303">
+				<ele>959.0286365430802</ele>
+				<time>2017-10-09T18:56:41Z</time>
+				<extensions>
+					<speed>6.594235420227051</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01566971153506" lon="-84.21168600332429">
+				<ele>959.3919362584129</ele>
+				<time>2017-10-09T18:56:42Z</time>
+				<extensions>
+					<speed>4.6157331466674805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01567901618403" lon="-84.21165845793116">
+				<ele>959.8119722679257</ele>
+				<time>2017-10-09T18:56:43Z</time>
+				<extensions>
+					<speed>2.718292713165283</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015692558063293" lon="-84.2116561269951">
+				<ele>960.2171896211803</ele>
+				<time>2017-10-09T18:56:44Z</time>
+				<extensions>
+					<speed>1.2663544416427612</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015705989228202" lon="-84.2116698624659">
+				<ele>960.8438092544675</ele>
+				<time>2017-10-09T18:56:45Z</time>
+				<extensions>
+					<speed>1.3220268487930298</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015720370790975" lon="-84.21168027484983">
+				<ele>961.1781628057361</ele>
+				<time>2017-10-09T18:56:46Z</time>
+				<extensions>
+					<speed>1.418671727180481</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015730437690166" lon="-84.21168744971608">
+				<ele>961.447743140161</ele>
+				<time>2017-10-09T18:56:47Z</time>
+				<extensions>
+					<speed>1.197356939315796</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015748582441862" lon="-84.21168960176473">
+				<ele>961.3854941166937</ele>
+				<time>2017-10-09T18:56:48Z</time>
+				<extensions>
+					<speed>1.3438549041748047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015764487924656" lon="-84.2116929629667">
+				<ele>961.3702990710735</ele>
+				<time>2017-10-09T18:56:49Z</time>
+				<extensions>
+					<speed>1.3655182123184204</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01577589297937" lon="-84.2117008129231">
+				<ele>961.3106736885384</ele>
+				<time>2017-10-09T18:56:50Z</time>
+				<extensions>
+					<speed>1.2768641710281372</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015780967829837" lon="-84.21170639919015">
+				<ele>961.3079286832362</ele>
+				<time>2017-10-09T18:56:51Z</time>
+				<extensions>
+					<speed>1.0312670469284058</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015781189395055" lon="-84.21171594256265">
+				<ele>961.4184942021966</ele>
+				<time>2017-10-09T18:56:52Z</time>
+				<extensions>
+					<speed>0.7603918313980103</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015781189395055" lon="-84.21171594256265">
+				<ele>961.4184942021966</ele>
+				<time>2017-10-09T18:56:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015776629023009" lon="-84.21172951317929">
+				<ele>961.4243749845773</ele>
+				<time>2017-10-09T18:56:54Z</time>
+				<extensions>
+					<speed>0.6168919801712036</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015776629023009" lon="-84.21172951317929">
+				<ele>961.4243749845773</ele>
+				<time>2017-10-09T18:56:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015749084964721" lon="-84.21176032871077">
+				<ele>961.6799943763763</ele>
+				<time>2017-10-09T18:56:56Z</time>
+				<extensions>
+					<speed>0.7150716185569763</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015749084964721" lon="-84.21176032871077">
+				<ele>961.6799943763763</ele>
+				<time>2017-10-09T18:56:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015740650389478" lon="-84.21177682955826">
+				<ele>962.1282326467335</ele>
+				<time>2017-10-09T18:56:58Z</time>
+				<extensions>
+					<speed>0.4033844470977783</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015740650389478" lon="-84.21177682955826">
+				<ele>962.1282326467335</ele>
+				<time>2017-10-09T18:56:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735226969081" lon="-84.21178567928742">
+				<ele>963.0806244825944</ele>
+				<time>2017-10-09T18:57:00Z</time>
+				<extensions>
+					<speed>0.292473167181015</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735226969081" lon="-84.21178567928742">
+				<ele>963.0806244825944</ele>
+				<time>2017-10-09T18:57:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735226969081" lon="-84.21178567928742">
+				<ele>963.0806244825944</ele>
+				<time>2017-10-09T18:57:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735226969081" lon="-84.21178567928742">
+				<ele>963.0806244825944</ele>
+				<time>2017-10-09T18:57:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735226969081" lon="-84.21178567928742">
+				<ele>963.0806244825944</ele>
+				<time>2017-10-09T18:57:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735226969081" lon="-84.21178567928742">
+				<ele>963.0806244825944</ele>
+				<time>2017-10-09T18:57:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735226969081" lon="-84.21178567928742">
+				<ele>963.0806244825944</ele>
+				<time>2017-10-09T18:57:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735226969081" lon="-84.21178567928742">
+				<ele>963.0806244825944</ele>
+				<time>2017-10-09T18:57:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735226969081" lon="-84.21178567928742">
+				<ele>963.0806244825944</ele>
+				<time>2017-10-09T18:57:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735226969081" lon="-84.21178567928742">
+				<ele>963.0806244825944</ele>
+				<time>2017-10-09T18:57:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735226969081" lon="-84.21178567928742">
+				<ele>963.0806244825944</ele>
+				<time>2017-10-09T18:57:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735226969081" lon="-84.21178567928742">
+				<ele>963.0806244825944</ele>
+				<time>2017-10-09T18:57:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735226969081" lon="-84.21178567928742">
+				<ele>963.0806244825944</ele>
+				<time>2017-10-09T18:57:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735226969081" lon="-84.21178567928742">
+				<ele>963.0806244825944</ele>
+				<time>2017-10-09T18:57:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735226969081" lon="-84.21178567928742">
+				<ele>963.0806244825944</ele>
+				<time>2017-10-09T18:57:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735226969081" lon="-84.21178567928742">
+				<ele>963.0806244825944</ele>
+				<time>2017-10-09T18:57:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735226969081" lon="-84.21178567928742">
+				<ele>963.0806244825944</ele>
+				<time>2017-10-09T18:57:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735226969081" lon="-84.21178567928742">
+				<ele>963.0806244825944</ele>
+				<time>2017-10-09T18:57:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735226969081" lon="-84.21178567928742">
+				<ele>963.0806244825944</ele>
+				<time>2017-10-09T18:57:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0157376954172" lon="-84.211780161792">
+				<ele>963.2172140004113</ele>
+				<time>2017-10-09T18:57:19Z</time>
+				<extensions>
+					<speed>0.9265466332435608</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01574039968533" lon="-84.21176706722429">
+				<ele>963.1296150740236</ele>
+				<time>2017-10-09T18:57:20Z</time>
+				<extensions>
+					<speed>1.4949822425842285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015739447619477" lon="-84.21174748680762">
+				<ele>963.1665389612317</ele>
+				<time>2017-10-09T18:57:21Z</time>
+				<extensions>
+					<speed>2.0129058361053467</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015738804627452" lon="-84.21171750969302">
+				<ele>963.2713464125991</ele>
+				<time>2017-10-09T18:57:22Z</time>
+				<extensions>
+					<speed>2.9919815063476563</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015748628264681" lon="-84.21168546802596">
+				<ele>963.4248618585989</ele>
+				<time>2017-10-09T18:57:23Z</time>
+				<extensions>
+					<speed>3.5684263706207275</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015754900726467" lon="-84.21164942540067">
+				<ele>963.4518738174811</ele>
+				<time>2017-10-09T18:57:24Z</time>
+				<extensions>
+					<speed>3.8357341289520264</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015762914243687" lon="-84.21160694236127">
+				<ele>963.4733741963282</ele>
+				<time>2017-10-09T18:57:25Z</time>
+				<extensions>
+					<speed>4.372708797454834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01576724333198" lon="-84.2115595772995">
+				<ele>963.4922657283023</ele>
+				<time>2017-10-09T18:57:26Z</time>
+				<extensions>
+					<speed>4.510341644287109</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015772567129767" lon="-84.21151544478847">
+				<ele>963.4286894863471</ele>
+				<time>2017-10-09T18:57:27Z</time>
+				<extensions>
+					<speed>4.222661972045898</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01577942115701" lon="-84.21148271549895">
+				<ele>963.3114100443199</ele>
+				<time>2017-10-09T18:57:28Z</time>
+				<extensions>
+					<speed>3.2739346027374268</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015783750830899" lon="-84.21146375693489">
+				<ele>963.1799074811861</ele>
+				<time>2017-10-09T18:57:29Z</time>
+				<extensions>
+					<speed>1.8060368299484253</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015784883595504" lon="-84.21145552762613">
+				<ele>963.1791038867086</ele>
+				<time>2017-10-09T18:57:30Z</time>
+				<extensions>
+					<speed>0.7220470309257507</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015782224422145" lon="-84.21145829391611">
+				<ele>963.4530746275559</ele>
+				<time>2017-10-09T18:57:31Z</time>
+				<extensions>
+					<speed>0.43991905450820923</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015782224422145" lon="-84.21145829391611">
+				<ele>963.4530746275559</ele>
+				<time>2017-10-09T18:57:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015778392636674" lon="-84.21146743528263">
+				<ele>963.8186466330662</ele>
+				<time>2017-10-09T18:57:33Z</time>
+				<extensions>
+					<speed>0.5073257684707642</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015778392636674" lon="-84.21146743528263">
+				<ele>963.8186466330662</ele>
+				<time>2017-10-09T18:57:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01577158629317" lon="-84.21146435408788">
+				<ele>964.5289146862924</ele>
+				<time>2017-10-09T18:57:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01577158629317" lon="-84.21146435408788">
+				<ele>964.5289146862924</ele>
+				<time>2017-10-09T18:57:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01577158629317" lon="-84.21146435408788">
+				<ele>964.5289146862924</ele>
+				<time>2017-10-09T18:57:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01577158629317" lon="-84.21146435408788">
+				<ele>964.5289146862924</ele>
+				<time>2017-10-09T18:57:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015767493930989" lon="-84.21146416464599">
+				<ele>964.9817205499858</ele>
+				<time>2017-10-09T18:57:39Z</time>
+				<extensions>
+					<speed>0.7581167817115784</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01577158629317" lon="-84.21146435408788">
+				<ele>964.5289146862924</ele>
+				<time>2017-10-09T18:57:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015777706319476" lon="-84.21145898743816">
+				<ele>965.03808489535</ele>
+				<time>2017-10-09T18:57:41Z</time>
+				<extensions>
+					<speed>1.371301531791687</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015776982043233" lon="-84.21144813553215">
+				<ele>965.1822776887566</ele>
+				<time>2017-10-09T18:57:42Z</time>
+				<extensions>
+					<speed>1.23152494430542</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015771446371444" lon="-84.21143848507212">
+				<ele>965.4114882228896</ele>
+				<time>2017-10-09T18:57:43Z</time>
+				<extensions>
+					<speed>0.9774352312088013</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015771446371444" lon="-84.21143848507212">
+				<ele>965.4114882228896</ele>
+				<time>2017-10-09T18:57:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015775204734535" lon="-84.21144097058897">
+				<ele>965.6460015056655</ele>
+				<time>2017-10-09T18:57:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015775204734535" lon="-84.21144097058897">
+				<ele>965.6460015056655</ele>
+				<time>2017-10-09T18:57:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015775204734535" lon="-84.21144097058897">
+				<ele>965.6460015056655</ele>
+				<time>2017-10-09T18:57:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015771870555366" lon="-84.21143437030577">
+				<ele>965.5711247269064</ele>
+				<time>2017-10-09T18:57:48Z</time>
+				<extensions>
+					<speed>1.1357817649841309</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015776043942193" lon="-84.21143535709612">
+				<ele>964.1952077206224</ele>
+				<time>2017-10-09T18:57:49Z</time>
+				<extensions>
+					<speed>1.5929763317108154</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015770371615352" lon="-84.21142925710188">
+				<ele>963.5298606073484</ele>
+				<time>2017-10-09T18:57:50Z</time>
+				<extensions>
+					<speed>1.721887469291687</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015748871564416" lon="-84.21141808556094">
+				<ele>963.6943632550538</ele>
+				<time>2017-10-09T18:57:51Z</time>
+				<extensions>
+					<speed>1.9724527597427368</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015722642941483" lon="-84.21140748533223">
+				<ele>963.8153888471425</ele>
+				<time>2017-10-09T18:57:52Z</time>
+				<extensions>
+					<speed>3.1656222343444824</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015690597914586" lon="-84.2113951989858">
+				<ele>964.0186385447159</ele>
+				<time>2017-10-09T18:57:53Z</time>
+				<extensions>
+					<speed>4.392277240753174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01564937664793" lon="-84.2113832973041">
+				<ele>963.5691287117079</ele>
+				<time>2017-10-09T18:57:54Z</time>
+				<extensions>
+					<speed>5.831286907196045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015592476030545" lon="-84.21137387585115">
+				<ele>963.5547075029463</ele>
+				<time>2017-10-09T18:57:55Z</time>
+				<extensions>
+					<speed>6.955832481384277</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015527229189267" lon="-84.21136659288113">
+				<ele>963.7179395183921</ele>
+				<time>2017-10-09T18:57:56Z</time>
+				<extensions>
+					<speed>7.178046226501465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015465237767032" lon="-84.21135364483101">
+				<ele>963.5733751282096</ele>
+				<time>2017-10-09T18:57:57Z</time>
+				<extensions>
+					<speed>7.004744052886963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015410526627265" lon="-84.21133659088707">
+				<ele>962.7034566970542</ele>
+				<time>2017-10-09T18:57:58Z</time>
+				<extensions>
+					<speed>6.54879093170166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015358236723612" lon="-84.2113186888051">
+				<ele>962.0929517662153</ele>
+				<time>2017-10-09T18:57:59Z</time>
+				<extensions>
+					<speed>6.275374889373779</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01530464243704" lon="-84.2113015496845">
+				<ele>962.6135101616383</ele>
+				<time>2017-10-09T18:58:00Z</time>
+				<extensions>
+					<speed>6.13501501083374</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01524947145712" lon="-84.21128066623123">
+				<ele>962.7341046892107</ele>
+				<time>2017-10-09T18:58:01Z</time>
+				<extensions>
+					<speed>6.743499755859375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015189411174681" lon="-84.21125298562707">
+				<ele>962.7999789193273</ele>
+				<time>2017-10-09T18:58:02Z</time>
+				<extensions>
+					<speed>7.5939226150512695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015123632291756" lon="-84.21122403689361">
+				<ele>961.4054553350434</ele>
+				<time>2017-10-09T18:58:03Z</time>
+				<extensions>
+					<speed>8.900434494018555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015043576228765" lon="-84.21119762109782">
+				<ele>960.7802903084084</ele>
+				<time>2017-10-09T18:58:04Z</time>
+				<extensions>
+					<speed>9.783289909362793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014955375510105" lon="-84.21117124615766">
+				<ele>960.4682164685801</ele>
+				<time>2017-10-09T18:58:05Z</time>
+				<extensions>
+					<speed>10.385407447814941</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014877207133264" lon="-84.21113354352728">
+				<ele>957.6679318230599</ele>
+				<time>2017-10-09T18:58:06Z</time>
+				<extensions>
+					<speed>10.397161483764648</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014792047648191" lon="-84.21109075692615">
+				<ele>957.9845590628684</ele>
+				<time>2017-10-09T18:58:07Z</time>
+				<extensions>
+					<speed>9.430219650268555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713079619838" lon="-84.21106396033537">
+				<ele>958.0558930300176</ele>
+				<time>2017-10-09T18:58:08Z</time>
+				<extensions>
+					<speed>9.053362846374512</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014634399280869" lon="-84.21103888366304">
+				<ele>958.3579478180036</ele>
+				<time>2017-10-09T18:58:09Z</time>
+				<extensions>
+					<speed>8.818610191345215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014555007663734" lon="-84.21101365625393">
+				<ele>958.9362068781629</ele>
+				<time>2017-10-09T18:58:10Z</time>
+				<extensions>
+					<speed>8.970458984375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014469732650461" lon="-84.2109806573075">
+				<ele>960.633271323517</ele>
+				<time>2017-10-09T18:58:11Z</time>
+				<extensions>
+					<speed>9.370318412780762</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014385550104317" lon="-84.21094648310151">
+				<ele>961.2086362764239</ele>
+				<time>2017-10-09T18:58:12Z</time>
+				<extensions>
+					<speed>9.829018592834473</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430166082822" lon="-84.21091137981034">
+				<ele>961.6187735274434</ele>
+				<time>2017-10-09T18:58:13Z</time>
+				<extensions>
+					<speed>10.092901229858398</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01421590834754" lon="-84.21087793833537">
+				<ele>962.472693188116</ele>
+				<time>2017-10-09T18:58:14Z</time>
+				<extensions>
+					<speed>9.965145111083984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014136363279379" lon="-84.21084069695551">
+				<ele>962.4868343565613</ele>
+				<time>2017-10-09T18:58:15Z</time>
+				<extensions>
+					<speed>9.57460880279541</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014064914130229" lon="-84.21080267439507">
+				<ele>961.9137791898102</ele>
+				<time>2017-10-09T18:58:16Z</time>
+				<extensions>
+					<speed>9.051462173461914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013994966235114" lon="-84.21075924147797">
+				<ele>961.4621434053406</ele>
+				<time>2017-10-09T18:58:17Z</time>
+				<extensions>
+					<speed>9.064846992492676</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013927948543724" lon="-84.2107228683846">
+				<ele>960.8632382275537</ele>
+				<time>2017-10-09T18:58:18Z</time>
+				<extensions>
+					<speed>8.664024353027344</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013863759867487" lon="-84.21068812884259">
+				<ele>960.1301630558446</ele>
+				<time>2017-10-09T18:58:19Z</time>
+				<extensions>
+					<speed>8.362756729125977</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01380235948605" lon="-84.2106557685387">
+				<ele>959.4833771716803</ele>
+				<time>2017-10-09T18:58:20Z</time>
+				<extensions>
+					<speed>8.122794151306152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013743525669678" lon="-84.21062456815056">
+				<ele>958.7591024655849</ele>
+				<time>2017-10-09T18:58:21Z</time>
+				<extensions>
+					<speed>7.616504669189453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013693563680455" lon="-84.21059737222421">
+				<ele>958.2851867051795</ele>
+				<time>2017-10-09T18:58:22Z</time>
+				<extensions>
+					<speed>6.214512348175049</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013656068700149" lon="-84.21057174188147">
+				<ele>957.1309855207801</ele>
+				<time>2017-10-09T18:58:23Z</time>
+				<extensions>
+					<speed>4.307913303375244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013629214833207" lon="-84.21055749132654">
+				<ele>956.9113788632676</ele>
+				<time>2017-10-09T18:58:24Z</time>
+				<extensions>
+					<speed>2.67506742477417</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013615812882328" lon="-84.21054950845061">
+				<ele>956.5704440344125</ele>
+				<time>2017-10-09T18:58:25Z</time>
+				<extensions>
+					<speed>1.374796986579895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013609893337762" lon="-84.21054593653861">
+				<ele>956.1557928677648</ele>
+				<time>2017-10-09T18:58:26Z</time>
+				<extensions>
+					<speed>0.6207098364830017</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013609893337762" lon="-84.21054593653861">
+				<ele>956.1557928677648</ele>
+				<time>2017-10-09T18:58:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013612930342495" lon="-84.21055121334443">
+				<ele>954.8699532449245</ele>
+				<time>2017-10-09T18:58:28Z</time>
+				<extensions>
+					<speed>0.6400531530380249</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013612930342495" lon="-84.21055121334443">
+				<ele>954.8699532449245</ele>
+				<time>2017-10-09T18:58:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013603917440195" lon="-84.2105580567377">
+				<ele>954.5618899771944</ele>
+				<time>2017-10-09T18:58:30Z</time>
+				<extensions>
+					<speed>1.2927595376968384</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013591345358746" lon="-84.2105609284904">
+				<ele>954.3426539292559</ele>
+				<time>2017-10-09T18:58:31Z</time>
+				<extensions>
+					<speed>1.4881510734558105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0135789979521" lon="-84.21055879348397">
+				<ele>954.4979589106515</ele>
+				<time>2017-10-09T18:58:32Z</time>
+				<extensions>
+					<speed>1.4252269268035889</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013568665649478" lon="-84.21055497333548">
+				<ele>954.4163444740698</ele>
+				<time>2017-10-09T18:58:33Z</time>
+				<extensions>
+					<speed>1.4267847537994385</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013558835907286" lon="-84.21055124304732">
+				<ele>954.2659010440111</ele>
+				<time>2017-10-09T18:58:34Z</time>
+				<extensions>
+					<speed>1.2331273555755615</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013550401630564" lon="-84.21055027447738">
+				<ele>954.1513066962361</ele>
+				<time>2017-10-09T18:58:35Z</time>
+				<extensions>
+					<speed>1.0570939779281616</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013542353198881" lon="-84.21054723052889">
+				<ele>953.8182418420911</ele>
+				<time>2017-10-09T18:58:36Z</time>
+				<extensions>
+					<speed>1.1557022333145142</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013530832984623" lon="-84.2105392557276">
+				<ele>953.5249695405364</ele>
+				<time>2017-10-09T18:58:37Z</time>
+				<extensions>
+					<speed>1.1874921321868896</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013518841670551" lon="-84.21053026231887">
+				<ele>953.2969430489466</ele>
+				<time>2017-10-09T18:58:38Z</time>
+				<extensions>
+					<speed>1.1425341367721558</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01350695124064" lon="-84.21052129150335">
+				<ele>953.4132970068604</ele>
+				<time>2017-10-09T18:58:39Z</time>
+				<extensions>
+					<speed>0.7222315669059753</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01350695124064" lon="-84.21052129150335">
+				<ele>953.4132970068604</ele>
+				<time>2017-10-09T18:58:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013504106943529" lon="-84.21051224833917">
+				<ele>953.7031681099907</ele>
+				<time>2017-10-09T18:58:41Z</time>
+				<extensions>
+					<speed>0.043859295547008514</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013504106943529" lon="-84.21051224833917">
+				<ele>953.7031681099907</ele>
+				<time>2017-10-09T18:58:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013504106943529" lon="-84.21051224833917">
+				<ele>953.7031681099907</ele>
+				<time>2017-10-09T18:58:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013504106943529" lon="-84.21051224833917">
+				<ele>953.7031681099907</ele>
+				<time>2017-10-09T18:58:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013504106943529" lon="-84.21051224833917">
+				<ele>953.7031681099907</ele>
+				<time>2017-10-09T18:58:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013504106943529" lon="-84.21051224833917">
+				<ele>953.7031681099907</ele>
+				<time>2017-10-09T18:58:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013504106943529" lon="-84.21051224833917">
+				<ele>953.7031681099907</ele>
+				<time>2017-10-09T18:58:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013501847088614" lon="-84.21050976429689">
+				<ele>953.2109516197816</ele>
+				<time>2017-10-09T18:58:48Z</time>
+				<extensions>
+					<speed>0.7618699669837952</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013495253815117" lon="-84.21050306106693">
+				<ele>952.4051139261574</ele>
+				<time>2017-10-09T18:58:49Z</time>
+				<extensions>
+					<speed>1.4909499883651733</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013481537387594" lon="-84.21049169242346">
+				<ele>951.7855727411807</ele>
+				<time>2017-10-09T18:58:50Z</time>
+				<extensions>
+					<speed>2.4993512630462646</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013456462752126" lon="-84.21047874990221">
+				<ele>951.5586912026629</ele>
+				<time>2017-10-09T18:58:51Z</time>
+				<extensions>
+					<speed>3.3746726512908936</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013424508389965" lon="-84.2104635340186">
+				<ele>951.2412120150402</ele>
+				<time>2017-10-09T18:58:52Z</time>
+				<extensions>
+					<speed>4.043332099914551</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013387811789952" lon="-84.2104480596575">
+				<ele>951.1127754775807</ele>
+				<time>2017-10-09T18:58:53Z</time>
+				<extensions>
+					<speed>4.572831153869629</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013346000119423" lon="-84.21043172741639">
+				<ele>950.5497700897977</ele>
+				<time>2017-10-09T18:58:54Z</time>
+				<extensions>
+					<speed>5.3188629150390625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013295978903638" lon="-84.21041130625095">
+				<ele>950.3268347987905</ele>
+				<time>2017-10-09T18:58:55Z</time>
+				<extensions>
+					<speed>6.001227378845215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013243431977164" lon="-84.2103913910673">
+				<ele>949.8680910132825</ele>
+				<time>2017-10-09T18:58:56Z</time>
+				<extensions>
+					<speed>6.239727020263672</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013186885052665" lon="-84.21037080349247">
+				<ele>949.5615461375564</ele>
+				<time>2017-10-09T18:58:57Z</time>
+				<extensions>
+					<speed>6.952110290527344</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013125903704386" lon="-84.21035036814317">
+				<ele>949.4306311542168</ele>
+				<time>2017-10-09T18:58:58Z</time>
+				<extensions>
+					<speed>7.305351257324219</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013059824893089" lon="-84.21032891947095">
+				<ele>949.3794139781967</ele>
+				<time>2017-10-09T18:58:59Z</time>
+				<extensions>
+					<speed>7.94857931137085</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012992292679881" lon="-84.21030740169306">
+				<ele>949.4339555315673</ele>
+				<time>2017-10-09T18:59:00Z</time>
+				<extensions>
+					<speed>7.7357563972473145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012924076979825" lon="-84.21028475321215">
+				<ele>949.5569255286828</ele>
+				<time>2017-10-09T18:59:01Z</time>
+				<extensions>
+					<speed>7.3427653312683105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012861896609278" lon="-84.21026462252954">
+				<ele>949.5661776103079</ele>
+				<time>2017-10-09T18:59:02Z</time>
+				<extensions>
+					<speed>6.314702033996582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012811551608094" lon="-84.21024560927913">
+				<ele>949.3135113148019</ele>
+				<time>2017-10-09T18:59:03Z</time>
+				<extensions>
+					<speed>5.2028985023498535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012774854644698" lon="-84.21022929119592">
+				<ele>949.0508030261844</ele>
+				<time>2017-10-09T18:59:04Z</time>
+				<extensions>
+					<speed>3.4107820987701416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012752026159944" lon="-84.21021911675619">
+				<ele>949.2194336084649</ele>
+				<time>2017-10-09T18:59:05Z</time>
+				<extensions>
+					<speed>1.797440767288208</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012742761900865" lon="-84.21021508734145">
+				<ele>949.2640196382999</ele>
+				<time>2017-10-09T18:59:06Z</time>
+				<extensions>
+					<speed>0.4085889756679535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012745618801855" lon="-84.21021535546136">
+				<ele>949.3273695902899</ele>
+				<time>2017-10-09T18:59:07Z</time>
+				<extensions>
+					<speed>0.910923421382904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012756912540802" lon="-84.21022106920708">
+				<ele>949.2420451017097</ele>
+				<time>2017-10-09T18:59:08Z</time>
+				<extensions>
+					<speed>1.6984026432037354</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012768496293173" lon="-84.21022807745247">
+				<ele>949.30118735414</ele>
+				<time>2017-10-09T18:59:09Z</time>
+				<extensions>
+					<speed>1.574079155921936</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01277743983453" lon="-84.2102334382789">
+				<ele>949.494272865355</ele>
+				<time>2017-10-09T18:59:10Z</time>
+				<extensions>
+					<speed>1.174791693687439</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012783384181027" lon="-84.2102371168733">
+				<ele>949.5116003965959</ele>
+				<time>2017-10-09T18:59:11Z</time>
+				<extensions>
+					<speed>0.8445175886154175</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012783384181027" lon="-84.2102371168733">
+				<ele>949.5116003965959</ele>
+				<time>2017-10-09T18:59:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:13Z</time>
+				<extensions>
+					<speed>0.29458972811698914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012789559623947" lon="-84.21024589759385">
+				<ele>948.829659184441</ele>
+				<time>2017-10-09T18:59:27Z</time>
+				<extensions>
+					<speed>0.7976178526878357</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T18:59:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012786473198732" lon="-84.21023709288309">
+				<ele>949.6507995342836</ele>
+				<time>2017-10-09T19:00:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01279386416725" lon="-84.21024508556636">
+				<ele>949.6867611175403</ele>
+				<time>2017-10-09T19:00:01Z</time>
+				<extensions>
+					<speed>0.7756481766700745</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012799102609453" lon="-84.21025208887096">
+				<ele>949.8641088912264</ele>
+				<time>2017-10-09T19:00:02Z</time>
+				<extensions>
+					<speed>0.5453189015388489</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:03Z</time>
+				<extensions>
+					<speed>0.03981710225343704</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798260848369" lon="-84.21025437733617">
+				<ele>950.071956907399</ele>
+				<time>2017-10-09T19:00:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012800835298536" lon="-84.21025913523228">
+				<ele>950.041894950904</ele>
+				<time>2017-10-09T19:00:32Z</time>
+				<extensions>
+					<speed>0.8988202810287476</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012804240041545" lon="-84.21026057807195">
+				<ele>950.0219134353101</ele>
+				<time>2017-10-09T19:00:33Z</time>
+				<extensions>
+					<speed>0.3509206175804138</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012805063876742" lon="-84.21025643125182">
+				<ele>949.8941893605515</ele>
+				<time>2017-10-09T19:00:34Z</time>
+				<extensions>
+					<speed>0.4331643581390381</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012805063876742" lon="-84.21025643125182">
+				<ele>949.8941893605515</ele>
+				<time>2017-10-09T19:00:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012807259610858" lon="-84.21025348774565">
+				<ele>949.8778892764822</ele>
+				<time>2017-10-09T19:00:36Z</time>
+				<extensions>
+					<speed>0.12145861983299255</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012807259610858" lon="-84.21025348774565">
+				<ele>949.8778892764822</ele>
+				<time>2017-10-09T19:00:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012807259610858" lon="-84.21025348774565">
+				<ele>949.8778892764822</ele>
+				<time>2017-10-09T19:00:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012807259610858" lon="-84.21025348774565">
+				<ele>949.8778892764822</ele>
+				<time>2017-10-09T19:00:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012802008661419" lon="-84.21025413947095">
+				<ele>950.0950983660296</ele>
+				<time>2017-10-09T19:00:40Z</time>
+				<extensions>
+					<speed>0.8342496156692505</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012797272053806" lon="-84.21025202297187">
+				<ele>950.2888537123799</ele>
+				<time>2017-10-09T19:00:41Z</time>
+				<extensions>
+					<speed>0.5944847464561462</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012797159429383" lon="-84.21024681003345">
+				<ele>950.5159353520721</ele>
+				<time>2017-10-09T19:00:42Z</time>
+				<extensions>
+					<speed>0.34749841690063477</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012797159429383" lon="-84.21024681003345">
+				<ele>950.5159353520721</ele>
+				<time>2017-10-09T19:00:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012797159429383" lon="-84.21024681003345">
+				<ele>950.5159353520721</ele>
+				<time>2017-10-09T19:00:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012797159429383" lon="-84.21024681003345">
+				<ele>950.5159353520721</ele>
+				<time>2017-10-09T19:00:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012797159429383" lon="-84.21024681003345">
+				<ele>950.5159353520721</ele>
+				<time>2017-10-09T19:00:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012797159429383" lon="-84.21024681003345">
+				<ele>950.5159353520721</ele>
+				<time>2017-10-09T19:00:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012797159429383" lon="-84.21024681003345">
+				<ele>950.5159353520721</ele>
+				<time>2017-10-09T19:00:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012797159429383" lon="-84.21024681003345">
+				<ele>950.5159353520721</ele>
+				<time>2017-10-09T19:00:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012797159429383" lon="-84.21024681003345">
+				<ele>950.5159353520721</ele>
+				<time>2017-10-09T19:00:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01279945200707" lon="-84.21025376157098">
+				<ele>950.6281533483416</ele>
+				<time>2017-10-09T19:00:51Z</time>
+				<extensions>
+					<speed>0.9312241673469543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012798016304087" lon="-84.21026341699205">
+				<ele>950.5944391628727</ele>
+				<time>2017-10-09T19:00:52Z</time>
+				<extensions>
+					<speed>1.2313252687454224</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012792311580512" lon="-84.21026713970345">
+				<ele>950.3746023559943</ele>
+				<time>2017-10-09T19:00:53Z</time>
+				<extensions>
+					<speed>0.9415909051895142</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012778146079782" lon="-84.210268288357">
+				<ele>950.4100760845467</ele>
+				<time>2017-10-09T19:00:54Z</time>
+				<extensions>
+					<speed>1.811030626296997</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012761660378755" lon="-84.21027212438867">
+				<ele>950.3931265445426</ele>
+				<time>2017-10-09T19:00:55Z</time>
+				<extensions>
+					<speed>2.1059646606445313</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012744135910838" lon="-84.2102817777654">
+				<ele>950.5462135076523</ele>
+				<time>2017-10-09T19:00:56Z</time>
+				<extensions>
+					<speed>2.603429079055786</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012722960313914" lon="-84.21029124317526">
+				<ele>950.6401785686612</ele>
+				<time>2017-10-09T19:00:57Z</time>
+				<extensions>
+					<speed>2.9627387523651123</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012701870632617" lon="-84.21030486156617">
+				<ele>950.8068853551522</ele>
+				<time>2017-10-09T19:00:58Z</time>
+				<extensions>
+					<speed>3.041846513748169</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012684598674422" lon="-84.21032308577205">
+				<ele>951.0330606168136</ele>
+				<time>2017-10-09T19:00:59Z</time>
+				<extensions>
+					<speed>2.905636787414551</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012663511482993" lon="-84.2103449643735">
+				<ele>951.1393497847021</ele>
+				<time>2017-10-09T19:01:00Z</time>
+				<extensions>
+					<speed>3.77620005607605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012639718818122" lon="-84.21037723276618">
+				<ele>951.132884176448</ele>
+				<time>2017-10-09T19:01:01Z</time>
+				<extensions>
+					<speed>4.9373931884765625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01261993127058" lon="-84.21043227475305">
+				<ele>951.3089548507705</ele>
+				<time>2017-10-09T19:01:02Z</time>
+				<extensions>
+					<speed>7.585123538970947</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01260142643586" lon="-84.21049510201384">
+				<ele>952.2666154606268</ele>
+				<time>2017-10-09T19:01:03Z</time>
+				<extensions>
+					<speed>9.226025581359863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012581378033179" lon="-84.21058091270031">
+				<ele>953.2957442542538</ele>
+				<time>2017-10-09T19:01:04Z</time>
+				<extensions>
+					<speed>11.157780647277832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012562237470718" lon="-84.21067663990672">
+				<ele>954.2235008999705</ele>
+				<time>2017-10-09T19:01:05Z</time>
+				<extensions>
+					<speed>11.843838691711426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01254005977718" lon="-84.21078448395895">
+				<ele>954.4936456112191</ele>
+				<time>2017-10-09T19:01:06Z</time>
+				<extensions>
+					<speed>12.501805305480957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012518343440847" lon="-84.21090320168236">
+				<ele>954.0925866551697</ele>
+				<time>2017-10-09T19:01:07Z</time>
+				<extensions>
+					<speed>13.062921524047852</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012487803381788" lon="-84.21101560793369">
+				<ele>952.6268669171259</ele>
+				<time>2017-10-09T19:01:08Z</time>
+				<extensions>
+					<speed>12.972179412841797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012444433566579" lon="-84.21113634310011">
+				<ele>952.4553735051304</ele>
+				<time>2017-10-09T19:01:09Z</time>
+				<extensions>
+					<speed>13.709012985229492</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012386700917695" lon="-84.21127104767439">
+				<ele>951.2165490826592</ele>
+				<time>2017-10-09T19:01:10Z</time>
+				<extensions>
+					<speed>14.888160705566406</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012335650988431" lon="-84.21141287681404">
+				<ele>950.7811025874689</ele>
+				<time>2017-10-09T19:01:11Z</time>
+				<extensions>
+					<speed>16.347448348999023</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01227797398951" lon="-84.21155810810453">
+				<ele>949.7044931342825</ele>
+				<time>2017-10-09T19:01:12Z</time>
+				<extensions>
+					<speed>15.92010498046875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012230029755825" lon="-84.21170360450266">
+				<ele>949.2285089045763</ele>
+				<time>2017-10-09T19:01:13Z</time>
+				<extensions>
+					<speed>16.12989044189453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012183108312353" lon="-84.21184259443068">
+				<ele>948.8426674166694</ele>
+				<time>2017-10-09T19:01:14Z</time>
+				<extensions>
+					<speed>15.33892822265625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012141102534194" lon="-84.21197350299332">
+				<ele>949.0510816881433</ele>
+				<time>2017-10-09T19:01:15Z</time>
+				<extensions>
+					<speed>14.972249031066895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012100802746199" lon="-84.21209301746396">
+				<ele>949.4712671348825</ele>
+				<time>2017-10-09T19:01:16Z</time>
+				<extensions>
+					<speed>13.790778160095215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01206290320963" lon="-84.21219812511511">
+				<ele>949.5932290311903</ele>
+				<time>2017-10-09T19:01:17Z</time>
+				<extensions>
+					<speed>11.806854248046875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012027254084186" lon="-84.2122870535235">
+				<ele>949.5842509046197</ele>
+				<time>2017-10-09T19:01:18Z</time>
+				<extensions>
+					<speed>10.484515190124512</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011994675827147" lon="-84.21236904869356">
+				<ele>949.4689602199942</ele>
+				<time>2017-10-09T19:01:19Z</time>
+				<extensions>
+					<speed>9.916661262512207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011964703760306" lon="-84.21244390998588">
+				<ele>949.0823366967961</ele>
+				<time>2017-10-09T19:01:20Z</time>
+				<extensions>
+					<speed>9.111289978027344</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011936776429286" lon="-84.21251395875882">
+				<ele>948.8995291972533</ele>
+				<time>2017-10-09T19:01:21Z</time>
+				<extensions>
+					<speed>8.220362663269043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01191395907936" lon="-84.2125711464014">
+				<ele>948.8373101996258</ele>
+				<time>2017-10-09T19:01:22Z</time>
+				<extensions>
+					<speed>6.791430473327637</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011897083087206" lon="-84.21262151504095">
+				<ele>948.8001015456393</ele>
+				<time>2017-10-09T19:01:23Z</time>
+				<extensions>
+					<speed>5.88829231262207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011883730001994" lon="-84.2126615509332">
+				<ele>949.3523594662547</ele>
+				<time>2017-10-09T19:01:24Z</time>
+				<extensions>
+					<speed>4.585494518280029</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011875665669663" lon="-84.21269472706044">
+				<ele>949.4496929366142</ele>
+				<time>2017-10-09T19:01:25Z</time>
+				<extensions>
+					<speed>3.5448336601257324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011874799044321" lon="-84.2127131377389">
+				<ele>949.4815254174173</ele>
+				<time>2017-10-09T19:01:26Z</time>
+				<extensions>
+					<speed>2.022552967071533</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011876069129743" lon="-84.21271772927719">
+				<ele>949.7358161266893</ele>
+				<time>2017-10-09T19:01:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011879705766594" lon="-84.21271356873442">
+				<ele>949.7488449700177</ele>
+				<time>2017-10-09T19:01:28Z</time>
+				<extensions>
+					<speed>0.6144153475761414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011879705766594" lon="-84.21271356873442">
+				<ele>949.7488449700177</ele>
+				<time>2017-10-09T19:01:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011885999043095" lon="-84.21270041851652">
+				<ele>949.6932847052813</ele>
+				<time>2017-10-09T19:01:30Z</time>
+				<extensions>
+					<speed>0.9800902605056763</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011893354862288" lon="-84.21268702881295">
+				<ele>949.7224366702139</ele>
+				<time>2017-10-09T19:01:31Z</time>
+				<extensions>
+					<speed>1.1412343978881836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011899048112996" lon="-84.21267320938848">
+				<ele>949.5994319338351</ele>
+				<time>2017-10-09T19:01:32Z</time>
+				<extensions>
+					<speed>1.2416858673095703</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011905812237243" lon="-84.21266513632175">
+				<ele>949.5114502757788</ele>
+				<time>2017-10-09T19:01:33Z</time>
+				<extensions>
+					<speed>1.1574676036834717</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011909144288023" lon="-84.21266144091389">
+				<ele>949.229190852493</ele>
+				<time>2017-10-09T19:01:34Z</time>
+				<extensions>
+					<speed>0.9635416269302368</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011909144288023" lon="-84.21266144091389">
+				<ele>949.229190852493</ele>
+				<time>2017-10-09T19:01:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011908429120087" lon="-84.21265927592454">
+				<ele>948.8299267347902</ele>
+				<time>2017-10-09T19:01:36Z</time>
+				<extensions>
+					<speed>0.451973557472229</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011908429120087" lon="-84.21265927592454">
+				<ele>948.8299267347902</ele>
+				<time>2017-10-09T19:01:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011908717166744" lon="-84.21265522076249">
+				<ele>948.4137690309435</ele>
+				<time>2017-10-09T19:01:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011908717166744" lon="-84.21265522076249">
+				<ele>948.4137690309435</ele>
+				<time>2017-10-09T19:01:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011908717166744" lon="-84.21265522076249">
+				<ele>948.4137690309435</ele>
+				<time>2017-10-09T19:01:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011908717166744" lon="-84.21265522076249">
+				<ele>948.4137690309435</ele>
+				<time>2017-10-09T19:01:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011908717166744" lon="-84.21265522076249">
+				<ele>948.4137690309435</ele>
+				<time>2017-10-09T19:01:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011908717166744" lon="-84.21265522076249">
+				<ele>948.4137690309435</ele>
+				<time>2017-10-09T19:01:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011908717166744" lon="-84.21265522076249">
+				<ele>948.4137690309435</ele>
+				<time>2017-10-09T19:01:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011908717166744" lon="-84.21265522076249">
+				<ele>948.4137690309435</ele>
+				<time>2017-10-09T19:01:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011908717166744" lon="-84.21265522076249">
+				<ele>948.4137690309435</ele>
+				<time>2017-10-09T19:01:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011908717166744" lon="-84.21265522076249">
+				<ele>948.4137690309435</ele>
+				<time>2017-10-09T19:01:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011906300131795" lon="-84.21268476420981">
+				<ele>948.1472311960533</ele>
+				<time>2017-10-09T19:01:48Z</time>
+				<extensions>
+					<speed>0.9592152833938599</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01190784476716" lon="-84.21269038460939">
+				<ele>947.9528465876356</ele>
+				<time>2017-10-09T19:01:49Z</time>
+				<extensions>
+					<speed>1.0983161926269531</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01190473525041" lon="-84.21269701091225">
+				<ele>947.5448936512694</ele>
+				<time>2017-10-09T19:01:50Z</time>
+				<extensions>
+					<speed>1.577573537826538</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01190247895386" lon="-84.21271337129572">
+				<ele>947.1995085468516</ele>
+				<time>2017-10-09T19:01:51Z</time>
+				<extensions>
+					<speed>2.1665337085723877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01190349916176" lon="-84.21274980677987">
+				<ele>947.083971963264</ele>
+				<time>2017-10-09T19:01:52Z</time>
+				<extensions>
+					<speed>2.9152090549468994</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011899173771669" lon="-84.21278959550841">
+				<ele>947.0393679393455</ele>
+				<time>2017-10-09T19:01:53Z</time>
+				<extensions>
+					<speed>3.4899981021881104</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01188660542892" lon="-84.21283449036274">
+				<ele>947.0839186850935</ele>
+				<time>2017-10-09T19:01:54Z</time>
+				<extensions>
+					<speed>4.41000509262085</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011873590601166" lon="-84.21287820538284">
+				<ele>947.2152872122824</ele>
+				<time>2017-10-09T19:01:55Z</time>
+				<extensions>
+					<speed>4.87701416015625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011865606498484" lon="-84.21294677187304">
+				<ele>947.2710481593385</ele>
+				<time>2017-10-09T19:01:56Z</time>
+				<extensions>
+					<speed>6.127505779266357</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011850889250814" lon="-84.21300495740084">
+				<ele>947.4328530495986</ele>
+				<time>2017-10-09T19:01:57Z</time>
+				<extensions>
+					<speed>6.356498718261719</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011834676635646" lon="-84.21305934722828">
+				<ele>947.5712042665109</ele>
+				<time>2017-10-09T19:01:58Z</time>
+				<extensions>
+					<speed>5.6717915534973145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011820656730462" lon="-84.2131099583878">
+				<ele>947.6693168347701</ele>
+				<time>2017-10-09T19:01:59Z</time>
+				<extensions>
+					<speed>4.988164901733398</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011805664078933" lon="-84.21315309400576">
+				<ele>947.6826098477468</ele>
+				<time>2017-10-09T19:02:00Z</time>
+				<extensions>
+					<speed>4.844760417938232</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01179270134194" lon="-84.21319618489339">
+				<ele>947.5446154205129</ele>
+				<time>2017-10-09T19:02:01Z</time>
+				<extensions>
+					<speed>4.698434829711914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011787757218954" lon="-84.21322487029866">
+				<ele>947.4704283736646</ele>
+				<time>2017-10-09T19:02:02Z</time>
+				<extensions>
+					<speed>3.5917248725891113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011782851288649" lon="-84.21325092956914">
+				<ele>947.5355537775904</ele>
+				<time>2017-10-09T19:02:03Z</time>
+				<extensions>
+					<speed>2.680863857269287</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011772230280265" lon="-84.21326983384489">
+				<ele>948.0013947756961</ele>
+				<time>2017-10-09T19:02:04Z</time>
+				<extensions>
+					<speed>2.6312406063079834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011747000280735" lon="-84.21326332205285">
+				<ele>948.2851018840447</ele>
+				<time>2017-10-09T19:02:05Z</time>
+				<extensions>
+					<speed>1.8157552480697632</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011740496833273" lon="-84.21326399970621">
+				<ele>948.6757874349132</ele>
+				<time>2017-10-09T19:02:06Z</time>
+				<extensions>
+					<speed>1.280344843864441</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011741446507594" lon="-84.21326407855764">
+				<ele>949.2664826400578</ele>
+				<time>2017-10-09T19:02:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011741446507594" lon="-84.21326407855764">
+				<ele>949.2664826400578</ele>
+				<time>2017-10-09T19:02:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01173879569163" lon="-84.21325459765653">
+				<ele>949.7529581217095</ele>
+				<time>2017-10-09T19:02:09Z</time>
+				<extensions>
+					<speed>0.731311559677124</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011741446507594" lon="-84.21326407855764">
+				<ele>949.2664826400578</ele>
+				<time>2017-10-09T19:02:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011741446507594" lon="-84.21326407855764">
+				<ele>949.2664826400578</ele>
+				<time>2017-10-09T19:02:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011741446507594" lon="-84.21326407855764">
+				<ele>949.2664826400578</ele>
+				<time>2017-10-09T19:02:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011741446507594" lon="-84.21326407855764">
+				<ele>949.2664826400578</ele>
+				<time>2017-10-09T19:02:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011741446507594" lon="-84.21326407855764">
+				<ele>949.2664826400578</ele>
+				<time>2017-10-09T19:02:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011741446507594" lon="-84.21326407855764">
+				<ele>949.2664826400578</ele>
+				<time>2017-10-09T19:02:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011741446507594" lon="-84.21326407855764">
+				<ele>949.2664826400578</ele>
+				<time>2017-10-09T19:02:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011741446507594" lon="-84.21326407855764">
+				<ele>949.2664826400578</ele>
+				<time>2017-10-09T19:02:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011741446507594" lon="-84.21326407855764">
+				<ele>949.2664826400578</ele>
+				<time>2017-10-09T19:02:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011741446507594" lon="-84.21326407855764">
+				<ele>949.2664826400578</ele>
+				<time>2017-10-09T19:02:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011741446507594" lon="-84.21326407855764">
+				<ele>949.2664826400578</ele>
+				<time>2017-10-09T19:02:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011741446507594" lon="-84.21326407855764">
+				<ele>949.2664826400578</ele>
+				<time>2017-10-09T19:02:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011738591859102" lon="-84.2132756215722">
+				<ele>949.2613820536062</ele>
+				<time>2017-10-09T19:02:22Z</time>
+				<extensions>
+					<speed>1.4407715797424316</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011733564167079" lon="-84.21329573059482">
+				<ele>949.047609558329</ele>
+				<time>2017-10-09T19:02:23Z</time>
+				<extensions>
+					<speed>2.5408122539520264</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01172884740852" lon="-84.21332952589474">
+				<ele>948.7029268331826</ele>
+				<time>2017-10-09T19:02:24Z</time>
+				<extensions>
+					<speed>4.2622151374816895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011723535691669" lon="-84.21336953954352">
+				<ele>948.4760898370296</ele>
+				<time>2017-10-09T19:02:25Z</time>
+				<extensions>
+					<speed>5.066000461578369</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011716116239416" lon="-84.2134143219336">
+				<ele>948.5817899471149</ele>
+				<time>2017-10-09T19:02:26Z</time>
+				<extensions>
+					<speed>5.258750915527344</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011705970748428" lon="-84.21346188074195">
+				<ele>948.8117017820477</ele>
+				<time>2017-10-09T19:02:27Z</time>
+				<extensions>
+					<speed>5.556452751159668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01169484393657" lon="-84.21351169683413">
+				<ele>948.8435206431895</ele>
+				<time>2017-10-09T19:02:28Z</time>
+				<extensions>
+					<speed>5.912836074829102</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01168323118951" lon="-84.21356127708846">
+				<ele>949.2030827300623</ele>
+				<time>2017-10-09T19:02:29Z</time>
+				<extensions>
+					<speed>5.779324054718018</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011673636006094" lon="-84.21360820892795">
+				<ele>949.5627151047811</ele>
+				<time>2017-10-09T19:02:30Z</time>
+				<extensions>
+					<speed>5.090762615203857</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011664653446694" lon="-84.21364910972139">
+				<ele>949.636108844541</ele>
+				<time>2017-10-09T19:02:31Z</time>
+				<extensions>
+					<speed>4.416156768798828</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011655268850157" lon="-84.21368244966413">
+				<ele>949.7754751276225</ele>
+				<time>2017-10-09T19:02:32Z</time>
+				<extensions>
+					<speed>3.294456720352173</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011646983493485" lon="-84.21370612049043">
+				<ele>949.9975317809731</ele>
+				<time>2017-10-09T19:02:33Z</time>
+				<extensions>
+					<speed>2.190298080444336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011638903195921" lon="-84.21372043795891">
+				<ele>950.2644097460434</ele>
+				<time>2017-10-09T19:02:34Z</time>
+				<extensions>
+					<speed>1.3692735433578491</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01163352963413" lon="-84.21371993957204">
+				<ele>950.450622426346</ele>
+				<time>2017-10-09T19:02:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01163352963413" lon="-84.21371993957204">
+				<ele>950.450622426346</ele>
+				<time>2017-10-09T19:02:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01163352963413" lon="-84.21371993957204">
+				<ele>950.450622426346</ele>
+				<time>2017-10-09T19:02:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01163352963413" lon="-84.21371993957204">
+				<ele>950.450622426346</ele>
+				<time>2017-10-09T19:02:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01163352963413" lon="-84.21371993957204">
+				<ele>950.450622426346</ele>
+				<time>2017-10-09T19:02:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01163352963413" lon="-84.21371993957204">
+				<ele>950.450622426346</ele>
+				<time>2017-10-09T19:02:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011627202611658" lon="-84.21372804254584">
+				<ele>950.0543609149754</ele>
+				<time>2017-10-09T19:02:41Z</time>
+				<extensions>
+					<speed>1.1371581554412842</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011610987022582" lon="-84.21374047381491">
+				<ele>949.6352830715477</ele>
+				<time>2017-10-09T19:02:42Z</time>
+				<extensions>
+					<speed>2.4105725288391113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011586736430608" lon="-84.21375238281426">
+				<ele>949.4704764001071</ele>
+				<time>2017-10-09T19:02:43Z</time>
+				<extensions>
+					<speed>3.188131093978882</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011548751873525" lon="-84.21375923306407">
+				<ele>949.3975340845063</ele>
+				<time>2017-10-09T19:02:44Z</time>
+				<extensions>
+					<speed>4.289953231811523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011485988789538" lon="-84.2137549939401">
+				<ele>949.0331294657663</ele>
+				<time>2017-10-09T19:02:45Z</time>
+				<extensions>
+					<speed>6.947997570037842</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011420436961647" lon="-84.21374309591152">
+				<ele>949.0849968250841</ele>
+				<time>2017-10-09T19:02:46Z</time>
+				<extensions>
+					<speed>7.553624629974365</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011350497127125" lon="-84.21372563760276">
+				<ele>949.1823357008398</ele>
+				<time>2017-10-09T19:02:47Z</time>
+				<extensions>
+					<speed>7.9087443351745605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011266140532788" lon="-84.21369785307924">
+				<ele>949.1268661823124</ele>
+				<time>2017-10-09T19:02:48Z</time>
+				<extensions>
+					<speed>9.587522506713867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01117976633972" lon="-84.21366751096008">
+				<ele>949.0184400621802</ele>
+				<time>2017-10-09T19:02:49Z</time>
+				<extensions>
+					<speed>10.410608291625977</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011088345087549" lon="-84.21363754537869">
+				<ele>948.9795131506398</ele>
+				<time>2017-10-09T19:02:50Z</time>
+				<extensions>
+					<speed>10.64958381652832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011001870685467" lon="-84.21360258957256">
+				<ele>948.5744446227327</ele>
+				<time>2017-10-09T19:02:51Z</time>
+				<extensions>
+					<speed>10.013760566711426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010924259229304" lon="-84.21357165816745">
+				<ele>948.4810879910365</ele>
+				<time>2017-10-09T19:02:52Z</time>
+				<extensions>
+					<speed>9.157280921936035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010845430386976" lon="-84.2135441750276">
+				<ele>948.5713336868212</ele>
+				<time>2017-10-09T19:02:53Z</time>
+				<extensions>
+					<speed>9.164383888244629</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010768757064186" lon="-84.21351896011875">
+				<ele>948.7810821365565</ele>
+				<time>2017-10-09T19:02:54Z</time>
+				<extensions>
+					<speed>8.788983345031738</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010694501158598" lon="-84.21349658536771">
+				<ele>949.082456914708</ele>
+				<time>2017-10-09T19:02:55Z</time>
+				<extensions>
+					<speed>8.358631134033203</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010625914686052" lon="-84.2134801963747">
+				<ele>949.1311416821554</ele>
+				<time>2017-10-09T19:02:56Z</time>
+				<extensions>
+					<speed>7.111407279968262</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010564001263262" lon="-84.21346504248767">
+				<ele>949.1510021798313</ele>
+				<time>2017-10-09T19:02:57Z</time>
+				<extensions>
+					<speed>6.300662040710449</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010510226148991" lon="-84.21345223797697">
+				<ele>949.2935585556552</ele>
+				<time>2017-10-09T19:02:58Z</time>
+				<extensions>
+					<speed>5.556481838226318</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010458541728623" lon="-84.21344259567675">
+				<ele>949.2599277282134</ele>
+				<time>2017-10-09T19:02:59Z</time>
+				<extensions>
+					<speed>5.1777825355529785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010405525647485" lon="-84.21343613154586">
+				<ele>949.2210948215798</ele>
+				<time>2017-10-09T19:03:00Z</time>
+				<extensions>
+					<speed>5.335834980010986</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010356065873928" lon="-84.21342160525845">
+				<ele>948.9885182902217</ele>
+				<time>2017-10-09T19:03:01Z</time>
+				<extensions>
+					<speed>4.982607841491699</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010316245197501" lon="-84.21339803884146">
+				<ele>948.6703204661608</ele>
+				<time>2017-10-09T19:03:02Z</time>
+				<extensions>
+					<speed>4.962836265563965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010287739707145" lon="-84.21335866673427">
+				<ele>948.488616861403</ele>
+				<time>2017-10-09T19:03:03Z</time>
+				<extensions>
+					<speed>4.678512096405029</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01026033138872" lon="-84.21331280859943">
+				<ele>947.9511488685384</ele>
+				<time>2017-10-09T19:03:04Z</time>
+				<extensions>
+					<speed>4.6532793045043945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010243155338815" lon="-84.2132885500154">
+				<ele>948.00371188391</ele>
+				<time>2017-10-09T19:03:05Z</time>
+				<extensions>
+					<speed>3.085026502609253</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010225745153802" lon="-84.21327883171222">
+				<ele>947.5148701369762</ele>
+				<time>2017-10-09T19:03:06Z</time>
+				<extensions>
+					<speed>1.4241933822631836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010204457206457" lon="-84.21327111203496">
+				<ele>947.2005586363375</ele>
+				<time>2017-10-09T19:03:07Z</time>
+				<extensions>
+					<speed>1.4210834503173828</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010184704336096" lon="-84.21328478178033">
+				<ele>947.032830754295</ele>
+				<time>2017-10-09T19:03:08Z</time>
+				<extensions>
+					<speed>1.372101068496704</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01016061392502" lon="-84.21329039765712">
+				<ele>946.823226432316</ele>
+				<time>2017-10-09T19:03:09Z</time>
+				<extensions>
+					<speed>1.9169600009918213</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010149607003545" lon="-84.21331630132117">
+				<ele>946.7235301472247</ele>
+				<time>2017-10-09T19:03:10Z</time>
+				<extensions>
+					<speed>1.801794409751892</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010140870585303" lon="-84.21333953734457">
+				<ele>946.7145980345085</ele>
+				<time>2017-10-09T19:03:11Z</time>
+				<extensions>
+					<speed>1.9077035188674927</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010135739575706" lon="-84.21335611070747">
+				<ele>946.8155409414321</ele>
+				<time>2017-10-09T19:03:12Z</time>
+				<extensions>
+					<speed>1.6830806732177734</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010131835360154" lon="-84.21337846234063">
+				<ele>946.8558309683576</ele>
+				<time>2017-10-09T19:03:13Z</time>
+				<extensions>
+					<speed>1.8854939937591553</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010129327137326" lon="-84.21341305731133">
+				<ele>946.84555065725</ele>
+				<time>2017-10-09T19:03:14Z</time>
+				<extensions>
+					<speed>2.2754485607147217</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010130520500732" lon="-84.21345135724394">
+				<ele>946.9022947270423</ele>
+				<time>2017-10-09T19:03:15Z</time>
+				<extensions>
+					<speed>2.6955530643463135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010135093692961" lon="-84.21347068741078">
+				<ele>946.9121122639626</ele>
+				<time>2017-10-09T19:03:16Z</time>
+				<extensions>
+					<speed>2.701836347579956</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010147383242925" lon="-84.21347915198943">
+				<ele>946.9831434721127</ele>
+				<time>2017-10-09T19:03:17Z</time>
+				<extensions>
+					<speed>2.6312828063964844</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010165480161115" lon="-84.21350982673505">
+				<ele>947.0604447582737</ele>
+				<time>2017-10-09T19:03:18Z</time>
+				<extensions>
+					<speed>3.058403491973877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010173324172714" lon="-84.21353652538306">
+				<ele>947.4339385898784</ele>
+				<time>2017-10-09T19:03:19Z</time>
+				<extensions>
+					<speed>2.6734554767608643</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010189437056171" lon="-84.21356537782734">
+				<ele>947.6542614074424</ele>
+				<time>2017-10-09T19:03:20Z</time>
+				<extensions>
+					<speed>2.626004457473755</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01019805013149" lon="-84.21358197806902">
+				<ele>947.7753249816597</ele>
+				<time>2017-10-09T19:03:21Z</time>
+				<extensions>
+					<speed>2.431033134460449</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010205340452849" lon="-84.21358236915988">
+				<ele>948.2297153510153</ele>
+				<time>2017-10-09T19:03:22Z</time>
+				<extensions>
+					<speed>1.4408671855926514</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010218418917919" lon="-84.21358480757111">
+				<ele>948.5479046776891</ele>
+				<time>2017-10-09T19:03:23Z</time>
+				<extensions>
+					<speed>1.2937954664230347</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010233589340027" lon="-84.2135820458136">
+				<ele>948.9180756378919</ele>
+				<time>2017-10-09T19:03:24Z</time>
+				<extensions>
+					<speed>1.1127660274505615</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01024616921481" lon="-84.21359719143315">
+				<ele>949.3026054855436</ele>
+				<time>2017-10-09T19:03:25Z</time>
+				<extensions>
+					<speed>0.957621693611145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01024616921481" lon="-84.21359719143315">
+				<ele>949.3026054855436</ele>
+				<time>2017-10-09T19:03:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010238240027785" lon="-84.21355793802175">
+				<ele>949.4871943295002</ele>
+				<time>2017-10-09T19:03:27Z</time>
+				<extensions>
+					<speed>0.5029771327972412</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010238240027785" lon="-84.21355793802175">
+				<ele>949.4871943295002</ele>
+				<time>2017-10-09T19:03:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010237274787931" lon="-84.21350981346184">
+				<ele>949.4557196404785</ele>
+				<time>2017-10-09T19:03:29Z</time>
+				<extensions>
+					<speed>1.298893690109253</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010230242611835" lon="-84.21346562384872">
+				<ele>949.654763661325</ele>
+				<time>2017-10-09T19:03:30Z</time>
+				<extensions>
+					<speed>1.227595567703247</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010216158911284" lon="-84.21344044172345">
+				<ele>949.5500692380592</ele>
+				<time>2017-10-09T19:03:31Z</time>
+				<extensions>
+					<speed>1.4147868156433105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010234551432866" lon="-84.21336764370565">
+				<ele>949.4748161491007</ele>
+				<time>2017-10-09T19:03:32Z</time>
+				<extensions>
+					<speed>1.8456851243972778</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010241505445931" lon="-84.21327167260995">
+				<ele>948.9557042606175</ele>
+				<time>2017-10-09T19:03:33Z</time>
+				<extensions>
+					<speed>1.9080138206481934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01021408764433" lon="-84.21319932984842">
+				<ele>948.7723305337131</ele>
+				<time>2017-10-09T19:03:34Z</time>
+				<extensions>
+					<speed>1.7926372289657593</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010235219327985" lon="-84.21305808756344">
+				<ele>947.3366168597713</ele>
+				<time>2017-10-09T19:03:35Z</time>
+				<extensions>
+					<speed>2.1783108711242676</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01022554243427" lon="-84.21298619802478">
+				<ele>946.899037193507</ele>
+				<time>2017-10-09T19:03:36Z</time>
+				<extensions>
+					<speed>2.3058247566223145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01020505429375" lon="-84.21293971012463">
+				<ele>946.684827179648</ele>
+				<time>2017-10-09T19:03:37Z</time>
+				<extensions>
+					<speed>2.2541275024414063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010184331922337" lon="-84.21292071498276">
+				<ele>946.7768667247146</ele>
+				<time>2017-10-09T19:03:38Z</time>
+				<extensions>
+					<speed>1.9752804040908813</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010184331922337" lon="-84.21292071498276">
+				<ele>948.001557960175</ele>
+				<time>2017-10-09T19:03:39Z</time>
+				<extensions>
+					<speed>1.8424865007400513</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01000767398778" lon="-84.21273634008402">
+				<ele>948.1440239734948</ele>
+				<time>2017-10-09T19:03:40Z</time>
+				<extensions>
+					<speed>1.0516536235809326</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010008863126556" lon="-84.21274905722942">
+				<ele>948.236102852039</ele>
+				<time>2017-10-09T19:03:41Z</time>
+				<extensions>
+					<speed>0.7195469737052917</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009982948255265" lon="-84.21273629916247">
+				<ele>948.2625936958939</ele>
+				<time>2017-10-09T19:03:42Z</time>
+				<extensions>
+					<speed>0.8309692740440369</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009976289694775" lon="-84.21274134994388">
+				<ele>948.122188786976</ele>
+				<time>2017-10-09T19:03:43Z</time>
+				<extensions>
+					<speed>0.9683351516723633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00996607678126" lon="-84.21274215569824">
+				<ele>948.0326346810907</ele>
+				<time>2017-10-09T19:03:44Z</time>
+				<extensions>
+					<speed>1.1120022535324097</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009946683728604" lon="-84.2127338890958">
+				<ele>947.965381543152</ele>
+				<time>2017-10-09T19:03:45Z</time>
+				<extensions>
+					<speed>1.6939865350723267</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009926514128031" lon="-84.21273343463186">
+				<ele>947.8610514011234</ele>
+				<time>2017-10-09T19:03:46Z</time>
+				<extensions>
+					<speed>1.997983455657959</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009929785442193" lon="-84.21274554352036">
+				<ele>947.7641346110031</ele>
+				<time>2017-10-09T19:03:47Z</time>
+				<extensions>
+					<speed>1.7415846586227417</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009940211272331" lon="-84.21276796300425">
+				<ele>947.4688663762063</ele>
+				<time>2017-10-09T19:03:48Z</time>
+				<extensions>
+					<speed>1.1521143913269043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00993501012809" lon="-84.21276767031434">
+				<ele>947.2611833540723</ele>
+				<time>2017-10-09T19:03:49Z</time>
+				<extensions>
+					<speed>1.0772433280944824</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009922667540279" lon="-84.2127424994865">
+				<ele>947.3845885312185</ele>
+				<time>2017-10-09T19:03:50Z</time>
+				<extensions>
+					<speed>1.279784917831421</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009914938058376" lon="-84.21272700988676">
+				<ele>947.3785176258534</ele>
+				<time>2017-10-09T19:03:51Z</time>
+				<extensions>
+					<speed>1.751427173614502</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00990989103922" lon="-84.21270736997488">
+				<ele>947.2761115422472</ele>
+				<time>2017-10-09T19:03:52Z</time>
+				<extensions>
+					<speed>2.4080333709716797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009894414324569" lon="-84.21267999232425">
+				<ele>947.6065288614482</ele>
+				<time>2017-10-09T19:03:53Z</time>
+				<extensions>
+					<speed>2.632913589477539</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009884336641695" lon="-84.21265482015718">
+				<ele>947.6093958811834</ele>
+				<time>2017-10-09T19:03:54Z</time>
+				<extensions>
+					<speed>3.2047572135925293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009857489145706" lon="-84.21262254223248">
+				<ele>947.4943799078465</ele>
+				<time>2017-10-09T19:03:55Z</time>
+				<extensions>
+					<speed>3.569741725921631</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00984565252985" lon="-84.21259625686073">
+				<ele>947.3433198807761</ele>
+				<time>2017-10-09T19:03:56Z</time>
+				<extensions>
+					<speed>3.8734662532806396</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009819854526459" lon="-84.21256248766633">
+				<ele>947.2511935383081</ele>
+				<time>2017-10-09T19:03:57Z</time>
+				<extensions>
+					<speed>4.43144416809082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009791805135267" lon="-84.21253227729531">
+				<ele>946.9590298021212</ele>
+				<time>2017-10-09T19:03:58Z</time>
+				<extensions>
+					<speed>4.682555198669434</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009728429627986" lon="-84.21248893954238">
+				<ele>946.9628891339526</ele>
+				<time>2017-10-09T19:03:59Z</time>
+				<extensions>
+					<speed>5.669384956359863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009677455144189" lon="-84.21244229911555">
+				<ele>946.8598512317985</ele>
+				<time>2017-10-09T19:04:00Z</time>
+				<extensions>
+					<speed>6.551911354064941</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009624640450804" lon="-84.21239528537562">
+				<ele>946.8297019060701</ele>
+				<time>2017-10-09T19:04:01Z</time>
+				<extensions>
+					<speed>6.929560661315918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009543534104136" lon="-84.21233676593752">
+				<ele>946.6957077756524</ele>
+				<time>2017-10-09T19:04:02Z</time>
+				<extensions>
+					<speed>7.7282304763793945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009454533360529" lon="-84.212253756806">
+				<ele>946.8987491549924</ele>
+				<time>2017-10-09T19:04:03Z</time>
+				<extensions>
+					<speed>9.175467491149902</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009387502179484" lon="-84.2121837280023">
+				<ele>947.2424271740019</ele>
+				<time>2017-10-09T19:04:04Z</time>
+				<extensions>
+					<speed>9.390636444091797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009321414200205" lon="-84.21211538954357">
+				<ele>947.2878041062504</ele>
+				<time>2017-10-09T19:04:05Z</time>
+				<extensions>
+					<speed>9.648782730102539</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009265129297276" lon="-84.21205115032008">
+				<ele>946.9963157968596</ele>
+				<time>2017-10-09T19:04:06Z</time>
+				<extensions>
+					<speed>9.474566459655762</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00921748328003" lon="-84.21198218618807">
+				<ele>946.3886929312721</ele>
+				<time>2017-10-09T19:04:07Z</time>
+				<extensions>
+					<speed>9.446747779846191</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00917280967693" lon="-84.21191320677829">
+				<ele>945.5947181740776</ele>
+				<time>2017-10-09T19:04:08Z</time>
+				<extensions>
+					<speed>9.24378776550293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009111368902028" lon="-84.2118451291083">
+				<ele>945.4944580178708</ele>
+				<time>2017-10-09T19:04:09Z</time>
+				<extensions>
+					<speed>9.281519889831543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009007479277845" lon="-84.21176178741027">
+				<ele>944.7608084715903</ele>
+				<time>2017-10-09T19:04:10Z</time>
+				<extensions>
+					<speed>9.49317455291748</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008880989042462" lon="-84.21166306390982">
+				<ele>942.9551927736029</ele>
+				<time>2017-10-09T19:04:11Z</time>
+				<extensions>
+					<speed>9.370473861694336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008798606857782" lon="-84.21160284491867">
+				<ele>941.6568579673767</ele>
+				<time>2017-10-09T19:04:12Z</time>
+				<extensions>
+					<speed>7.434837341308594</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008754206639926" lon="-84.211536955995">
+				<ele>941.4697573930025</ele>
+				<time>2017-10-09T19:04:13Z</time>
+				<extensions>
+					<speed>6.9193010330200195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008726868612232" lon="-84.21147280728475">
+				<ele>941.1837304569781</ele>
+				<time>2017-10-09T19:04:14Z</time>
+				<extensions>
+					<speed>6.766869068145752</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008714654092344" lon="-84.21140609239308">
+				<ele>940.8446664670482</ele>
+				<time>2017-10-09T19:04:15Z</time>
+				<extensions>
+					<speed>6.963963508605957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008709167744641" lon="-84.21134007955719">
+				<ele>940.315681074746</ele>
+				<time>2017-10-09T19:04:16Z</time>
+				<extensions>
+					<speed>6.931534767150879</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008699308208676" lon="-84.21127121503136">
+				<ele>939.4853643616661</ele>
+				<time>2017-10-09T19:04:17Z</time>
+				<extensions>
+					<speed>6.724091529846191</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662860396049" lon="-84.21118179707442">
+				<ele>938.7696038680151</ele>
+				<time>2017-10-09T19:04:18Z</time>
+				<extensions>
+					<speed>8.406926155090332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008655885831821" lon="-84.21109164249454">
+				<ele>939.5201105484739</ele>
+				<time>2017-10-09T19:04:19Z</time>
+				<extensions>
+					<speed>9.07302474975586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008650992745231" lon="-84.21099892627495">
+				<ele>940.4086639871821</ele>
+				<time>2017-10-09T19:04:20Z</time>
+				<extensions>
+					<speed>8.981475830078125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008645428238955" lon="-84.21091609151425">
+				<ele>940.7305288137868</ele>
+				<time>2017-10-09T19:04:21Z</time>
+				<extensions>
+					<speed>8.899693489074707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008649549025316" lon="-84.21084108608032">
+				<ele>941.6940451031551</ele>
+				<time>2017-10-09T19:04:22Z</time>
+				<extensions>
+					<speed>8.087462425231934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00864675358115" lon="-84.21077204143917">
+				<ele>943.3284690510482</ele>
+				<time>2017-10-09T19:04:23Z</time>
+				<extensions>
+					<speed>6.563162803649902</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633827360534" lon="-84.21069747040409">
+				<ele>944.9539976874366</ele>
+				<time>2017-10-09T19:04:24Z</time>
+				<extensions>
+					<speed>7.6199259757995605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008618066729717" lon="-84.210617755435">
+				<ele>945.3236818350852</ele>
+				<time>2017-10-09T19:04:25Z</time>
+				<extensions>
+					<speed>8.483530044555664</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633728847846" lon="-84.21057125557311">
+				<ele>943.3461946817115</ele>
+				<time>2017-10-09T19:04:26Z</time>
+				<extensions>
+					<speed>8.14061164855957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008611351622003" lon="-84.2104830551579">
+				<ele>943.9816230982542</ele>
+				<time>2017-10-09T19:04:27Z</time>
+				<extensions>
+					<speed>7.932896614074707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008592480679482" lon="-84.21044125430946">
+				<ele>940.9855918250978</ele>
+				<time>2017-10-09T19:04:28Z</time>
+				<extensions>
+					<speed>8.374741554260254</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00858048862995" lon="-84.21035289794833">
+				<ele>941.7935220189393</ele>
+				<time>2017-10-09T19:04:29Z</time>
+				<extensions>
+					<speed>8.703185081481934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008579700838032" lon="-84.2102945799082">
+				<ele>940.4160710545257</ele>
+				<time>2017-10-09T19:04:30Z</time>
+				<extensions>
+					<speed>7.592146873474121</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008580033431874" lon="-84.21024848035242">
+				<ele>939.2435432840139</ele>
+				<time>2017-10-09T19:04:31Z</time>
+				<extensions>
+					<speed>6.09262228012085</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008582921080151" lon="-84.21021006183042">
+				<ele>938.5150545109063</ele>
+				<time>2017-10-09T19:04:32Z</time>
+				<extensions>
+					<speed>4.634498596191406</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0085874640576" lon="-84.2101805061912">
+				<ele>938.1751263542101</ele>
+				<time>2017-10-09T19:04:33Z</time>
+				<extensions>
+					<speed>2.9622602462768555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008589887824261" lon="-84.21016498634579">
+				<ele>937.702021821402</ele>
+				<time>2017-10-09T19:04:34Z</time>
+				<extensions>
+					<speed>1.3484716415405273</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008590323068033" lon="-84.21016094276051">
+				<ele>937.4734490886331</ele>
+				<time>2017-10-09T19:04:35Z</time>
+				<extensions>
+					<speed>0.27755698561668396</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008590323068033" lon="-84.21016094276051">
+				<ele>937.4734490886331</ele>
+				<time>2017-10-09T19:04:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008589386823362" lon="-84.21017509457094">
+				<ele>937.0181277319789</ele>
+				<time>2017-10-09T19:04:37Z</time>
+				<extensions>
+					<speed>0.9555369019508362</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00858863721366" lon="-84.21019029298459">
+				<ele>936.8727465756238</ele>
+				<time>2017-10-09T19:04:38Z</time>
+				<extensions>
+					<speed>1.2724689245224</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008588545282315" lon="-84.21020391800958">
+				<ele>936.5675726756454</ele>
+				<time>2017-10-09T19:04:39Z</time>
+				<extensions>
+					<speed>1.206977128982544</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008585715281956" lon="-84.21021566896025">
+				<ele>936.1599684208632</ele>
+				<time>2017-10-09T19:04:40Z</time>
+				<extensions>
+					<speed>1.096498727798462</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008580641915328" lon="-84.21022768659415">
+				<ele>936.0009289691225</ele>
+				<time>2017-10-09T19:04:41Z</time>
+				<extensions>
+					<speed>1.3968020677566528</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008581560437001" lon="-84.2102480526604">
+				<ele>935.6734921289608</ele>
+				<time>2017-10-09T19:04:42Z</time>
+				<extensions>
+					<speed>1.9389818906784058</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008589965007529" lon="-84.21026467134773">
+				<ele>935.0146316271275</ele>
+				<time>2017-10-09T19:04:43Z</time>
+				<extensions>
+					<speed>1.6958833932876587</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008599326511721" lon="-84.21028386087326">
+				<ele>934.2961462931708</ele>
+				<time>2017-10-09T19:04:44Z</time>
+				<extensions>
+					<speed>1.8593156337738037</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008610158635447" lon="-84.21029185421708">
+				<ele>933.2623538589105</ele>
+				<time>2017-10-09T19:04:45Z</time>
+				<extensions>
+					<speed>1.0856397151947021</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008617876265612" lon="-84.21029510876593">
+				<ele>932.2932302672416</ele>
+				<time>2017-10-09T19:04:46Z</time>
+				<extensions>
+					<speed>0.5185673832893372</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008617876265612" lon="-84.21029510876593">
+				<ele>932.2932302672416</ele>
+				<time>2017-10-09T19:04:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008622815987922" lon="-84.21027698720542">
+				<ele>931.5922331465408</ele>
+				<time>2017-10-09T19:04:48Z</time>
+				<extensions>
+					<speed>2.1794533729553223</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008623735929419" lon="-84.21025240208324">
+				<ele>931.6137435110286</ele>
+				<time>2017-10-09T19:04:49Z</time>
+				<extensions>
+					<speed>3.097611904144287</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00862470545201" lon="-84.21022128452611">
+				<ele>931.7103190757334</ele>
+				<time>2017-10-09T19:04:50Z</time>
+				<extensions>
+					<speed>3.6471266746520996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008622575405305" lon="-84.21017799803978">
+				<ele>931.6242399867624</ele>
+				<time>2017-10-09T19:04:51Z</time>
+				<extensions>
+					<speed>4.763978481292725</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008620392120092" lon="-84.2101267040264">
+				<ele>931.8243121225387</ele>
+				<time>2017-10-09T19:04:52Z</time>
+				<extensions>
+					<speed>5.559028625488281</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008621946495973" lon="-84.21005992798506">
+				<ele>931.7616491559893</ele>
+				<time>2017-10-09T19:04:53Z</time>
+				<extensions>
+					<speed>6.8303375244140625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00861985434002" lon="-84.20997697644621">
+				<ele>931.4736509043723</ele>
+				<time>2017-10-09T19:04:54Z</time>
+				<extensions>
+					<speed>8.539549827575684</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0086223674622" lon="-84.20988530900767">
+				<ele>931.2649378497154</ele>
+				<time>2017-10-09T19:04:55Z</time>
+				<extensions>
+					<speed>9.52119255065918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00861847220043" lon="-84.20979368244258">
+				<ele>930.8611150952056</ele>
+				<time>2017-10-09T19:04:56Z</time>
+				<extensions>
+					<speed>9.923644065856934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0086129337343" lon="-84.20970202378243">
+				<ele>930.7017691126093</ele>
+				<time>2017-10-09T19:04:57Z</time>
+				<extensions>
+					<speed>9.500284194946289</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008607610438734" lon="-84.20961774874255">
+				<ele>930.7751485146582</ele>
+				<time>2017-10-09T19:04:58Z</time>
+				<extensions>
+					<speed>8.463763236999512</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008609267969716" lon="-84.20954800799353">
+				<ele>931.102892040275</ele>
+				<time>2017-10-09T19:04:59Z</time>
+				<extensions>
+					<speed>6.218869209289551</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008611852635182" lon="-84.20949196424434">
+				<ele>932.4663642421365</ele>
+				<time>2017-10-09T19:05:00Z</time>
+				<extensions>
+					<speed>4.764753341674805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008615458139609" lon="-84.20945325445858">
+				<ele>933.8666423875839</ele>
+				<time>2017-10-09T19:05:01Z</time>
+				<extensions>
+					<speed>2.756291151046753</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008615010092475" lon="-84.20942573080602">
+				<ele>934.9309192476794</ele>
+				<time>2017-10-09T19:05:02Z</time>
+				<extensions>
+					<speed>1.4094462394714355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008615714454953" lon="-84.20941155538081">
+				<ele>935.5001610722393</ele>
+				<time>2017-10-09T19:05:03Z</time>
+				<extensions>
+					<speed>0.9451858401298523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008622467484189" lon="-84.2093958015675">
+				<ele>935.9578864136711</ele>
+				<time>2017-10-09T19:05:04Z</time>
+				<extensions>
+					<speed>1.2298232316970825</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008628156997132" lon="-84.20938305840826">
+				<ele>936.497641120106</ele>
+				<time>2017-10-09T19:05:05Z</time>
+				<extensions>
+					<speed>1.2255219221115112</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008637660354177" lon="-84.20937346573412">
+				<ele>936.8929383140057</ele>
+				<time>2017-10-09T19:05:06Z</time>
+				<extensions>
+					<speed>1.215340495109558</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008645405284492" lon="-84.2093629535302">
+				<ele>936.889680207707</ele>
+				<time>2017-10-09T19:05:07Z</time>
+				<extensions>
+					<speed>1.1736401319503784</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00865541126013" lon="-84.20935097366373">
+				<ele>936.42684962973</ele>
+				<time>2017-10-09T19:05:08Z</time>
+				<extensions>
+					<speed>1.3259613513946533</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00865836778458" lon="-84.20933302406647">
+				<ele>935.9672701107338</ele>
+				<time>2017-10-09T19:05:09Z</time>
+				<extensions>
+					<speed>1.4713501930236816</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008664370185015" lon="-84.20931587850629">
+				<ele>935.1426949007437</ele>
+				<time>2017-10-09T19:05:10Z</time>
+				<extensions>
+					<speed>1.9109398126602173</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008667995769077" lon="-84.20929101692995">
+				<ele>934.9144231015816</ele>
+				<time>2017-10-09T19:05:11Z</time>
+				<extensions>
+					<speed>2.767444133758545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008668149713257" lon="-84.20925610574919">
+				<ele>934.7564907874912</ele>
+				<time>2017-10-09T19:05:12Z</time>
+				<extensions>
+					<speed>3.6447441577911377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00866909175438" lon="-84.20921339760955">
+				<ele>934.6978089539334</ele>
+				<time>2017-10-09T19:05:13Z</time>
+				<extensions>
+					<speed>4.333683490753174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008673019169507" lon="-84.20914977556835">
+				<ele>935.2506686858833</ele>
+				<time>2017-10-09T19:05:14Z</time>
+				<extensions>
+					<speed>5.5199174880981445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008682030978868" lon="-84.2090788080457">
+				<ele>935.6529913833365</ele>
+				<time>2017-10-09T19:05:15Z</time>
+				<extensions>
+					<speed>6.59616231918335</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008680808869656" lon="-84.20900599127611">
+				<ele>935.6822887100279</ele>
+				<time>2017-10-09T19:05:16Z</time>
+				<extensions>
+					<speed>7.1562724113464355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008690221683183" lon="-84.2089339202346">
+				<ele>934.397901265882</ele>
+				<time>2017-10-09T19:05:17Z</time>
+				<extensions>
+					<speed>7.2406158447265625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008701088994226" lon="-84.208859504467">
+				<ele>933.6109406352043</ele>
+				<time>2017-10-09T19:05:18Z</time>
+				<extensions>
+					<speed>7.414018630981445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008686192470023" lon="-84.20878922280482">
+				<ele>932.8535643145442</ele>
+				<time>2017-10-09T19:05:19Z</time>
+				<extensions>
+					<speed>7.397597789764404</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008671620792056" lon="-84.2087156827764">
+				<ele>932.0962060438469</ele>
+				<time>2017-10-09T19:05:20Z</time>
+				<extensions>
+					<speed>7.481088638305664</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008652483682994" lon="-84.20866198865816">
+				<ele>931.2935218662024</ele>
+				<time>2017-10-09T19:05:21Z</time>
+				<extensions>
+					<speed>6.8824639320373535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008634746135892" lon="-84.20862002606002">
+				<ele>930.4891987396404</ele>
+				<time>2017-10-09T19:05:22Z</time>
+				<extensions>
+					<speed>6.089135646820068</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0086226399311" lon="-84.20856561419083">
+				<ele>929.974312895909</ele>
+				<time>2017-10-09T19:05:23Z</time>
+				<extensions>
+					<speed>6.052607536315918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008620000123077" lon="-84.20848663135881">
+				<ele>929.518177786842</ele>
+				<time>2017-10-09T19:05:24Z</time>
+				<extensions>
+					<speed>6.400464057922363</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008616126783624" lon="-84.20841484914753">
+				<ele>929.0820360546932</ele>
+				<time>2017-10-09T19:05:25Z</time>
+				<extensions>
+					<speed>6.572493076324463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008613708653366" lon="-84.20834243914769">
+				<ele>928.7046810341999</ele>
+				<time>2017-10-09T19:05:26Z</time>
+				<extensions>
+					<speed>6.748481273651123</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008616832512105" lon="-84.20832870998638">
+				<ele>928.3331937985495</ele>
+				<time>2017-10-09T19:05:27Z</time>
+				<extensions>
+					<speed>5.617771148681641</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008629918856524" lon="-84.20837464291203">
+				<ele>927.7698127226904</ele>
+				<time>2017-10-09T19:05:28Z</time>
+				<extensions>
+					<speed>3.4197463989257813</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008637881316309" lon="-84.20837090877875">
+				<ele>927.6276815468445</ele>
+				<time>2017-10-09T19:05:29Z</time>
+				<extensions>
+					<speed>2.8833446502685547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008645403525659" lon="-84.20834300477493">
+				<ele>927.5219377493486</ele>
+				<time>2017-10-09T19:05:30Z</time>
+				<extensions>
+					<speed>3.4837610721588135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008672619709204" lon="-84.20830814770902">
+				<ele>927.021102167666</ele>
+				<time>2017-10-09T19:05:31Z</time>
+				<extensions>
+					<speed>5.402559757232666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008676429913468" lon="-84.20828536186592">
+				<ele>926.5256424099207</ele>
+				<time>2017-10-09T19:05:32Z</time>
+				<extensions>
+					<speed>6.5011887550354</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00867617547986" lon="-84.2082382341706">
+				<ele>926.1513322265819</ele>
+				<time>2017-10-09T19:05:33Z</time>
+				<extensions>
+					<speed>7.004993438720703</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00867679541576" lon="-84.2081959438551">
+				<ele>925.641898564063</ele>
+				<time>2017-10-09T19:05:34Z</time>
+				<extensions>
+					<speed>7.253573894500732</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008681699508745" lon="-84.20814699674756">
+				<ele>925.1389049338177</ele>
+				<time>2017-10-09T19:05:35Z</time>
+				<extensions>
+					<speed>7.13008451461792</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008688132052303" lon="-84.20808431161112">
+				<ele>924.5454211365432</ele>
+				<time>2017-10-09T19:05:36Z</time>
+				<extensions>
+					<speed>6.673223972320557</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008684455272284" lon="-84.20804133141661">
+				<ele>924.1017084680498</ele>
+				<time>2017-10-09T19:05:37Z</time>
+				<extensions>
+					<speed>5.739973068237305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008675586249351" lon="-84.20801021193574">
+				<ele>923.4008614700288</ele>
+				<time>2017-10-09T19:05:38Z</time>
+				<extensions>
+					<speed>3.35306715965271</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008667314334271" lon="-84.20799507150882">
+				<ele>922.8806946761906</ele>
+				<time>2017-10-09T19:05:39Z</time>
+				<extensions>
+					<speed>1.8790135383605957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008657018676935" lon="-84.20798523030628">
+				<ele>922.2409530188888</ele>
+				<time>2017-10-09T19:05:40Z</time>
+				<extensions>
+					<speed>1.178621530532837</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00864616696911" lon="-84.20798015811057">
+				<ele>921.7503461642191</ele>
+				<time>2017-10-09T19:05:41Z</time>
+				<extensions>
+					<speed>0.8161978721618652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00864616696911" lon="-84.20798015811057">
+				<ele>921.7503461642191</ele>
+				<time>2017-10-09T19:05:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640009162246" lon="-84.20798874025124">
+				<ele>921.467154584825</ele>
+				<time>2017-10-09T19:05:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640009162246" lon="-84.20798874025124">
+				<ele>921.467154584825</ele>
+				<time>2017-10-09T19:05:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640421685849" lon="-84.20799239648154">
+				<ele>921.3418006030843</ele>
+				<time>2017-10-09T19:05:45Z</time>
+				<extensions>
+					<speed>0.7329297065734863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640009162246" lon="-84.20798874025124">
+				<ele>921.467154584825</ele>
+				<time>2017-10-09T19:05:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640009162246" lon="-84.20798874025124">
+				<ele>921.467154584825</ele>
+				<time>2017-10-09T19:05:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00864425600536" lon="-84.20798766896733">
+				<ele>921.0828277282417</ele>
+				<time>2017-10-09T19:05:48Z</time>
+				<extensions>
+					<speed>0.7739498615264893</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008652943022637" lon="-84.2079818139334">
+				<ele>920.6771719856188</ele>
+				<time>2017-10-09T19:05:49Z</time>
+				<extensions>
+					<speed>1.2005083560943604</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008655369414756" lon="-84.20797016714741">
+				<ele>920.5107779838145</ele>
+				<time>2017-10-09T19:05:50Z</time>
+				<extensions>
+					<speed>1.4547921419143677</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00865388796339" lon="-84.20795473633869">
+				<ele>920.5397663945332</ele>
+				<time>2017-10-09T19:05:51Z</time>
+				<extensions>
+					<speed>1.5496315956115723</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00865163815771" lon="-84.207942063426">
+				<ele>920.4606989063323</ele>
+				<time>2017-10-09T19:05:52Z</time>
+				<extensions>
+					<speed>1.408976674079895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008652089154381" lon="-84.20792237934963">
+				<ele>920.5110184876248</ele>
+				<time>2017-10-09T19:05:53Z</time>
+				<extensions>
+					<speed>2.012563467025757</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008651327378736" lon="-84.20790318596369">
+				<ele>920.6866511153057</ele>
+				<time>2017-10-09T19:05:54Z</time>
+				<extensions>
+					<speed>2.0816707611083984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008651633352287" lon="-84.20788993319994">
+				<ele>920.5926775736734</ele>
+				<time>2017-10-09T19:05:55Z</time>
+				<extensions>
+					<speed>1.6569446325302124</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008643410579914" lon="-84.20787970344493">
+				<ele>920.5921248560771</ele>
+				<time>2017-10-09T19:05:56Z</time>
+				<extensions>
+					<speed>2.0315780639648438</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008629809456737" lon="-84.207859917164">
+				<ele>921.111404268071</ele>
+				<time>2017-10-09T19:05:57Z</time>
+				<extensions>
+					<speed>2.7714946269989014</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00861052073746" lon="-84.20784040683515">
+				<ele>921.9418674521148</ele>
+				<time>2017-10-09T19:05:58Z</time>
+				<extensions>
+					<speed>2.826474666595459</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008587178364243" lon="-84.2078190733643">
+				<ele>922.8574461648241</ele>
+				<time>2017-10-09T19:05:59Z</time>
+				<extensions>
+					<speed>3.248232126235962</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008564330474966" lon="-84.20779973208806">
+				<ele>923.3654802199453</ele>
+				<time>2017-10-09T19:06:00Z</time>
+				<extensions>
+					<speed>2.9989635944366455</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008539840644795" lon="-84.20778309692427">
+				<ele>923.7059908593073</ele>
+				<time>2017-10-09T19:06:01Z</time>
+				<extensions>
+					<speed>3.0298991203308105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008516981296959" lon="-84.20776566255076">
+				<ele>923.5135645559058</ele>
+				<time>2017-10-09T19:06:02Z</time>
+				<extensions>
+					<speed>2.9424173831939697</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00849359171773" lon="-84.20774991918408">
+				<ele>923.147342864424</ele>
+				<time>2017-10-09T19:06:03Z</time>
+				<extensions>
+					<speed>3.022932767868042</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008468927056011" lon="-84.20773630474578">
+				<ele>922.8990544080734</ele>
+				<time>2017-10-09T19:06:04Z</time>
+				<extensions>
+					<speed>3.0647895336151123</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008441887633609" lon="-84.20771714009797">
+				<ele>922.7596785640344</ele>
+				<time>2017-10-09T19:06:05Z</time>
+				<extensions>
+					<speed>3.463395595550537</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008409982339687" lon="-84.20770053632084">
+				<ele>923.1406380301341</ele>
+				<time>2017-10-09T19:06:06Z</time>
+				<extensions>
+					<speed>4.105911731719971</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008373520317546" lon="-84.20767741457638">
+				<ele>923.8696852158755</ele>
+				<time>2017-10-09T19:06:07Z</time>
+				<extensions>
+					<speed>4.88277530670166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008329449853644" lon="-84.2076476543907">
+				<ele>924.6452126996592</ele>
+				<time>2017-10-09T19:06:08Z</time>
+				<extensions>
+					<speed>6.130412578582764</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008304048546394" lon="-84.20761974996158">
+				<ele>919.7011700347066</ele>
+				<time>2017-10-09T19:06:09Z</time>
+				<extensions>
+					<speed>6.794142246246338</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008252646809778" lon="-84.20757903812456">
+				<ele>919.0831441385671</ele>
+				<time>2017-10-09T19:06:10Z</time>
+				<extensions>
+					<speed>7.5953874588012695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008193518939178" lon="-84.20753099274151">
+				<ele>918.7385084051639</ele>
+				<time>2017-10-09T19:06:11Z</time>
+				<extensions>
+					<speed>8.652484893798828</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008125808318647" lon="-84.20747671742363">
+				<ele>919.7500386629254</ele>
+				<time>2017-10-09T19:06:12Z</time>
+				<extensions>
+					<speed>9.187982559204102</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008059524807086" lon="-84.20741957025301">
+				<ele>919.3832648620009</ele>
+				<time>2017-10-09T19:06:13Z</time>
+				<extensions>
+					<speed>9.71945571899414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007995592365962" lon="-84.20735851630388">
+				<ele>918.4104594951496</ele>
+				<time>2017-10-09T19:06:14Z</time>
+				<extensions>
+					<speed>10.183404922485352</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007918921158787" lon="-84.20729307230457">
+				<ele>918.3656631829217</ele>
+				<time>2017-10-09T19:06:15Z</time>
+				<extensions>
+					<speed>10.67956829071045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007840236739394" lon="-84.20722385864495">
+				<ele>918.4337358260527</ele>
+				<time>2017-10-09T19:06:16Z</time>
+				<extensions>
+					<speed>10.986096382141113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007761248638325" lon="-84.20715233829388">
+				<ele>918.500423097983</ele>
+				<time>2017-10-09T19:06:17Z</time>
+				<extensions>
+					<speed>11.05534553527832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007687586560461" lon="-84.20708321894807">
+				<ele>918.6732617141679</ele>
+				<time>2017-10-09T19:06:18Z</time>
+				<extensions>
+					<speed>10.81840991973877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007613362014265" lon="-84.20701239338709">
+				<ele>918.1082070255652</ele>
+				<time>2017-10-09T19:06:19Z</time>
+				<extensions>
+					<speed>11.193108558654785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007533241331155" lon="-84.20694550985156">
+				<ele>917.9057593718171</ele>
+				<time>2017-10-09T19:06:20Z</time>
+				<extensions>
+					<speed>11.28309440612793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007453138471156" lon="-84.2068738245212">
+				<ele>917.0146037582308</ele>
+				<time>2017-10-09T19:06:21Z</time>
+				<extensions>
+					<speed>11.815173149108887</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007372991403063" lon="-84.20680414194854">
+				<ele>916.8997552525252</ele>
+				<time>2017-10-09T19:06:22Z</time>
+				<extensions>
+					<speed>11.563448905944824</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007297418189571" lon="-84.20673172707967">
+				<ele>916.470331126824</ele>
+				<time>2017-10-09T19:06:23Z</time>
+				<extensions>
+					<speed>11.573881149291992</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007223345637488" lon="-84.20665785373947">
+				<ele>916.1655054958537</ele>
+				<time>2017-10-09T19:06:24Z</time>
+				<extensions>
+					<speed>11.799139022827148</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007152090247764" lon="-84.20657822592462">
+				<ele>915.2722567180172</ele>
+				<time>2017-10-09T19:06:25Z</time>
+				<extensions>
+					<speed>11.813436508178711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007077211298878" lon="-84.20649850349606">
+				<ele>914.9355570310727</ele>
+				<time>2017-10-09T19:06:26Z</time>
+				<extensions>
+					<speed>12.070292472839355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007001570634014" lon="-84.20642004281883">
+				<ele>914.3477868931368</ele>
+				<time>2017-10-09T19:06:27Z</time>
+				<extensions>
+					<speed>12.203879356384277</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006918824357514" lon="-84.20634373468172">
+				<ele>914.3043420035392</ele>
+				<time>2017-10-09T19:06:28Z</time>
+				<extensions>
+					<speed>12.319330215454102</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006830144163406" lon="-84.20627024460175">
+				<ele>914.6280532646924</ele>
+				<time>2017-10-09T19:06:29Z</time>
+				<extensions>
+					<speed>12.32131576538086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00674878736196" lon="-84.20619424391381">
+				<ele>913.5994579475373</ele>
+				<time>2017-10-09T19:06:30Z</time>
+				<extensions>
+					<speed>12.10258674621582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00666860497037" lon="-84.20611731546764">
+				<ele>912.7627791250125</ele>
+				<time>2017-10-09T19:06:31Z</time>
+				<extensions>
+					<speed>11.871787071228027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006584953478196" lon="-84.20604051542708">
+				<ele>912.5765378866345</ele>
+				<time>2017-10-09T19:06:32Z</time>
+				<extensions>
+					<speed>11.708943367004395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006501347581562" lon="-84.20596921716242">
+				<ele>912.3424801854417</ele>
+				<time>2017-10-09T19:06:33Z</time>
+				<extensions>
+					<speed>11.847618103027344</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006425447311063" lon="-84.2058950434649">
+				<ele>911.0400892831385</ele>
+				<time>2017-10-09T19:06:34Z</time>
+				<extensions>
+					<speed>11.626492500305176</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006344558497624" lon="-84.20582716423182">
+				<ele>911.008118391037</ele>
+				<time>2017-10-09T19:06:35Z</time>
+				<extensions>
+					<speed>11.287248611450195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00625933095052" lon="-84.20576720967274">
+				<ele>910.9701512763277</ele>
+				<time>2017-10-09T19:06:36Z</time>
+				<extensions>
+					<speed>10.5116548538208</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006178952018214" lon="-84.20571476581667">
+				<ele>911.5922941090539</ele>
+				<time>2017-10-09T19:06:37Z</time>
+				<extensions>
+					<speed>9.830344200134277</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006110721235041" lon="-84.20567128499458">
+				<ele>911.8902999898419</ele>
+				<time>2017-10-09T19:06:38Z</time>
+				<extensions>
+					<speed>7.316950798034668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006058738959531" lon="-84.20564280996504">
+				<ele>911.8843043055385</ele>
+				<time>2017-10-09T19:06:39Z</time>
+				<extensions>
+					<speed>5.686323642730713</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006018398348537" lon="-84.20562640086312">
+				<ele>911.8162305345759</ele>
+				<time>2017-10-09T19:06:40Z</time>
+				<extensions>
+					<speed>4.011725425720215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005981746550617" lon="-84.20562921168758">
+				<ele>914.0597970075905</ele>
+				<time>2017-10-09T19:06:41Z</time>
+				<extensions>
+					<speed>3.5069422721862793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00595788147493" lon="-84.20564475755498">
+				<ele>915.0891379555687</ele>
+				<time>2017-10-09T19:06:42Z</time>
+				<extensions>
+					<speed>4.347096920013428</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005932100203626" lon="-84.20567149210856">
+				<ele>915.5937781268731</ele>
+				<time>2017-10-09T19:06:43Z</time>
+				<extensions>
+					<speed>4.747577667236328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005903850640733" lon="-84.20570880297025">
+				<ele>916.2644192734733</ele>
+				<time>2017-10-09T19:06:44Z</time>
+				<extensions>
+					<speed>5.010550022125244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005876884260765" lon="-84.2057564046684">
+				<ele>916.4323617257178</ele>
+				<time>2017-10-09T19:06:45Z</time>
+				<extensions>
+					<speed>6.207081317901611</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005855788265663" lon="-84.20580882541182">
+				<ele>916.1515197278932</ele>
+				<time>2017-10-09T19:06:46Z</time>
+				<extensions>
+					<speed>6.221536636352539</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005837502414442" lon="-84.20586651153826">
+				<ele>916.1797233279794</ele>
+				<time>2017-10-09T19:06:47Z</time>
+				<extensions>
+					<speed>6.618020534515381</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005826899781106" lon="-84.20591377259049">
+				<ele>915.2957710372284</ele>
+				<time>2017-10-09T19:06:48Z</time>
+				<extensions>
+					<speed>5.840311527252197</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005814906706727" lon="-84.20594975852244">
+				<ele>915.1771801412106</ele>
+				<time>2017-10-09T19:06:49Z</time>
+				<extensions>
+					<speed>3.967479705810547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005802354069955" lon="-84.20596127163897">
+				<ele>915.1380694331601</ele>
+				<time>2017-10-09T19:06:50Z</time>
+				<extensions>
+					<speed>1.558583378791809</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005786053330759" lon="-84.20596712633439">
+				<ele>916.8892684318125</ele>
+				<time>2017-10-09T19:06:51Z</time>
+				<extensions>
+					<speed>1.178995132446289</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005781801547636" lon="-84.20596679443533">
+				<ele>918.7017895402387</ele>
+				<time>2017-10-09T19:06:52Z</time>
+				<extensions>
+					<speed>1.0377776622772217</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005783277302841" lon="-84.20595371650407">
+				<ele>919.0443203225732</ele>
+				<time>2017-10-09T19:06:53Z</time>
+				<extensions>
+					<speed>1.035468578338623</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005785090330237" lon="-84.20594467952093">
+				<ele>919.0887808324769</ele>
+				<time>2017-10-09T19:06:54Z</time>
+				<extensions>
+					<speed>0.5271462202072144</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005785090330237" lon="-84.20594467952093">
+				<ele>919.0887808324769</ele>
+				<time>2017-10-09T19:06:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005792719602036" lon="-84.20593525239063">
+				<ele>919.0682896692306</ele>
+				<time>2017-10-09T19:06:56Z</time>
+				<extensions>
+					<speed>0.6178438067436218</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005792719602036" lon="-84.20593525239063">
+				<ele>919.0682896692306</ele>
+				<time>2017-10-09T19:06:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005800687744312" lon="-84.20593810574802">
+				<ele>919.1055702893063</ele>
+				<time>2017-10-09T19:06:58Z</time>
+				<extensions>
+					<speed>0.7546446323394775</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005808564749001" lon="-84.20594294990067">
+				<ele>919.583908116445</ele>
+				<time>2017-10-09T19:06:59Z</time>
+				<extensions>
+					<speed>1.0547053813934326</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0058098197051" lon="-84.20595023897633">
+				<ele>920.0679032551125</ele>
+				<time>2017-10-09T19:07:00Z</time>
+				<extensions>
+					<speed>1.6060845851898193</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00580760328274" lon="-84.20596552367115">
+				<ele>920.5257285805419</ele>
+				<time>2017-10-09T19:07:01Z</time>
+				<extensions>
+					<speed>2.1175758838653564</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005799319437507" lon="-84.2059843394877">
+				<ele>920.7893872968853</ele>
+				<time>2017-10-09T19:07:02Z</time>
+				<extensions>
+					<speed>2.6297004222869873</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005781062831986" lon="-84.20601282668623">
+				<ele>921.2261064015329</ele>
+				<time>2017-10-09T19:07:03Z</time>
+				<extensions>
+					<speed>3.5458688735961914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005751397988584" lon="-84.20604561732908">
+				<ele>921.5796303441748</ele>
+				<time>2017-10-09T19:07:04Z</time>
+				<extensions>
+					<speed>4.479779243469238</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005712553482612" lon="-84.2060791434726">
+				<ele>921.8531959028915</ele>
+				<time>2017-10-09T19:07:05Z</time>
+				<extensions>
+					<speed>5.379295349121094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005676168716105" lon="-84.20612007199853">
+				<ele>921.9001327641308</ele>
+				<time>2017-10-09T19:07:06Z</time>
+				<extensions>
+					<speed>5.874037265777588</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005639170857078" lon="-84.20617056227613">
+				<ele>921.8106518834829</ele>
+				<time>2017-10-09T19:07:07Z</time>
+				<extensions>
+					<speed>6.636239528656006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00559681629992" lon="-84.20622857852366">
+				<ele>921.371620898135</ele>
+				<time>2017-10-09T19:07:08Z</time>
+				<extensions>
+					<speed>7.468669891357422</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005553229304292" lon="-84.2062856453004">
+				<ele>921.416866841726</ele>
+				<time>2017-10-09T19:07:09Z</time>
+				<extensions>
+					<speed>7.761857032775879</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005506970954977" lon="-84.2063436149511">
+				<ele>921.8848155057058</ele>
+				<time>2017-10-09T19:07:10Z</time>
+				<extensions>
+					<speed>8.078198432922363</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00544571202899" lon="-84.20640529687533">
+				<ele>922.6761307222769</ele>
+				<time>2017-10-09T19:07:11Z</time>
+				<extensions>
+					<speed>8.915108680725098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005389367694054" lon="-84.2064662799089">
+				<ele>922.9814761979505</ele>
+				<time>2017-10-09T19:07:12Z</time>
+				<extensions>
+					<speed>9.331299781799316</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005326275630148" lon="-84.20652223338769">
+				<ele>923.4541332554072</ele>
+				<time>2017-10-09T19:07:13Z</time>
+				<extensions>
+					<speed>9.397703170776367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005256473443533" lon="-84.20657696542784">
+				<ele>924.0827518841252</ele>
+				<time>2017-10-09T19:07:14Z</time>
+				<extensions>
+					<speed>9.278996467590332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005186954663982" lon="-84.2066262711051">
+				<ele>924.7588063618168</ele>
+				<time>2017-10-09T19:07:15Z</time>
+				<extensions>
+					<speed>8.920445442199707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005128368652933" lon="-84.20667297064863">
+				<ele>925.388045988977</ele>
+				<time>2017-10-09T19:07:16Z</time>
+				<extensions>
+					<speed>8.17574691772461</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005077666825395" lon="-84.20672007318146">
+				<ele>925.9531144555658</ele>
+				<time>2017-10-09T19:07:17Z</time>
+				<extensions>
+					<speed>7.484917163848877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005034945019602" lon="-84.20675559203042">
+				<ele>926.4414264876395</ele>
+				<time>2017-10-09T19:07:18Z</time>
+				<extensions>
+					<speed>6.254644870758057</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00499196513467" lon="-84.20678409674653">
+				<ele>926.85279136803</ele>
+				<time>2017-10-09T19:07:19Z</time>
+				<extensions>
+					<speed>5.596123695373535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004941801298934" lon="-84.2067980141212">
+				<ele>927.0189271289855</ele>
+				<time>2017-10-09T19:07:20Z</time>
+				<extensions>
+					<speed>5.2349348068237305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004887701138848" lon="-84.20677717480004">
+				<ele>927.1552453879267</ele>
+				<time>2017-10-09T19:07:21Z</time>
+				<extensions>
+					<speed>5.624910831451416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004846378355404" lon="-84.20675004140209">
+				<ele>927.5219013364986</ele>
+				<time>2017-10-09T19:07:22Z</time>
+				<extensions>
+					<speed>5.472989082336426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00481147241517" lon="-84.20671798825161">
+				<ele>927.4528528926894</ele>
+				<time>2017-10-09T19:07:23Z</time>
+				<extensions>
+					<speed>4.31244421005249</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004775141546517" lon="-84.20668583764547">
+				<ele>927.4391856230795</ele>
+				<time>2017-10-09T19:07:24Z</time>
+				<extensions>
+					<speed>3.8245656490325928</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004764454624185" lon="-84.20665009676559">
+				<ele>927.1774735543877</ele>
+				<time>2017-10-09T19:07:25Z</time>
+				<extensions>
+					<speed>3.1986072063446045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00475656410081" lon="-84.20661964423907">
+				<ele>926.9409436248243</ele>
+				<time>2017-10-09T19:07:26Z</time>
+				<extensions>
+					<speed>2.772512912750244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004782042530492" lon="-84.20662216519773">
+				<ele>926.7754872934893</ele>
+				<time>2017-10-09T19:07:27Z</time>
+				<extensions>
+					<speed>1.2117401361465454</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004787557002595" lon="-84.20661354143148">
+				<ele>926.6433023381978</ele>
+				<time>2017-10-09T19:07:28Z</time>
+				<extensions>
+					<speed>1.040319800376892</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00478753089862" lon="-84.20660849122156">
+				<ele>926.6881103077903</ele>
+				<time>2017-10-09T19:07:29Z</time>
+				<extensions>
+					<speed>0.6305091977119446</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00478753089862" lon="-84.20660849122156">
+				<ele>926.6881103077903</ele>
+				<time>2017-10-09T19:07:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004788651936865" lon="-84.20660760094017">
+				<ele>926.7475373540074</ele>
+				<time>2017-10-09T19:07:31Z</time>
+				<extensions>
+					<speed>0.4481370449066162</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004788651936865" lon="-84.20660760094017">
+				<ele>926.7475373540074</ele>
+				<time>2017-10-09T19:07:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004792537987274" lon="-84.20660725598975">
+				<ele>926.8311455165967</ele>
+				<time>2017-10-09T19:07:33Z</time>
+				<extensions>
+					<speed>0.43277549743652344</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004792537987274" lon="-84.20660725598975">
+				<ele>926.8311455165967</ele>
+				<time>2017-10-09T19:07:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004799047774277" lon="-84.20660863072554">
+				<ele>926.8899330496788</ele>
+				<time>2017-10-09T19:07:35Z</time>
+				<extensions>
+					<speed>0.4274475574493408</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004799047774277" lon="-84.20660863072554">
+				<ele>926.8899330496788</ele>
+				<time>2017-10-09T19:07:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00479441526655" lon="-84.20660497084543">
+				<ele>926.7885767649859</ele>
+				<time>2017-10-09T19:07:37Z</time>
+				<extensions>
+					<speed>0.3205462694168091</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00479441526655" lon="-84.20660497084543">
+				<ele>926.7885767649859</ele>
+				<time>2017-10-09T19:07:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00479441526655" lon="-84.20660497084543">
+				<ele>926.7885767649859</ele>
+				<time>2017-10-09T19:07:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004785227713048" lon="-84.20661450584906">
+				<ele>926.8797464314848</ele>
+				<time>2017-10-09T19:07:40Z</time>
+				<extensions>
+					<speed>0.6120947003364563</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00479441526655" lon="-84.20660497084543">
+				<ele>926.7885767649859</ele>
+				<time>2017-10-09T19:07:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00479441526655" lon="-84.20660497084543">
+				<ele>926.7885767649859</ele>
+				<time>2017-10-09T19:07:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00479441526655" lon="-84.20660497084543">
+				<ele>926.7885767649859</ele>
+				<time>2017-10-09T19:07:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004801398662984" lon="-84.20659766275755">
+				<ele>926.7961973855272</ele>
+				<time>2017-10-09T19:07:44Z</time>
+				<extensions>
+					<speed>0.7893943190574646</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004801968006676" lon="-84.2065950222342">
+				<ele>926.9903908781707</ele>
+				<time>2017-10-09T19:07:45Z</time>
+				<extensions>
+					<speed>1.0182050466537476</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004798937975877" lon="-84.20658441406398">
+				<ele>927.3093634974211</ele>
+				<time>2017-10-09T19:07:46Z</time>
+				<extensions>
+					<speed>1.4792057275772095</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004741999344496" lon="-84.20655495645775">
+				<ele>926.8336299555376</ele>
+				<time>2017-10-09T19:07:47Z</time>
+				<extensions>
+					<speed>2.5882723331451416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004718207105109" lon="-84.20652048198632">
+				<ele>927.3062575506046</ele>
+				<time>2017-10-09T19:07:48Z</time>
+				<extensions>
+					<speed>3.9179534912109375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004692525971906" lon="-84.20648948438787">
+				<ele>927.6593695385382</ele>
+				<time>2017-10-09T19:07:49Z</time>
+				<extensions>
+					<speed>4.300312519073486</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004665259634088" lon="-84.2064572359141">
+				<ele>928.0232498990372</ele>
+				<time>2017-10-09T19:07:50Z</time>
+				<extensions>
+					<speed>4.688260555267334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004624335479274" lon="-84.2064198220078">
+				<ele>928.4286995874718</ele>
+				<time>2017-10-09T19:07:51Z</time>
+				<extensions>
+					<speed>5.124082088470459</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004580496433373" lon="-84.20638079998844">
+				<ele>929.1009637527168</ele>
+				<time>2017-10-09T19:07:52Z</time>
+				<extensions>
+					<speed>5.365095138549805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004528561203045" lon="-84.2063526502077">
+				<ele>929.4164518062025</ele>
+				<time>2017-10-09T19:07:53Z</time>
+				<extensions>
+					<speed>5.549160957336426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004482893048666" lon="-84.20632274217745">
+				<ele>929.8873767061159</ele>
+				<time>2017-10-09T19:07:54Z</time>
+				<extensions>
+					<speed>5.749356746673584</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004436662677772" lon="-84.20629018723017">
+				<ele>930.2789851482958</ele>
+				<time>2017-10-09T19:07:55Z</time>
+				<extensions>
+					<speed>5.905978202819824</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004390383286914" lon="-84.20625730123264">
+				<ele>930.5783076351508</ele>
+				<time>2017-10-09T19:07:56Z</time>
+				<extensions>
+					<speed>5.932387828826904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004349263544349" lon="-84.20622074918396">
+				<ele>930.7897252095863</ele>
+				<time>2017-10-09T19:07:57Z</time>
+				<extensions>
+					<speed>5.870683670043945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004306956168957" lon="-84.20618740562134">
+				<ele>930.9471737965941</ele>
+				<time>2017-10-09T19:07:58Z</time>
+				<extensions>
+					<speed>5.713632106781006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004246251686677" lon="-84.20615394518231">
+				<ele>930.8706222502515</ele>
+				<time>2017-10-09T19:07:59Z</time>
+				<extensions>
+					<speed>5.198155403137207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004217616973403" lon="-84.20613384101733">
+				<ele>931.0307964906096</ele>
+				<time>2017-10-09T19:08:00Z</time>
+				<extensions>
+					<speed>4.688431739807129</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004202211650773" lon="-84.2061143176131">
+				<ele>931.1922553544864</ele>
+				<time>2017-10-09T19:08:01Z</time>
+				<extensions>
+					<speed>4.144956588745117</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0043142745289" lon="-84.20607618747333">
+				<ele>931.6596989985555</ele>
+				<time>2017-10-09T19:08:02Z</time>
+				<extensions>
+					<speed>3.2011802196502686</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004339433951229" lon="-84.20604946704309">
+				<ele>932.0516053847969</ele>
+				<time>2017-10-09T19:08:03Z</time>
+				<extensions>
+					<speed>3.096529245376587</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00435486425567" lon="-84.20602000479082">
+				<ele>932.4628592599183</ele>
+				<time>2017-10-09T19:08:04Z</time>
+				<extensions>
+					<speed>3.2173044681549072</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004367156630215" lon="-84.20598458399942">
+				<ele>932.9047562144697</ele>
+				<time>2017-10-09T19:08:05Z</time>
+				<extensions>
+					<speed>3.3025755882263184</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004389555917284" lon="-84.20595781897333">
+				<ele>933.484944214113</ele>
+				<time>2017-10-09T19:08:06Z</time>
+				<extensions>
+					<speed>3.52124285697937</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004440241566797" lon="-84.20592461906546">
+				<ele>934.7383228791878</ele>
+				<time>2017-10-09T19:08:07Z</time>
+				<extensions>
+					<speed>4.849164962768555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004530944854013" lon="-84.20588178752816">
+				<ele>936.5644417786971</ele>
+				<time>2017-10-09T19:08:08Z</time>
+				<extensions>
+					<speed>4.917259693145752</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004527102993794" lon="-84.2058637581837">
+				<ele>935.7197459619492</ele>
+				<time>2017-10-09T19:08:09Z</time>
+				<extensions>
+					<speed>5.205801963806152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004532543386478" lon="-84.20583955297288">
+				<ele>935.0263916943222</ele>
+				<time>2017-10-09T19:08:10Z</time>
+				<extensions>
+					<speed>5.503633499145508</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004552188268596" lon="-84.205792812876">
+				<ele>935.8043006910011</ele>
+				<time>2017-10-09T19:08:11Z</time>
+				<extensions>
+					<speed>6.13848876953125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004630648422577" lon="-84.2057624044087">
+				<ele>935.4411758333445</ele>
+				<time>2017-10-09T19:08:12Z</time>
+				<extensions>
+					<speed>5.700755596160889</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004673081053229" lon="-84.20571656123458">
+				<ele>935.42884378694</ele>
+				<time>2017-10-09T19:08:13Z</time>
+				<extensions>
+					<speed>5.644661903381348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004706594567534" lon="-84.20566594957045">
+				<ele>936.1006834255531</ele>
+				<time>2017-10-09T19:08:14Z</time>
+				<extensions>
+					<speed>6.624933242797852</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004745737123672" lon="-84.20562351620985">
+				<ele>936.2242889450863</ele>
+				<time>2017-10-09T19:08:15Z</time>
+				<extensions>
+					<speed>6.3675217628479</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004776638101779" lon="-84.20559122903646">
+				<ele>935.4110641013831</ele>
+				<time>2017-10-09T19:08:16Z</time>
+				<extensions>
+					<speed>6.424635410308838</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004829773294384" lon="-84.20555940795087">
+				<ele>934.8800944341347</ele>
+				<time>2017-10-09T19:08:17Z</time>
+				<extensions>
+					<speed>6.563963890075684</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004873101632317" lon="-84.20552343015032">
+				<ele>934.4664860796183</ele>
+				<time>2017-10-09T19:08:18Z</time>
+				<extensions>
+					<speed>6.373650074005127</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00491310585734" lon="-84.20548616897625">
+				<ele>934.5708208438009</ele>
+				<time>2017-10-09T19:08:19Z</time>
+				<extensions>
+					<speed>5.874444484710693</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004925897241499" lon="-84.20546811018421">
+				<ele>932.8864388726652</ele>
+				<time>2017-10-09T19:08:20Z</time>
+				<extensions>
+					<speed>5.180967330932617</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004947544471992" lon="-84.2054431027624">
+				<ele>931.7567794872448</ele>
+				<time>2017-10-09T19:08:21Z</time>
+				<extensions>
+					<speed>4.185370922088623</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004977847741918" lon="-84.20541680964757">
+				<ele>931.4486486790702</ele>
+				<time>2017-10-09T19:08:22Z</time>
+				<extensions>
+					<speed>3.8111369609832764</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004998140356655" lon="-84.20539175978774">
+				<ele>931.0104056606069</ele>
+				<time>2017-10-09T19:08:23Z</time>
+				<extensions>
+					<speed>3.202446222305298</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005013820810344" lon="-84.20537451503368">
+				<ele>930.797049199231</ele>
+				<time>2017-10-09T19:08:24Z</time>
+				<extensions>
+					<speed>2.0388998985290527</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005025609378308" lon="-84.20536879829227">
+				<ele>930.5408933795989</ele>
+				<time>2017-10-09T19:08:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005034352140617" lon="-84.20537099358798">
+				<ele>929.8298989636824</ele>
+				<time>2017-10-09T19:08:26Z</time>
+				<extensions>
+					<speed>0.6018409132957458</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005034352140617" lon="-84.20537099358798">
+				<ele>929.8298989636824</ele>
+				<time>2017-10-09T19:08:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00503552769512" lon="-84.2053775632546">
+				<ele>929.3491018665954</ele>
+				<time>2017-10-09T19:08:28Z</time>
+				<extensions>
+					<speed>1.0611599683761597</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005040352755856" lon="-84.20538579953507">
+				<ele>928.3128193868324</ele>
+				<time>2017-10-09T19:08:29Z</time>
+				<extensions>
+					<speed>1.0670459270477295</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00504135268854" lon="-84.20539088450286">
+				<ele>927.9384868275374</ele>
+				<time>2017-10-09T19:08:30Z</time>
+				<extensions>
+					<speed>0.9065774083137512</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00504135268854" lon="-84.20539088450286">
+				<ele>927.9384868275374</ele>
+				<time>2017-10-09T19:08:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005041256010594" lon="-84.20538925917839">
+				<ele>927.6433294657618</ele>
+				<time>2017-10-09T19:08:32Z</time>
+				<extensions>
+					<speed>0.12250901758670807</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005041256010594" lon="-84.20538925917839">
+				<ele>927.6433294657618</ele>
+				<time>2017-10-09T19:08:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005047468442136" lon="-84.2053800323011">
+				<ele>927.2323340754956</ele>
+				<time>2017-10-09T19:08:34Z</time>
+				<extensions>
+					<speed>1.4913409948349</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005057959633596" lon="-84.2053612085491">
+				<ele>927.2494672155008</ele>
+				<time>2017-10-09T19:08:35Z</time>
+				<extensions>
+					<speed>2.632847309112549</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005075429048594" lon="-84.20533792010798">
+				<ele>927.197791188024</ele>
+				<time>2017-10-09T19:08:36Z</time>
+				<extensions>
+					<speed>3.35137677192688</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00509537201331" lon="-84.20531173344855">
+				<ele>927.5291076144204</ele>
+				<time>2017-10-09T19:08:37Z</time>
+				<extensions>
+					<speed>3.483872652053833</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005117015336223" lon="-84.2052889236489">
+				<ele>927.6916575012729</ele>
+				<time>2017-10-09T19:08:38Z</time>
+				<extensions>
+					<speed>3.273486852645874</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005136936724963" lon="-84.20527729576516">
+				<ele>927.647019866854</ele>
+				<time>2017-10-09T19:08:39Z</time>
+				<extensions>
+					<speed>2.3675663471221924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00515171945258" lon="-84.20526362537903">
+				<ele>927.7420736216009</ele>
+				<time>2017-10-09T19:08:40Z</time>
+				<extensions>
+					<speed>1.7825040817260742</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0051636252276" lon="-84.2052510308712">
+				<ele>927.8350188368931</ele>
+				<time>2017-10-09T19:08:41Z</time>
+				<extensions>
+					<speed>1.065733551979065</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00517141627621" lon="-84.20524162104496">
+				<ele>928.2161878198385</ele>
+				<time>2017-10-09T19:08:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00517141627621" lon="-84.20524162104496">
+				<ele>928.2161878198385</ele>
+				<time>2017-10-09T19:08:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00517141627621" lon="-84.20524162104496">
+				<ele>928.2161878198385</ele>
+				<time>2017-10-09T19:08:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00517141627621" lon="-84.20524162104496">
+				<ele>928.2161878198385</ele>
+				<time>2017-10-09T19:08:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00517141627621" lon="-84.20524162104496">
+				<ele>928.2161878198385</ele>
+				<time>2017-10-09T19:08:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00517141627621" lon="-84.20524162104496">
+				<ele>928.2161878198385</ele>
+				<time>2017-10-09T19:08:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00517141627621" lon="-84.20524162104496">
+				<ele>928.2161878198385</ele>
+				<time>2017-10-09T19:08:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00517141627621" lon="-84.20524162104496">
+				<ele>928.2161878198385</ele>
+				<time>2017-10-09T19:08:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00517141627621" lon="-84.20524162104496">
+				<ele>928.2161878198385</ele>
+				<time>2017-10-09T19:08:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00517141627621" lon="-84.20524162104496">
+				<ele>928.2161878198385</ele>
+				<time>2017-10-09T19:08:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00517141627621" lon="-84.20524162104496">
+				<ele>928.2161878198385</ele>
+				<time>2017-10-09T19:08:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00517141627621" lon="-84.20524162104496">
+				<ele>928.2161878198385</ele>
+				<time>2017-10-09T19:08:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00517141627621" lon="-84.20524162104496">
+				<ele>928.2161878198385</ele>
+				<time>2017-10-09T19:08:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00517141627621" lon="-84.20524162104496">
+				<ele>928.2161878198385</ele>
+				<time>2017-10-09T19:08:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00517141627621" lon="-84.20524162104496">
+				<ele>928.2161878198385</ele>
+				<time>2017-10-09T19:08:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005181480845796" lon="-84.20523579801979">
+				<ele>927.6172818336636</ele>
+				<time>2017-10-09T19:08:57Z</time>
+				<extensions>
+					<speed>0.8721789717674255</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005192967766357" lon="-84.20522997868392">
+				<ele>927.2004633527249</ele>
+				<time>2017-10-09T19:08:58Z</time>
+				<extensions>
+					<speed>1.1299047470092773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005206621001257" lon="-84.20522243558045">
+				<ele>926.8568063350394</ele>
+				<time>2017-10-09T19:08:59Z</time>
+				<extensions>
+					<speed>1.231930136680603</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005219511285683" lon="-84.2052147996984">
+				<ele>926.2746812617406</ele>
+				<time>2017-10-09T19:09:00Z</time>
+				<extensions>
+					<speed>0.8875085115432739</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005219511285683" lon="-84.2052147996984">
+				<ele>926.2746812617406</ele>
+				<time>2017-10-09T19:09:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005226684946514" lon="-84.20521068623054">
+				<ele>925.6953394552693</ele>
+				<time>2017-10-09T19:09:02Z</time>
+				<extensions>
+					<speed>0.5238475203514099</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005226684946514" lon="-84.20521068623054">
+				<ele>925.6953394552693</ele>
+				<time>2017-10-09T19:09:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005237827529044" lon="-84.20520209887474">
+				<ele>925.4728525513783</ele>
+				<time>2017-10-09T19:09:04Z</time>
+				<extensions>
+					<speed>1.2258044481277466</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005250610064838" lon="-84.20519048934437">
+				<ele>925.1788306180388</ele>
+				<time>2017-10-09T19:09:05Z</time>
+				<extensions>
+					<speed>1.6967095136642456</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005262772500473" lon="-84.20517355236308">
+				<ele>924.9136699019</ele>
+				<time>2017-10-09T19:09:06Z</time>
+				<extensions>
+					<speed>2.143758773803711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005274106674705" lon="-84.20515833001855">
+				<ele>924.8973070718348</ele>
+				<time>2017-10-09T19:09:07Z</time>
+				<extensions>
+					<speed>1.7903131246566772</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005287004772166" lon="-84.20513741416225">
+				<ele>924.6016249554232</ele>
+				<time>2017-10-09T19:09:08Z</time>
+				<extensions>
+					<speed>2.4107537269592285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005301834627701" lon="-84.20511198467902">
+				<ele>924.6973356371745</ele>
+				<time>2017-10-09T19:09:09Z</time>
+				<extensions>
+					<speed>3.017076015472412</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00532036548417" lon="-84.2050833733889">
+				<ele>925.0041536428034</ele>
+				<time>2017-10-09T19:09:10Z</time>
+				<extensions>
+					<speed>3.496124267578125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005341572940331" lon="-84.20505960540324">
+				<ele>925.3707951139659</ele>
+				<time>2017-10-09T19:09:11Z</time>
+				<extensions>
+					<speed>3.16294264793396</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005363636635048" lon="-84.20504337924842">
+				<ele>925.886933692731</ele>
+				<time>2017-10-09T19:09:12Z</time>
+				<extensions>
+					<speed>2.400270700454712</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005385091693366" lon="-84.20503230477597">
+				<ele>925.9916090564802</ele>
+				<time>2017-10-09T19:09:13Z</time>
+				<extensions>
+					<speed>2.0154213905334473</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005404696559127" lon="-84.20501937248582">
+				<ele>925.8135112319142</ele>
+				<time>2017-10-09T19:09:14Z</time>
+				<extensions>
+					<speed>1.8779710531234741</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005420774851713" lon="-84.20500536750683">
+				<ele>925.9917473811656</ele>
+				<time>2017-10-09T19:09:15Z</time>
+				<extensions>
+					<speed>1.8311482667922974</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005436742414531" lon="-84.20499075728384">
+				<ele>926.2519867010415</ele>
+				<time>2017-10-09T19:09:16Z</time>
+				<extensions>
+					<speed>2.3043477535247803</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005458761373507" lon="-84.20497175814033">
+				<ele>926.1406248519197</ele>
+				<time>2017-10-09T19:09:17Z</time>
+				<extensions>
+					<speed>2.866532325744629</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00548316054155" lon="-84.2049450903066">
+				<ele>926.1933373743668</ele>
+				<time>2017-10-09T19:09:18Z</time>
+				<extensions>
+					<speed>3.314100980758667</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005507575249895" lon="-84.20491614556211">
+				<ele>925.766986625269</ele>
+				<time>2017-10-09T19:09:19Z</time>
+				<extensions>
+					<speed>3.4324028491973877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005528874236306" lon="-84.20488610702537">
+				<ele>925.6922005275264</ele>
+				<time>2017-10-09T19:09:20Z</time>
+				<extensions>
+					<speed>3.433941125869751</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005548852976023" lon="-84.20486103913824">
+				<ele>925.4746400322765</ele>
+				<time>2017-10-09T19:09:21Z</time>
+				<extensions>
+					<speed>3.315680980682373</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005568960957618" lon="-84.2048335773064">
+				<ele>925.0443351054564</ele>
+				<time>2017-10-09T19:09:22Z</time>
+				<extensions>
+					<speed>3.430119037628174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00559074159325" lon="-84.20479999760583">
+				<ele>924.9090889394283</ele>
+				<time>2017-10-09T19:09:23Z</time>
+				<extensions>
+					<speed>3.879006862640381</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005614266539416" lon="-84.20476599347187">
+				<ele>925.0250613447279</ele>
+				<time>2017-10-09T19:09:24Z</time>
+				<extensions>
+					<speed>4.1002702713012695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005640263163135" lon="-84.20472862094462">
+				<ele>925.5800142083317</ele>
+				<time>2017-10-09T19:09:25Z</time>
+				<extensions>
+					<speed>4.174018859863281</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005670775527072" lon="-84.20469255915268">
+				<ele>926.669686473906</ele>
+				<time>2017-10-09T19:09:26Z</time>
+				<extensions>
+					<speed>4.464652061462402</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005706953814025" lon="-84.20465496912848">
+				<ele>927.3659426476806</ele>
+				<time>2017-10-09T19:09:27Z</time>
+				<extensions>
+					<speed>4.927883148193359</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00574142486531" lon="-84.20461597780239">
+				<ele>928.0637750113383</ele>
+				<time>2017-10-09T19:09:28Z</time>
+				<extensions>
+					<speed>5.242468357086182</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005777506071926" lon="-84.2045713577303">
+				<ele>928.5484128762037</ele>
+				<time>2017-10-09T19:09:29Z</time>
+				<extensions>
+					<speed>5.480102062225342</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005813674376844" lon="-84.20452603895828">
+				<ele>928.7399718761444</ele>
+				<time>2017-10-09T19:09:30Z</time>
+				<extensions>
+					<speed>5.391238212585449</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005845638353183" lon="-84.20448384201734">
+				<ele>929.3329795822501</ele>
+				<time>2017-10-09T19:09:31Z</time>
+				<extensions>
+					<speed>5.360940456390381</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005876753264943" lon="-84.20444786977217">
+				<ele>929.9004121469334</ele>
+				<time>2017-10-09T19:09:32Z</time>
+				<extensions>
+					<speed>4.777322769165039</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005903625342253" lon="-84.20441570354004">
+				<ele>930.0856012227014</ele>
+				<time>2017-10-09T19:09:33Z</time>
+				<extensions>
+					<speed>4.031122207641602</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00592694487021" lon="-84.20439390984158">
+				<ele>930.3708841204643</ele>
+				<time>2017-10-09T19:09:34Z</time>
+				<extensions>
+					<speed>2.91530442237854</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005938498316702" lon="-84.20438409918876">
+				<ele>930.7054223353043</ele>
+				<time>2017-10-09T19:09:35Z</time>
+				<extensions>
+					<speed>0.7092798352241516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0059486505149" lon="-84.20438748583335">
+				<ele>930.322468586266</ele>
+				<time>2017-10-09T19:09:36Z</time>
+				<extensions>
+					<speed>0.5429155826568604</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005956010292843" lon="-84.2043960625358">
+				<ele>930.1147762164474</ele>
+				<time>2017-10-09T19:09:37Z</time>
+				<extensions>
+					<speed>1.0897279977798462</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00595716858886" lon="-84.20440734509975">
+				<ele>930.1739815250039</ele>
+				<time>2017-10-09T19:09:38Z</time>
+				<extensions>
+					<speed>1.274920105934143</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00595476277055" lon="-84.20441820454896">
+				<ele>930.1356583461165</ele>
+				<time>2017-10-09T19:09:39Z</time>
+				<extensions>
+					<speed>1.5376355648040771</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00595073441607" lon="-84.20442982452825">
+				<ele>930.5973904011771</ele>
+				<time>2017-10-09T19:09:40Z</time>
+				<extensions>
+					<speed>1.580413818359375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0059456065366" lon="-84.20443714415956">
+				<ele>931.1391177847981</ele>
+				<time>2017-10-09T19:09:41Z</time>
+				<extensions>
+					<speed>1.1309760808944702</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005940344581887" lon="-84.20444711324825">
+				<ele>931.4697174727917</ele>
+				<time>2017-10-09T19:09:42Z</time>
+				<extensions>
+					<speed>1.3775770664215088</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005934119537084" lon="-84.2044641673816">
+				<ele>931.5807942925021</ele>
+				<time>2017-10-09T19:09:43Z</time>
+				<extensions>
+					<speed>1.97780442237854</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005927539276717" lon="-84.20447246488864">
+				<ele>931.8642356386408</ele>
+				<time>2017-10-09T19:09:44Z</time>
+				<extensions>
+					<speed>1.6089638471603394</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005924460579521" lon="-84.2044710239156">
+				<ele>931.9197387350723</ele>
+				<time>2017-10-09T19:09:45Z</time>
+				<extensions>
+					<speed>0.5929441452026367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005924088329312" lon="-84.20446288383039">
+				<ele>931.9340284271166</ele>
+				<time>2017-10-09T19:09:46Z</time>
+				<extensions>
+					<speed>1.16177237033844</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00593033546157" lon="-84.20444575129461">
+				<ele>932.3714476339519</ele>
+				<time>2017-10-09T19:09:47Z</time>
+				<extensions>
+					<speed>2.0646543502807617</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005940248328498" lon="-84.20441904864731">
+				<ele>933.1920078853145</ele>
+				<time>2017-10-09T19:09:48Z</time>
+				<extensions>
+					<speed>3.1738948822021484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00595713854807" lon="-84.2043903598559">
+				<ele>934.015042967163</ele>
+				<time>2017-10-09T19:09:49Z</time>
+				<extensions>
+					<speed>3.8200790882110596</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005981299580485" lon="-84.20436145952972">
+				<ele>934.3269678298384</ele>
+				<time>2017-10-09T19:09:50Z</time>
+				<extensions>
+					<speed>4.1833086013793945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0060059880386" lon="-84.20433020199893">
+				<ele>934.257760502398</ele>
+				<time>2017-10-09T19:09:51Z</time>
+				<extensions>
+					<speed>4.3986029624938965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006028787449143" lon="-84.20429846702298">
+				<ele>934.0578117538244</ele>
+				<time>2017-10-09T19:09:52Z</time>
+				<extensions>
+					<speed>4.393073081970215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006053344966208" lon="-84.2042607126519">
+				<ele>934.2635204140097</ele>
+				<time>2017-10-09T19:09:53Z</time>
+				<extensions>
+					<speed>4.871049880981445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006084034436109" lon="-84.20422603689927">
+				<ele>934.6854534689337</ele>
+				<time>2017-10-09T19:09:54Z</time>
+				<extensions>
+					<speed>4.89054536819458</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006116043950941" lon="-84.20419040507574">
+				<ele>934.6746583422646</ele>
+				<time>2017-10-09T19:09:55Z</time>
+				<extensions>
+					<speed>4.794078826904297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006146939752092" lon="-84.20416003107344">
+				<ele>934.7265271954238</ele>
+				<time>2017-10-09T19:09:56Z</time>
+				<extensions>
+					<speed>4.193779468536377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006163917318403" lon="-84.20412994611308">
+				<ele>934.4674995131791</ele>
+				<time>2017-10-09T19:09:57Z</time>
+				<extensions>
+					<speed>3.645260810852051</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00617932923747" lon="-84.20409933217212">
+				<ele>934.3452490214258</ele>
+				<time>2017-10-09T19:09:58Z</time>
+				<extensions>
+					<speed>3.0332131385803223</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006206884237953" lon="-84.20407466755769">
+				<ele>932.9672314533964</ele>
+				<time>2017-10-09T19:09:59Z</time>
+				<extensions>
+					<speed>2.2711703777313232</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006232090451954" lon="-84.20405553929203">
+				<ele>932.1806041169912</ele>
+				<time>2017-10-09T19:10:00Z</time>
+				<extensions>
+					<speed>2.924372434616089</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006267711770686" lon="-84.20404149805938">
+				<ele>931.1424974743277</ele>
+				<time>2017-10-09T19:10:01Z</time>
+				<extensions>
+					<speed>3.1965572834014893</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00630352832989" lon="-84.20403694649262">
+				<ele>930.4185256930068</ele>
+				<time>2017-10-09T19:10:02Z</time>
+				<extensions>
+					<speed>3.0993785858154297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006348800817204" lon="-84.20404975166198">
+				<ele>928.7752490732819</ele>
+				<time>2017-10-09T19:10:03Z</time>
+				<extensions>
+					<speed>4.349489688873291</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00639149584172" lon="-84.20406990383718">
+				<ele>928.4075752822682</ele>
+				<time>2017-10-09T19:10:04Z</time>
+				<extensions>
+					<speed>5.47795295715332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006437914821454" lon="-84.20409675179381">
+				<ele>928.9009993923828</ele>
+				<time>2017-10-09T19:10:05Z</time>
+				<extensions>
+					<speed>7.06520938873291</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006485953767763" lon="-84.2041337676427">
+				<ele>929.9555094446987</ele>
+				<time>2017-10-09T19:10:06Z</time>
+				<extensions>
+					<speed>7.320315361022949</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006533846503007" lon="-84.20417520079884">
+				<ele>931.2674630684778</ele>
+				<time>2017-10-09T19:10:07Z</time>
+				<extensions>
+					<speed>7.640885353088379</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006581788773659" lon="-84.20421505487366">
+				<ele>932.1664848737419</ele>
+				<time>2017-10-09T19:10:08Z</time>
+				<extensions>
+					<speed>7.7695722579956055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006630740957828" lon="-84.20426066533267">
+				<ele>932.9015827542171</ele>
+				<time>2017-10-09T19:10:09Z</time>
+				<extensions>
+					<speed>8.23143196105957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006688401397545" lon="-84.20431021470709">
+				<ele>933.3358806939796</ele>
+				<time>2017-10-09T19:10:10Z</time>
+				<extensions>
+					<speed>8.58157730102539</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006746031157734" lon="-84.20436263937971">
+				<ele>933.4891632329673</ele>
+				<time>2017-10-09T19:10:11Z</time>
+				<extensions>
+					<speed>8.52245807647705</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006807722332614" lon="-84.2044182105388">
+				<ele>933.5683478834108</ele>
+				<time>2017-10-09T19:10:12Z</time>
+				<extensions>
+					<speed>8.98119831085205</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006871900234417" lon="-84.20447936860548">
+				<ele>933.853402021341</ele>
+				<time>2017-10-09T19:10:13Z</time>
+				<extensions>
+					<speed>9.51385498046875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006936251019864" lon="-84.20454125992818">
+				<ele>933.8574393736199</ele>
+				<time>2017-10-09T19:10:14Z</time>
+				<extensions>
+					<speed>9.428365707397461</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006997107095758" lon="-84.20460079266732">
+				<ele>934.1282436922193</ele>
+				<time>2017-10-09T19:10:15Z</time>
+				<extensions>
+					<speed>8.879414558410645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007048197806307" lon="-84.20465446491093">
+				<ele>934.2605567956343</ele>
+				<time>2017-10-09T19:10:16Z</time>
+				<extensions>
+					<speed>7.8658599853515625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007093013799423" lon="-84.2047018159844">
+				<ele>934.2316125603393</ele>
+				<time>2017-10-09T19:10:17Z</time>
+				<extensions>
+					<speed>5.905035972595215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007129823642135" lon="-84.20473547089674">
+				<ele>934.4817350404337</ele>
+				<time>2017-10-09T19:10:18Z</time>
+				<extensions>
+					<speed>4.3905510902404785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00715809296081" lon="-84.20475828450027">
+				<ele>934.391981757246</ele>
+				<time>2017-10-09T19:10:19Z</time>
+				<extensions>
+					<speed>3.444040060043335</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007186399584393" lon="-84.20477524761516">
+				<ele>934.2816724525765</ele>
+				<time>2017-10-09T19:10:20Z</time>
+				<extensions>
+					<speed>2.9670569896698</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007216517166743" lon="-84.20478838138024">
+				<ele>934.2220439007506</ele>
+				<time>2017-10-09T19:10:21Z</time>
+				<extensions>
+					<speed>3.222656011581421</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007247964413784" lon="-84.20479959806282">
+				<ele>934.5277380682528</ele>
+				<time>2017-10-09T19:10:22Z</time>
+				<extensions>
+					<speed>3.281576156616211</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007269636723157" lon="-84.20478533536492">
+				<ele>934.8313883626834</ele>
+				<time>2017-10-09T19:10:23Z</time>
+				<extensions>
+					<speed>2.8232545852661133</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007305841007888" lon="-84.20477157522735">
+				<ele>934.874404238537</ele>
+				<time>2017-10-09T19:10:24Z</time>
+				<extensions>
+					<speed>3.6892409324645996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007338685099038" lon="-84.20476166878686">
+				<ele>934.8724966431037</ele>
+				<time>2017-10-09T19:10:25Z</time>
+				<extensions>
+					<speed>3.270848512649536</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007368236592551" lon="-84.20473384469666">
+				<ele>934.3315832996741</ele>
+				<time>2017-10-09T19:10:26Z</time>
+				<extensions>
+					<speed>5.185964584350586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00738242365788" lon="-84.20469427969259">
+				<ele>934.5339193725958</ele>
+				<time>2017-10-09T19:10:27Z</time>
+				<extensions>
+					<speed>4.715719699859619</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00738185395789" lon="-84.20464929804484">
+				<ele>934.4132235031575</ele>
+				<time>2017-10-09T19:10:28Z</time>
+				<extensions>
+					<speed>4.203785419464111</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007370930762383" lon="-84.2046099297407">
+				<ele>934.7738240184262</ele>
+				<time>2017-10-09T19:10:29Z</time>
+				<extensions>
+					<speed>2.7975738048553467</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007368108155584" lon="-84.20458124202777">
+				<ele>935.0650307582691</ele>
+				<time>2017-10-09T19:10:30Z</time>
+				<extensions>
+					<speed>1.559909701347351</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007359053139602" lon="-84.20455936947437">
+				<ele>935.6397448172793</ele>
+				<time>2017-10-09T19:10:31Z</time>
+				<extensions>
+					<speed>0.1064426526427269</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007356812421218" lon="-84.20455293489526">
+				<ele>935.8621327541769</ele>
+				<time>2017-10-09T19:10:32Z</time>
+				<extensions>
+					<speed>0.42003893852233887</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007356812421218" lon="-84.20455293489526">
+				<ele>935.8621327541769</ele>
+				<time>2017-10-09T19:10:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007349493482561" lon="-84.20455090135331">
+				<ele>935.9853195622563</ele>
+				<time>2017-10-09T19:10:34Z</time>
+				<extensions>
+					<speed>0.9060587882995605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007345359715117" lon="-84.20454957568582">
+				<ele>935.9634385369718</ele>
+				<time>2017-10-09T19:10:35Z</time>
+				<extensions>
+					<speed>1.2041492462158203</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00733431049005" lon="-84.20454076584257">
+				<ele>936.3157251430675</ele>
+				<time>2017-10-09T19:10:36Z</time>
+				<extensions>
+					<speed>1.0641611814498901</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007318089007038" lon="-84.20453341817006">
+				<ele>936.732913011685</ele>
+				<time>2017-10-09T19:10:37Z</time>
+				<extensions>
+					<speed>1.107136607170105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00730789340465" lon="-84.20452595263555">
+				<ele>937.266834541224</ele>
+				<time>2017-10-09T19:10:38Z</time>
+				<extensions>
+					<speed>0.4992566406726837</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00730789340465" lon="-84.20452595263555">
+				<ele>937.266834541224</ele>
+				<time>2017-10-09T19:10:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007314042994883" lon="-84.20451331334208">
+				<ele>937.7946045128629</ele>
+				<time>2017-10-09T19:10:40Z</time>
+				<extensions>
+					<speed>1.9578455686569214</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007326125013016" lon="-84.2044931318099">
+				<ele>938.8762903735042</ele>
+				<time>2017-10-09T19:10:41Z</time>
+				<extensions>
+					<speed>2.920903444290161</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007346045270216" lon="-84.20446883040549">
+				<ele>939.5029628975317</ele>
+				<time>2017-10-09T19:10:42Z</time>
+				<extensions>
+					<speed>3.7065303325653076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007370394256844" lon="-84.20443801362545">
+				<ele>939.873297647573</ele>
+				<time>2017-10-09T19:10:43Z</time>
+				<extensions>
+					<speed>4.375831127166748</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007400421736383" lon="-84.20439819424355">
+				<ele>940.0562043013051</ele>
+				<time>2017-10-09T19:10:44Z</time>
+				<extensions>
+					<speed>5.580565929412842</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007437266291673" lon="-84.20436297067708">
+				<ele>940.3696779469028</ele>
+				<time>2017-10-09T19:10:45Z</time>
+				<extensions>
+					<speed>5.539623737335205</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007475789074325" lon="-84.2043281026949">
+				<ele>940.8666510963812</ele>
+				<time>2017-10-09T19:10:46Z</time>
+				<extensions>
+					<speed>5.737645626068115</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007515609450463" lon="-84.20428817574431">
+				<ele>941.0326025886461</ele>
+				<time>2017-10-09T19:10:47Z</time>
+				<extensions>
+					<speed>6.244999885559082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007558322942106" lon="-84.20424714076715">
+				<ele>940.974804289639</ele>
+				<time>2017-10-09T19:10:48Z</time>
+				<extensions>
+					<speed>6.7492899894714355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007609069324785" lon="-84.20420667572641">
+				<ele>940.7030671825632</ele>
+				<time>2017-10-09T19:10:49Z</time>
+				<extensions>
+					<speed>7.328999042510986</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007658672855232" lon="-84.20416109345301">
+				<ele>940.9954109461978</ele>
+				<time>2017-10-09T19:10:50Z</time>
+				<extensions>
+					<speed>7.816037178039551</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007711007112988" lon="-84.2041154132929">
+				<ele>941.0484037259594</ele>
+				<time>2017-10-09T19:10:51Z</time>
+				<extensions>
+					<speed>7.718181610107422</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007761702963998" lon="-84.20407283588614">
+				<ele>941.4953410932794</ele>
+				<time>2017-10-09T19:10:52Z</time>
+				<extensions>
+					<speed>7.65074348449707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00781760818848" lon="-84.20402999639515">
+				<ele>941.6997873876244</ele>
+				<time>2017-10-09T19:10:53Z</time>
+				<extensions>
+					<speed>7.923022270202637</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007871082332366" lon="-84.20398885513448">
+				<ele>942.1034851791337</ele>
+				<time>2017-10-09T19:10:54Z</time>
+				<extensions>
+					<speed>7.7227020263671875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007923260221087" lon="-84.20395390653842">
+				<ele>942.7074741460383</ele>
+				<time>2017-10-09T19:10:55Z</time>
+				<extensions>
+					<speed>7.153937816619873</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007972909020312" lon="-84.20392119190954">
+				<ele>943.0212834328413</ele>
+				<time>2017-10-09T19:10:56Z</time>
+				<extensions>
+					<speed>6.759064674377441</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008024663179162" lon="-84.20387699805443">
+				<ele>943.1266659591347</ele>
+				<time>2017-10-09T19:10:57Z</time>
+				<extensions>
+					<speed>7.618774890899658</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008073784502228" lon="-84.20382798213056">
+				<ele>943.4499043198302</ele>
+				<time>2017-10-09T19:10:58Z</time>
+				<extensions>
+					<speed>7.91090726852417</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008123710926426" lon="-84.20377414187543">
+				<ele>943.7835621479899</ele>
+				<time>2017-10-09T19:10:59Z</time>
+				<extensions>
+					<speed>8.282282829284668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008179754265601" lon="-84.2037228335109">
+				<ele>944.0236322581768</ele>
+				<time>2017-10-09T19:11:00Z</time>
+				<extensions>
+					<speed>8.424422264099121</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008235073154415" lon="-84.20367494950064">
+				<ele>943.8880053618923</ele>
+				<time>2017-10-09T19:11:01Z</time>
+				<extensions>
+					<speed>8.074644088745117</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008292787066098" lon="-84.20363522163072">
+				<ele>943.736366272904</ele>
+				<time>2017-10-09T19:11:02Z</time>
+				<extensions>
+					<speed>7.326632976531982</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008342199971489" lon="-84.20359768145349">
+				<ele>943.9809845276177</ele>
+				<time>2017-10-09T19:11:03Z</time>
+				<extensions>
+					<speed>6.39258337020874</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008382504669779" lon="-84.2035666947586">
+				<ele>944.018216073513</ele>
+				<time>2017-10-09T19:11:04Z</time>
+				<extensions>
+					<speed>5.113117218017578</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008405358235494" lon="-84.20355267017392">
+				<ele>944.2320336233824</ele>
+				<time>2017-10-09T19:11:05Z</time>
+				<extensions>
+					<speed>2.493018865585327</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008422795602172" lon="-84.20354320481741">
+				<ele>944.4155767243356</ele>
+				<time>2017-10-09T19:11:06Z</time>
+				<extensions>
+					<speed>1.5472813844680786</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008435906360836" lon="-84.2035377590556">
+				<ele>943.8453593663871</ele>
+				<time>2017-10-09T19:11:07Z</time>
+				<extensions>
+					<speed>1.1790632009506226</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008448261652099" lon="-84.20353130360353">
+				<ele>943.0325719015673</ele>
+				<time>2017-10-09T19:11:08Z</time>
+				<extensions>
+					<speed>1.1570805311203003</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00846240870425" lon="-84.20351384846504">
+				<ele>942.458902778104</ele>
+				<time>2017-10-09T19:11:09Z</time>
+				<extensions>
+					<speed>2.6848442554473877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008479988206927" lon="-84.20348923360946">
+				<ele>942.588531203568</ele>
+				<time>2017-10-09T19:11:10Z</time>
+				<extensions>
+					<speed>3.4620399475097656</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008506327690904" lon="-84.20346548613607">
+				<ele>943.1182336425409</ele>
+				<time>2017-10-09T19:11:11Z</time>
+				<extensions>
+					<speed>4.522524356842041</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008540304853142" lon="-84.20343563374523">
+				<ele>943.9536673985422</ele>
+				<time>2017-10-09T19:11:12Z</time>
+				<extensions>
+					<speed>5.487604141235352</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008579429128075" lon="-84.20340325216193">
+				<ele>944.7788930889219</ele>
+				<time>2017-10-09T19:11:13Z</time>
+				<extensions>
+					<speed>5.848306655883789</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008620240576615" lon="-84.20336800921451">
+				<ele>945.9758551903069</ele>
+				<time>2017-10-09T19:11:14Z</time>
+				<extensions>
+					<speed>6.147212505340576</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662394796927" lon="-84.20333128485774">
+				<ele>946.9474863065407</ele>
+				<time>2017-10-09T19:11:15Z</time>
+				<extensions>
+					<speed>6.244912624359131</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008705995215227" lon="-84.2032936598422">
+				<ele>947.6382923517376</ele>
+				<time>2017-10-09T19:11:16Z</time>
+				<extensions>
+					<speed>6.3550825119018555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008750923973786" lon="-84.2032589836992">
+				<ele>947.5811385260895</ele>
+				<time>2017-10-09T19:11:17Z</time>
+				<extensions>
+					<speed>5.98269510269165</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008794682722908" lon="-84.20322575030539">
+				<ele>947.0053596990183</ele>
+				<time>2017-10-09T19:11:18Z</time>
+				<extensions>
+					<speed>5.31918478012085</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00883079576803" lon="-84.20319857360178">
+				<ele>946.7865684619173</ele>
+				<time>2017-10-09T19:11:19Z</time>
+				<extensions>
+					<speed>4.446110248565674</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008857977698934" lon="-84.2031801490973">
+				<ele>946.5837906347588</ele>
+				<time>2017-10-09T19:11:20Z</time>
+				<extensions>
+					<speed>3.1096818447113037</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008873019570096" lon="-84.20316831891864">
+				<ele>946.198111416772</ele>
+				<time>2017-10-09T19:11:21Z</time>
+				<extensions>
+					<speed>1.4905213117599487</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008878399772321" lon="-84.2031666020374">
+				<ele>945.871002140455</ele>
+				<time>2017-10-09T19:11:22Z</time>
+				<extensions>
+					<speed>0.6506787538528442</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008878399772321" lon="-84.2031666020374">
+				<ele>945.871002140455</ele>
+				<time>2017-10-09T19:11:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008874503302497" lon="-84.2031735710451">
+				<ele>945.613081170246</ele>
+				<time>2017-10-09T19:11:24Z</time>
+				<extensions>
+					<speed>0.9049067497253418</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008865736166001" lon="-84.20318156142254">
+				<ele>946.1609540292993</ele>
+				<time>2017-10-09T19:11:25Z</time>
+				<extensions>
+					<speed>1.0301990509033203</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008863120364088" lon="-84.20318383805423">
+				<ele>945.8035513777286</ele>
+				<time>2017-10-09T19:11:26Z</time>
+				<extensions>
+					<speed>0.8199455142021179</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008863120364088" lon="-84.20318383805423">
+				<ele>945.8035513777286</ele>
+				<time>2017-10-09T19:11:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008864791546525" lon="-84.20318431501687">
+				<ele>945.78736525774</ele>
+				<time>2017-10-09T19:11:28Z</time>
+				<extensions>
+					<speed>0.12663902342319489</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008864791546525" lon="-84.20318431501687">
+				<ele>945.78736525774</ele>
+				<time>2017-10-09T19:11:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008875773790628" lon="-84.20317369144527">
+				<ele>946.0969348102808</ele>
+				<time>2017-10-09T19:11:30Z</time>
+				<extensions>
+					<speed>2.2145252227783203</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008895784043899" lon="-84.20315933401255">
+				<ele>946.0968920523301</ele>
+				<time>2017-10-09T19:11:31Z</time>
+				<extensions>
+					<speed>2.982905864715576</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00892084810337" lon="-84.20313921134523">
+				<ele>946.6106513999403</ele>
+				<time>2017-10-09T19:11:32Z</time>
+				<extensions>
+					<speed>3.9015796184539795</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008951291825673" lon="-84.20311486472299">
+				<ele>947.0377056002617</ele>
+				<time>2017-10-09T19:11:33Z</time>
+				<extensions>
+					<speed>4.573650360107422</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008984567414343" lon="-84.20308810490488">
+				<ele>947.1243610223755</ele>
+				<time>2017-10-09T19:11:34Z</time>
+				<extensions>
+					<speed>4.75533390045166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009019645045525" lon="-84.20306196742203">
+				<ele>946.8303688913584</ele>
+				<time>2017-10-09T19:11:35Z</time>
+				<extensions>
+					<speed>4.5314507484436035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009049440627637" lon="-84.20303867636785">
+				<ele>946.4733128547668</ele>
+				<time>2017-10-09T19:11:36Z</time>
+				<extensions>
+					<speed>3.783839464187622</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009069619240194" lon="-84.20302353253895">
+				<ele>946.1743935728446</ele>
+				<time>2017-10-09T19:11:37Z</time>
+				<extensions>
+					<speed>2.220778703689575</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009083206656294" lon="-84.203013128963">
+				<ele>946.1912755481899</ele>
+				<time>2017-10-09T19:11:38Z</time>
+				<extensions>
+					<speed>1.6175121068954468</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009098292211158" lon="-84.20299791246562">
+				<ele>946.0645102215931</ele>
+				<time>2017-10-09T19:11:39Z</time>
+				<extensions>
+					<speed>2.1207780838012695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009113154555001" lon="-84.20297938267225">
+				<ele>946.0870927479118</ele>
+				<time>2017-10-09T19:11:40Z</time>
+				<extensions>
+					<speed>2.3415441513061523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009129496788429" lon="-84.20296129251177">
+				<ele>946.2637671846896</ele>
+				<time>2017-10-09T19:11:41Z</time>
+				<extensions>
+					<speed>2.573580741882324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009146931105574" lon="-84.20294379327441">
+				<ele>946.455921093002</ele>
+				<time>2017-10-09T19:11:42Z</time>
+				<extensions>
+					<speed>2.663386106491089</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009166128254034" lon="-84.20292376598464">
+				<ele>946.5957512771711</ele>
+				<time>2017-10-09T19:11:43Z</time>
+				<extensions>
+					<speed>2.934462547302246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009193233010606" lon="-84.20290244500302">
+				<ele>946.9118445785716</ele>
+				<time>2017-10-09T19:11:44Z</time>
+				<extensions>
+					<speed>3.380523920059204</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00922714708796" lon="-84.2028793109178">
+				<ele>947.1939804563299</ele>
+				<time>2017-10-09T19:11:45Z</time>
+				<extensions>
+					<speed>4.025445938110352</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009273351183841" lon="-84.20285424353312">
+				<ele>947.5784359974787</ele>
+				<time>2017-10-09T19:11:46Z</time>
+				<extensions>
+					<speed>5.159853935241699</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009317346432237" lon="-84.20281978035443">
+				<ele>947.7980060949922</ele>
+				<time>2017-10-09T19:11:47Z</time>
+				<extensions>
+					<speed>5.621939182281494</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009371651863464" lon="-84.2027678733892">
+				<ele>948.5759242568165</ele>
+				<time>2017-10-09T19:11:48Z</time>
+				<extensions>
+					<speed>6.6156768798828125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009425398158045" lon="-84.20272948709244">
+				<ele>948.8872925182804</ele>
+				<time>2017-10-09T19:11:49Z</time>
+				<extensions>
+					<speed>7.290359973907471</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009477835608518" lon="-84.20268989587748">
+				<ele>949.1435494944453</ele>
+				<time>2017-10-09T19:11:50Z</time>
+				<extensions>
+					<speed>7.307359218597412</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009536674909564" lon="-84.20265285454558">
+				<ele>949.2910831673071</ele>
+				<time>2017-10-09T19:11:51Z</time>
+				<extensions>
+					<speed>7.439323425292969</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009590007825217" lon="-84.2026129193793">
+				<ele>949.5839996607974</ele>
+				<time>2017-10-09T19:11:52Z</time>
+				<extensions>
+					<speed>7.333093643188477</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009645047718172" lon="-84.20257519244666">
+				<ele>949.7134221522138</ele>
+				<time>2017-10-09T19:11:53Z</time>
+				<extensions>
+					<speed>7.3120222091674805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00969719990947" lon="-84.20254078578195">
+				<ele>949.7789669530466</ele>
+				<time>2017-10-09T19:11:54Z</time>
+				<extensions>
+					<speed>7.168537616729736</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009745340802395" lon="-84.20250179228516">
+				<ele>949.9582988740876</ele>
+				<time>2017-10-09T19:11:55Z</time>
+				<extensions>
+					<speed>7.052173614501953</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00978561211482" lon="-84.20246080028605">
+				<ele>950.0477888220921</ele>
+				<time>2017-10-09T19:11:56Z</time>
+				<extensions>
+					<speed>6.573506832122803</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009811852729346" lon="-84.20244148449565">
+				<ele>949.8348698690534</ele>
+				<time>2017-10-09T19:11:57Z</time>
+				<extensions>
+					<speed>5.077152252197266</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009833670847566" lon="-84.20242635303745">
+				<ele>949.9492485374212</ele>
+				<time>2017-10-09T19:11:58Z</time>
+				<extensions>
+					<speed>3.2994747161865234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009835805269567" lon="-84.20242711535747">
+				<ele>949.4178271051496</ele>
+				<time>2017-10-09T19:11:59Z</time>
+				<extensions>
+					<speed>0.07379735261201859</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009832117316819" lon="-84.20243071719477">
+				<ele>948.7345657721162</ele>
+				<time>2017-10-09T19:12:00Z</time>
+				<extensions>
+					<speed>0.9769428968429565</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009832117316819" lon="-84.20243071719477">
+				<ele>948.7345657721162</ele>
+				<time>2017-10-09T19:12:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00983141875004" lon="-84.20243682806773">
+				<ele>948.7660000063479</ele>
+				<time>2017-10-09T19:12:02Z</time>
+				<extensions>
+					<speed>0.7231156229972839</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00983141875004" lon="-84.20243682806773">
+				<ele>948.7660000063479</ele>
+				<time>2017-10-09T19:12:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009854004415015" lon="-84.20243766068657">
+				<ele>948.5255144461989</ele>
+				<time>2017-10-09T19:12:04Z</time>
+				<extensions>
+					<speed>2.1205146312713623</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009884845333648" lon="-84.20242670510123">
+				<ele>948.3213434386998</ele>
+				<time>2017-10-09T19:12:05Z</time>
+				<extensions>
+					<speed>3.490058422088623</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009920550315975" lon="-84.20241077508317">
+				<ele>948.3490791209042</ele>
+				<time>2017-10-09T19:12:06Z</time>
+				<extensions>
+					<speed>4.010841369628906</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009958235654539" lon="-84.20238818422605">
+				<ele>948.5380223980173</ele>
+				<time>2017-10-09T19:12:07Z</time>
+				<extensions>
+					<speed>5.188947677612305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010000662050894" lon="-84.20235518538317">
+				<ele>948.2987019224092</ele>
+				<time>2017-10-09T19:12:08Z</time>
+				<extensions>
+					<speed>5.400531768798828</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010045952204049" lon="-84.20231338304635">
+				<ele>947.8516347603872</ele>
+				<time>2017-10-09T19:12:09Z</time>
+				<extensions>
+					<speed>6.1495585441589355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01009365959578" lon="-84.20226386047038">
+				<ele>947.4205095181242</ele>
+				<time>2017-10-09T19:12:10Z</time>
+				<extensions>
+					<speed>6.966073989868164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010139708190172" lon="-84.20221910180452">
+				<ele>947.5517420433462</ele>
+				<time>2017-10-09T19:12:11Z</time>
+				<extensions>
+					<speed>7.0795440673828125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010190508065381" lon="-84.20217268069743">
+				<ele>947.7583007020876</ele>
+				<time>2017-10-09T19:12:12Z</time>
+				<extensions>
+					<speed>7.361756324768066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01025564076124" lon="-84.20211665477723">
+				<ele>947.753505056724</ele>
+				<time>2017-10-09T19:12:13Z</time>
+				<extensions>
+					<speed>8.663975715637207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010317426617467" lon="-84.20206621593012">
+				<ele>947.3675074521452</ele>
+				<time>2017-10-09T19:12:14Z</time>
+				<extensions>
+					<speed>8.723135948181152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010388039814984" lon="-84.20201374067783">
+				<ele>947.0539161656052</ele>
+				<time>2017-10-09T19:12:15Z</time>
+				<extensions>
+					<speed>9.309136390686035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010463077122735" lon="-84.20196034374968">
+				<ele>946.9699727389961</ele>
+				<time>2017-10-09T19:12:16Z</time>
+				<extensions>
+					<speed>9.936391830444336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010540445947584" lon="-84.20190950617136">
+				<ele>946.8340876335278</ele>
+				<time>2017-10-09T19:12:17Z</time>
+				<extensions>
+					<speed>9.927992820739746</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010619272613877" lon="-84.2018553378228">
+				<ele>946.8100171983242</ele>
+				<time>2017-10-09T19:12:18Z</time>
+				<extensions>
+					<speed>10.04617977142334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01069974406028" lon="-84.20180994379332">
+				<ele>946.6541551901028</ele>
+				<time>2017-10-09T19:12:19Z</time>
+				<extensions>
+					<speed>9.84639835357666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010772432680776" lon="-84.20176183913344">
+				<ele>946.6037633297965</ele>
+				<time>2017-10-09T19:12:20Z</time>
+				<extensions>
+					<speed>9.254982948303223</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010837423274888" lon="-84.2017247033958">
+				<ele>946.3219285104424</ele>
+				<time>2017-10-09T19:12:21Z</time>
+				<extensions>
+					<speed>7.667497634887695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010893736539199" lon="-84.20169668968735">
+				<ele>946.373807085678</ele>
+				<time>2017-10-09T19:12:22Z</time>
+				<extensions>
+					<speed>6.414312362670898</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010938955810838" lon="-84.2016793686269">
+				<ele>946.5633680326864</ele>
+				<time>2017-10-09T19:12:23Z</time>
+				<extensions>
+					<speed>4.737673759460449</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010974253239988" lon="-84.20166796081733">
+				<ele>946.6244573770091</ele>
+				<time>2017-10-09T19:12:24Z</time>
+				<extensions>
+					<speed>3.468027114868164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010997775703427" lon="-84.20166287614896">
+				<ele>946.6091266991571</ele>
+				<time>2017-10-09T19:12:25Z</time>
+				<extensions>
+					<speed>1.7805181741714478</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011007982340978" lon="-84.20166574735384">
+				<ele>946.4002027912065</ele>
+				<time>2017-10-09T19:12:26Z</time>
+				<extensions>
+					<speed>0.6307543516159058</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011014131635209" lon="-84.20166963732629">
+				<ele>946.3130401503295</ele>
+				<time>2017-10-09T19:12:27Z</time>
+				<extensions>
+					<speed>0.6450726389884949</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011014131635209" lon="-84.20166963732629">
+				<ele>946.3130401503295</ele>
+				<time>2017-10-09T19:12:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011022536037782" lon="-84.20166991537648">
+				<ele>947.7467375481501</ele>
+				<time>2017-10-09T19:12:29Z</time>
+				<extensions>
+					<speed>1.1704405546188354</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01103429660701" lon="-84.20166934949283">
+				<ele>948.1021815827116</ele>
+				<time>2017-10-09T19:12:30Z</time>
+				<extensions>
+					<speed>1.4631152153015137</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011052791055961" lon="-84.20166775758584">
+				<ele>948.2020368212834</ele>
+				<time>2017-10-09T19:12:31Z</time>
+				<extensions>
+					<speed>1.8219692707061768</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01107817393328" lon="-84.20166079692257">
+				<ele>948.4632596094161</ele>
+				<time>2017-10-09T19:12:32Z</time>
+				<extensions>
+					<speed>2.3419766426086426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011108705926164" lon="-84.20165734734684">
+				<ele>949.194505693391</ele>
+				<time>2017-10-09T19:12:33Z</time>
+				<extensions>
+					<speed>2.9156904220581055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011154924784819" lon="-84.20163980420875">
+				<ele>950.4601305555552</ele>
+				<time>2017-10-09T19:12:34Z</time>
+				<extensions>
+					<speed>3.9035584926605225</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011214287698383" lon="-84.20158007388498">
+				<ele>950.4441604027525</ele>
+				<time>2017-10-09T19:12:35Z</time>
+				<extensions>
+					<speed>5.037687301635742</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011275806495773" lon="-84.2015199182015">
+				<ele>950.0678814342245</ele>
+				<time>2017-10-09T19:12:36Z</time>
+				<extensions>
+					<speed>6.073456287384033</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011328844646023" lon="-84.20148462686548">
+				<ele>951.0077290507033</ele>
+				<time>2017-10-09T19:12:37Z</time>
+				<extensions>
+					<speed>5.568629264831543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011372174142503" lon="-84.20144940816914">
+				<ele>951.4584053773433</ele>
+				<time>2017-10-09T19:12:38Z</time>
+				<extensions>
+					<speed>4.98173713684082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011405963248322" lon="-84.20142351615938">
+				<ele>951.6083663031459</ele>
+				<time>2017-10-09T19:12:39Z</time>
+				<extensions>
+					<speed>4.000827312469482</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011443137437368" lon="-84.20140178178">
+				<ele>951.8777911784127</ele>
+				<time>2017-10-09T19:12:40Z</time>
+				<extensions>
+					<speed>3.7385268211364746</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011474450441488" lon="-84.20139230915365">
+				<ele>952.1503455694765</ele>
+				<time>2017-10-09T19:12:41Z</time>
+				<extensions>
+					<speed>3.5212297439575195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01150110241863" lon="-84.20138848156434">
+				<ele>952.3772102557123</ele>
+				<time>2017-10-09T19:12:42Z</time>
+				<extensions>
+					<speed>3.109065055847168</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011454213057121" lon="-84.20140766781063">
+				<ele>951.1680371183902</ele>
+				<time>2017-10-09T19:12:43Z</time>
+				<extensions>
+					<speed>0.5286946296691895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01144655570252" lon="-84.20141846585744">
+				<ele>950.2801301535219</ele>
+				<time>2017-10-09T19:12:44Z</time>
+				<extensions>
+					<speed>0.44347241520881653</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01144655570252" lon="-84.20141846585744">
+				<ele>950.2801301535219</ele>
+				<time>2017-10-09T19:12:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011440853181496" lon="-84.20141807814618">
+				<ele>950.6446454161778</ele>
+				<time>2017-10-09T19:12:46Z</time>
+				<extensions>
+					<speed>0.45761242508888245</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011440853181496" lon="-84.20141807814618">
+				<ele>950.6446454161778</ele>
+				<time>2017-10-09T19:12:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01144130457967" lon="-84.20141144165618">
+				<ele>952.1334437793121</ele>
+				<time>2017-10-09T19:12:48Z</time>
+				<extensions>
+					<speed>0.26218700408935547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01144130457967" lon="-84.20141144165618">
+				<ele>952.1334437793121</ele>
+				<time>2017-10-09T19:12:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01144130457967" lon="-84.20141144165618">
+				<ele>952.1334437793121</ele>
+				<time>2017-10-09T19:12:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01144130457967" lon="-84.20141144165618">
+				<ele>952.1334437793121</ele>
+				<time>2017-10-09T19:12:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01144130457967" lon="-84.20141144165618">
+				<ele>952.1334437793121</ele>
+				<time>2017-10-09T19:12:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01144130457967" lon="-84.20141144165618">
+				<ele>952.1334437793121</ele>
+				<time>2017-10-09T19:12:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01144130457967" lon="-84.20141144165618">
+				<ele>952.1334437793121</ele>
+				<time>2017-10-09T19:12:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01144130457967" lon="-84.20141144165618">
+				<ele>952.1334437793121</ele>
+				<time>2017-10-09T19:12:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011447773992096" lon="-84.20140720849275">
+				<ele>952.0754228169098</ele>
+				<time>2017-10-09T19:12:56Z</time>
+				<extensions>
+					<speed>1.1162437200546265</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0114642946517" lon="-84.20139837538323">
+				<ele>952.4367408407852</ele>
+				<time>2017-10-09T19:12:57Z</time>
+				<extensions>
+					<speed>2.5813369750976563</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011492455243264" lon="-84.20138681590682">
+				<ele>952.5520627116784</ele>
+				<time>2017-10-09T19:12:58Z</time>
+				<extensions>
+					<speed>3.9299893379211426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011530297212245" lon="-84.20138444587576">
+				<ele>951.1563418926671</ele>
+				<time>2017-10-09T19:12:59Z</time>
+				<extensions>
+					<speed>4.673657417297363</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011579875499919" lon="-84.20137609551698">
+				<ele>951.0968349883333</ele>
+				<time>2017-10-09T19:13:00Z</time>
+				<extensions>
+					<speed>6.130397796630859</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011637592688002" lon="-84.2013506062546">
+				<ele>951.6143201654777</ele>
+				<time>2017-10-09T19:13:01Z</time>
+				<extensions>
+					<speed>7.495761871337891</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011705414058861" lon="-84.2013169332511">
+				<ele>952.454221829772</ele>
+				<time>2017-10-09T19:13:02Z</time>
+				<extensions>
+					<speed>8.404681205749512</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01177957360334" lon="-84.2012760330581">
+				<ele>953.3254695395008</ele>
+				<time>2017-10-09T19:13:03Z</time>
+				<extensions>
+					<speed>9.514850616455078</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011860813054883" lon="-84.20123038869518">
+				<ele>953.5666292700917</ele>
+				<time>2017-10-09T19:13:04Z</time>
+				<extensions>
+					<speed>10.215766906738281</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01194273889274" lon="-84.20118264271838">
+				<ele>953.0971267595887</ele>
+				<time>2017-10-09T19:13:05Z</time>
+				<extensions>
+					<speed>10.117911338806152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012019371884222" lon="-84.20113656360611">
+				<ele>952.6157159255818</ele>
+				<time>2017-10-09T19:13:06Z</time>
+				<extensions>
+					<speed>9.446036338806152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012089109926254" lon="-84.20109739289143">
+				<ele>951.8883965816349</ele>
+				<time>2017-10-09T19:13:07Z</time>
+				<extensions>
+					<speed>8.159819602966309</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012148619366204" lon="-84.20106445056449">
+				<ele>950.8189300717786</ele>
+				<time>2017-10-09T19:13:08Z</time>
+				<extensions>
+					<speed>6.499011993408203</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012197855084782" lon="-84.20104831405912">
+				<ele>948.2480461001396</ele>
+				<time>2017-10-09T19:13:09Z</time>
+				<extensions>
+					<speed>3.9783830642700195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012222698736473" lon="-84.20104939544235">
+				<ele>946.5753496969119</ele>
+				<time>2017-10-09T19:13:10Z</time>
+				<extensions>
+					<speed>1.998632788658142</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012232915282715" lon="-84.20104782483033">
+				<ele>946.2619384275749</ele>
+				<time>2017-10-09T19:13:11Z</time>
+				<extensions>
+					<speed>0.7606196999549866</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012238733081626" lon="-84.20104291792613">
+				<ele>945.787315399386</ele>
+				<time>2017-10-09T19:13:12Z</time>
+				<extensions>
+					<speed>0.6746063828468323</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01225208979727" lon="-84.20104462554207">
+				<ele>944.4215643582866</ele>
+				<time>2017-10-09T19:13:13Z</time>
+				<extensions>
+					<speed>1.3627817630767822</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01227092161272" lon="-84.20104075095402">
+				<ele>943.4831163026392</ele>
+				<time>2017-10-09T19:13:14Z</time>
+				<extensions>
+					<speed>2.1284379959106445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012295179889916" lon="-84.20102936242183">
+				<ele>942.852646109648</ele>
+				<time>2017-10-09T19:13:15Z</time>
+				<extensions>
+					<speed>3.2910850048065186</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012331014151908" lon="-84.20100759302633">
+				<ele>942.0445143962279</ele>
+				<time>2017-10-09T19:13:16Z</time>
+				<extensions>
+					<speed>4.916774272918701</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012376695183487" lon="-84.2009766776035">
+				<ele>941.4254304543138</ele>
+				<time>2017-10-09T19:13:17Z</time>
+				<extensions>
+					<speed>6.488674640655518</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012429736688267" lon="-84.20094116676644">
+				<ele>941.3802421493456</ele>
+				<time>2017-10-09T19:13:18Z</time>
+				<extensions>
+					<speed>6.958344459533691</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012488825784962" lon="-84.20090516995023">
+				<ele>941.4491655379534</ele>
+				<time>2017-10-09T19:13:19Z</time>
+				<extensions>
+					<speed>7.774119853973389</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012552411460998" lon="-84.20086922132117">
+				<ele>941.4672083789483</ele>
+				<time>2017-10-09T19:13:20Z</time>
+				<extensions>
+					<speed>8.007559776306152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012619223817556" lon="-84.20083568990532">
+				<ele>941.293420964852</ele>
+				<time>2017-10-09T19:13:21Z</time>
+				<extensions>
+					<speed>8.14757251739502</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01268726359865" lon="-84.20080238322983">
+				<ele>940.9373361496255</ele>
+				<time>2017-10-09T19:13:22Z</time>
+				<extensions>
+					<speed>8.244297981262207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012754664127776" lon="-84.20076789370883">
+				<ele>941.0540297180414</ele>
+				<time>2017-10-09T19:13:23Z</time>
+				<extensions>
+					<speed>8.075340270996094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012814636407882" lon="-84.20073754421956">
+				<ele>941.6276517920196</ele>
+				<time>2017-10-09T19:13:24Z</time>
+				<extensions>
+					<speed>6.823629856109619</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012865548784314" lon="-84.20071388030254">
+				<ele>943.0772909140214</ele>
+				<time>2017-10-09T19:13:25Z</time>
+				<extensions>
+					<speed>5.270504474639893</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012899076777428" lon="-84.20069205903981">
+				<ele>944.9642641982064</ele>
+				<time>2017-10-09T19:13:26Z</time>
+				<extensions>
+					<speed>3.8559162616729736</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012918648498854" lon="-84.20067681113535">
+				<ele>945.5338991722092</ele>
+				<time>2017-10-09T19:13:27Z</time>
+				<extensions>
+					<speed>2.4303932189941406</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292216891192" lon="-84.20066805234862">
+				<ele>946.3996507236734</ele>
+				<time>2017-10-09T19:13:28Z</time>
+				<extensions>
+					<speed>0.6766713857650757</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012911575628156" lon="-84.20066618019177">
+				<ele>946.8256319202483</ele>
+				<time>2017-10-09T19:13:29Z</time>
+				<extensions>
+					<speed>0.7323216795921326</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012893262575451" lon="-84.20066539104306">
+				<ele>947.5851362543181</ele>
+				<time>2017-10-09T19:13:30Z</time>
+				<extensions>
+					<speed>1.2661235332489014</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01287798321942" lon="-84.20066892365092">
+				<ele>948.1273004822433</ele>
+				<time>2017-10-09T19:13:31Z</time>
+				<extensions>
+					<speed>0.9869837760925293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01287798321942" lon="-84.20066892365092">
+				<ele>948.1273004822433</ele>
+				<time>2017-10-09T19:13:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01288135679902" lon="-84.20066419903242">
+				<ele>948.4434080980718</ele>
+				<time>2017-10-09T19:13:33Z</time>
+				<extensions>
+					<speed>1.6177117824554443</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012900072364998" lon="-84.20065862251802">
+				<ele>948.7608846118674</ele>
+				<time>2017-10-09T19:13:34Z</time>
+				<extensions>
+					<speed>2.970533609390259</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012933614231471" lon="-84.20066052638502">
+				<ele>948.3813928738236</ele>
+				<time>2017-10-09T19:13:35Z</time>
+				<extensions>
+					<speed>4.056377410888672</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012977386972489" lon="-84.20067115813256">
+				<ele>948.1897666621953</ele>
+				<time>2017-10-09T19:13:36Z</time>
+				<extensions>
+					<speed>4.677917957305908</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013027135252933" lon="-84.20069914415963">
+				<ele>946.7042504018173</ele>
+				<time>2017-10-09T19:13:37Z</time>
+				<extensions>
+					<speed>5.721786975860596</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013072403641107" lon="-84.20073594516967">
+				<ele>946.3388060880825</ele>
+				<time>2017-10-09T19:13:38Z</time>
+				<extensions>
+					<speed>5.964951038360596</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013109471146628" lon="-84.2007765737238">
+				<ele>946.7138432031497</ele>
+				<time>2017-10-09T19:13:39Z</time>
+				<extensions>
+					<speed>5.9116435050964355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013139788513492" lon="-84.20082323351016">
+				<ele>946.6093976860866</ele>
+				<time>2017-10-09T19:13:40Z</time>
+				<extensions>
+					<speed>5.1077561378479</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013158910949873" lon="-84.20086154174571">
+				<ele>946.8821265595034</ele>
+				<time>2017-10-09T19:13:41Z</time>
+				<extensions>
+					<speed>3.8848278522491455</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01317195806567" lon="-84.20088895052216">
+				<ele>947.1763971922919</ele>
+				<time>2017-10-09T19:13:42Z</time>
+				<extensions>
+					<speed>2.863011598587036</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013180180193398" lon="-84.20091027982426">
+				<ele>947.0302402591333</ele>
+				<time>2017-10-09T19:13:43Z</time>
+				<extensions>
+					<speed>1.4774242639541626</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013180232967612" lon="-84.20092299690255">
+				<ele>946.8227324169129</ele>
+				<time>2017-10-09T19:13:44Z</time>
+				<extensions>
+					<speed>0.7491722106933594</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013180232967612" lon="-84.20092299690255">
+				<ele>946.8227324169129</ele>
+				<time>2017-10-09T19:13:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0131739929917" lon="-84.200922031606">
+				<ele>946.6689702067524</ele>
+				<time>2017-10-09T19:13:46Z</time>
+				<extensions>
+					<speed>0.9249465465545654</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01316792568646" lon="-84.20091507301534">
+				<ele>946.5615008054301</ele>
+				<time>2017-10-09T19:13:47Z</time>
+				<extensions>
+					<speed>1.49284827709198</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013161939673921" lon="-84.20090539079426">
+				<ele>946.9161252202466</ele>
+				<time>2017-10-09T19:13:48Z</time>
+				<extensions>
+					<speed>1.3891586065292358</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013156613096628" lon="-84.2008988878828">
+				<ele>947.1097614895552</ele>
+				<time>2017-10-09T19:13:49Z</time>
+				<extensions>
+					<speed>0.7700698375701904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013156613096628" lon="-84.2008988878828">
+				<ele>947.1097614895552</ele>
+				<time>2017-10-09T19:13:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013155255251231" lon="-84.20088818271797">
+				<ele>947.2059019682929</ele>
+				<time>2017-10-09T19:13:51Z</time>
+				<extensions>
+					<speed>1.166974663734436</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013154474884875" lon="-84.20087674171262">
+				<ele>947.3485382059589</ele>
+				<time>2017-10-09T19:13:52Z</time>
+				<extensions>
+					<speed>1.1557329893112183</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01315390595463" lon="-84.20087256933928">
+				<ele>947.5299455560744</ele>
+				<time>2017-10-09T19:13:53Z</time>
+				<extensions>
+					<speed>0.20772159099578857</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01315390595463" lon="-84.20087256933928">
+				<ele>947.5299455560744</ele>
+				<time>2017-10-09T19:13:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01315390595463" lon="-84.20087256933928">
+				<ele>947.5299455560744</ele>
+				<time>2017-10-09T19:13:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013153665526318" lon="-84.20087621520827">
+				<ele>947.3372493870556</ele>
+				<time>2017-10-09T19:13:56Z</time>
+				<extensions>
+					<speed>0.7397078275680542</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01315669922372" lon="-84.20088148373036">
+				<ele>947.4942986723036</ele>
+				<time>2017-10-09T19:13:57Z</time>
+				<extensions>
+					<speed>1.4538745880126953</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013164387224208" lon="-84.20089046244983">
+				<ele>947.1921075722203</ele>
+				<time>2017-10-09T19:13:58Z</time>
+				<extensions>
+					<speed>1.6752015352249146</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013174775221401" lon="-84.20090690156285">
+				<ele>947.0744619723409</ele>
+				<time>2017-10-09T19:13:59Z</time>
+				<extensions>
+					<speed>2.5847301483154297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013191758526297" lon="-84.20093449578563">
+				<ele>947.0012504570186</ele>
+				<time>2017-10-09T19:14:00Z</time>
+				<extensions>
+					<speed>4.148773670196533</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013218027202912" lon="-84.20097168816822">
+				<ele>946.9628254426643</ele>
+				<time>2017-10-09T19:14:01Z</time>
+				<extensions>
+					<speed>5.59230375289917</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013253142338563" lon="-84.20102068408593">
+				<ele>946.837381053716</ele>
+				<time>2017-10-09T19:14:02Z</time>
+				<extensions>
+					<speed>7.093569278717041</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013295077524136" lon="-84.20107685010657">
+				<ele>946.9429721198976</ele>
+				<time>2017-10-09T19:14:03Z</time>
+				<extensions>
+					<speed>8.165955543518066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013340604751843" lon="-84.20113657195708">
+				<ele>946.9891498982906</ele>
+				<time>2017-10-09T19:14:04Z</time>
+				<extensions>
+					<speed>8.24449348449707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013388342983177" lon="-84.20119286705767">
+				<ele>946.9162511285394</ele>
+				<time>2017-10-09T19:14:05Z</time>
+				<extensions>
+					<speed>7.951363563537598</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013437330286994" lon="-84.201246762438">
+				<ele>946.0028459569439</ele>
+				<time>2017-10-09T19:14:06Z</time>
+				<extensions>
+					<speed>7.4896321296691895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013489450426665" lon="-84.20129131012823">
+				<ele>944.5080015901476</ele>
+				<time>2017-10-09T19:14:07Z</time>
+				<extensions>
+					<speed>6.8905720710754395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013537456307365" lon="-84.20132697575498">
+				<ele>943.0360986096784</ele>
+				<time>2017-10-09T19:14:08Z</time>
+				<extensions>
+					<speed>5.988107681274414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013573268486903" lon="-84.20136392249847">
+				<ele>942.545712089166</ele>
+				<time>2017-10-09T19:14:09Z</time>
+				<extensions>
+					<speed>4.986756801605225</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013604165881727" lon="-84.20139235978992">
+				<ele>941.9495310205966</ele>
+				<time>2017-10-09T19:14:10Z</time>
+				<extensions>
+					<speed>3.6980459690093994</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013628499083541" lon="-84.20141491468081">
+				<ele>941.2714890167117</ele>
+				<time>2017-10-09T19:14:11Z</time>
+				<extensions>
+					<speed>2.2370855808258057</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013641401624428" lon="-84.20142738543399">
+				<ele>941.0191725539044</ele>
+				<time>2017-10-09T19:14:12Z</time>
+				<extensions>
+					<speed>0.5074142217636108</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013644033502988" lon="-84.20142984988235">
+				<ele>940.9266872666776</ele>
+				<time>2017-10-09T19:14:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013644033502988" lon="-84.20142984988235">
+				<ele>940.9266872666776</ele>
+				<time>2017-10-09T19:14:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013644033502988" lon="-84.20142984988235">
+				<ele>940.9266872666776</ele>
+				<time>2017-10-09T19:14:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013640035662698" lon="-84.20142231891208">
+				<ele>941.1497352682054</ele>
+				<time>2017-10-09T19:14:16Z</time>
+				<extensions>
+					<speed>0.9840806126594543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013644033502988" lon="-84.20142984988235">
+				<ele>940.9266872666776</ele>
+				<time>2017-10-09T19:14:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01363957638108" lon="-84.20142326482883">
+				<ele>941.2623574715108</ele>
+				<time>2017-10-09T19:14:18Z</time>
+				<extensions>
+					<speed>0.6186011433601379</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013644033502988" lon="-84.20142984988235">
+				<ele>940.9266872666776</ele>
+				<time>2017-10-09T19:14:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013644033502988" lon="-84.20142984988235">
+				<ele>940.9266872666776</ele>
+				<time>2017-10-09T19:14:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013644033502988" lon="-84.20142984988235">
+				<ele>940.9266872666776</ele>
+				<time>2017-10-09T19:14:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013644033502988" lon="-84.20142984988235">
+				<ele>940.9266872666776</ele>
+				<time>2017-10-09T19:14:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013644033502988" lon="-84.20142984988235">
+				<ele>940.9266872666776</ele>
+				<time>2017-10-09T19:14:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013644033502988" lon="-84.20142984988235">
+				<ele>940.9266872666776</ele>
+				<time>2017-10-09T19:14:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013644033502988" lon="-84.20142984988235">
+				<ele>940.9266872666776</ele>
+				<time>2017-10-09T19:14:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013644033502988" lon="-84.20142984988235">
+				<ele>940.9266872666776</ele>
+				<time>2017-10-09T19:14:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013644033502988" lon="-84.20142984988235">
+				<ele>940.9266872666776</ele>
+				<time>2017-10-09T19:14:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013643739913968" lon="-84.20143645957585">
+				<ele>940.9055128330365</ele>
+				<time>2017-10-09T19:14:28Z</time>
+				<extensions>
+					<speed>0.9422171115875244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013651390265666" lon="-84.20144893102828">
+				<ele>940.6790692787617</ele>
+				<time>2017-10-09T19:14:29Z</time>
+				<extensions>
+					<speed>2.227496385574341</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013666088394103" lon="-84.20146593208779">
+				<ele>940.7195178959519</ele>
+				<time>2017-10-09T19:14:30Z</time>
+				<extensions>
+					<speed>3.4231607913970947</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013691885468093" lon="-84.20149299883806">
+				<ele>940.7917215246707</ele>
+				<time>2017-10-09T19:14:31Z</time>
+				<extensions>
+					<speed>4.981246471405029</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01372722169478" lon="-84.20153443135585">
+				<ele>940.7061187513173</ele>
+				<time>2017-10-09T19:14:32Z</time>
+				<extensions>
+					<speed>6.59205436706543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013767271014991" lon="-84.20158571018948">
+				<ele>940.8983542118222</ele>
+				<time>2017-10-09T19:14:33Z</time>
+				<extensions>
+					<speed>7.508693695068359</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01381172683135" lon="-84.20164350526713">
+				<ele>940.9991034325212</ele>
+				<time>2017-10-09T19:14:34Z</time>
+				<extensions>
+					<speed>8.052879333496094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013855349360874" lon="-84.20170325350921">
+				<ele>941.3683761171997</ele>
+				<time>2017-10-09T19:14:35Z</time>
+				<extensions>
+					<speed>8.02526569366455</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013898606755607" lon="-84.201765379979">
+				<ele>941.442878681235</ele>
+				<time>2017-10-09T19:14:36Z</time>
+				<extensions>
+					<speed>8.205351829528809</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0139420692268" lon="-84.20183494323697">
+				<ele>941.6239015497267</ele>
+				<time>2017-10-09T19:14:37Z</time>
+				<extensions>
+					<speed>8.812692642211914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013987389308568" lon="-84.2019052412153">
+				<ele>941.659658472985</ele>
+				<time>2017-10-09T19:14:38Z</time>
+				<extensions>
+					<speed>9.02448844909668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01402234419237" lon="-84.20197803691369">
+				<ele>941.7504537198693</ele>
+				<time>2017-10-09T19:14:39Z</time>
+				<extensions>
+					<speed>8.550493240356445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014064979787646" lon="-84.20205519760549">
+				<ele>941.0706165200099</ele>
+				<time>2017-10-09T19:14:40Z</time>
+				<extensions>
+					<speed>9.131235122680664</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014118809479895" lon="-84.20213599040443">
+				<ele>940.0406507318839</ele>
+				<time>2017-10-09T19:14:41Z</time>
+				<extensions>
+					<speed>9.266507148742676</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01416459474155" lon="-84.2022116066031">
+				<ele>940.3027749611065</ele>
+				<time>2017-10-09T19:14:42Z</time>
+				<extensions>
+					<speed>9.070606231689453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014201373017881" lon="-84.20228480727475">
+				<ele>940.5158662730828</ele>
+				<time>2017-10-09T19:14:43Z</time>
+				<extensions>
+					<speed>8.690815925598145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014234203720859" lon="-84.2023516569089">
+				<ele>940.1449422463775</ele>
+				<time>2017-10-09T19:14:44Z</time>
+				<extensions>
+					<speed>7.098291397094727</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014259798654324" lon="-84.20240835487844">
+				<ele>940.0256959684193</ele>
+				<time>2017-10-09T19:14:45Z</time>
+				<extensions>
+					<speed>6.0723185539245605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014282276165677" lon="-84.20245335835642">
+				<ele>940.3866597842425</ele>
+				<time>2017-10-09T19:14:46Z</time>
+				<extensions>
+					<speed>5.232919216156006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01430707688985" lon="-84.20248219956378">
+				<ele>940.8362814793363</ele>
+				<time>2017-10-09T19:14:47Z</time>
+				<extensions>
+					<speed>3.695645809173584</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01433437362724" lon="-84.20249298341983">
+				<ele>940.9839773578569</ele>
+				<time>2017-10-09T19:14:48Z</time>
+				<extensions>
+					<speed>3.2949740886688232</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014366492222566" lon="-84.20248319130329">
+				<ele>941.0288491407409</ele>
+				<time>2017-10-09T19:14:49Z</time>
+				<extensions>
+					<speed>4.268510818481445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014405727345679" lon="-84.20245902617981">
+				<ele>941.3386910324916</ele>
+				<time>2017-10-09T19:14:50Z</time>
+				<extensions>
+					<speed>5.658102512359619</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014449204527958" lon="-84.20242342658149">
+				<ele>941.5352608626708</ele>
+				<time>2017-10-09T19:14:51Z</time>
+				<extensions>
+					<speed>6.77986478805542</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01449936146163" lon="-84.20237917983344">
+				<ele>941.4754620948806</ele>
+				<time>2017-10-09T19:14:52Z</time>
+				<extensions>
+					<speed>7.7737345695495605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014555150931512" lon="-84.20233444848708">
+				<ele>941.6843109168112</ele>
+				<time>2017-10-09T19:14:53Z</time>
+				<extensions>
+					<speed>8.06508731842041</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014608732244925" lon="-84.20229144615504">
+				<ele>942.0270976880565</ele>
+				<time>2017-10-09T19:14:54Z</time>
+				<extensions>
+					<speed>8.112581253051758</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01465443189485" lon="-84.20225762840437">
+				<ele>942.0213500475511</ele>
+				<time>2017-10-09T19:14:55Z</time>
+				<extensions>
+					<speed>5.838464260101318</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014684173513443" lon="-84.20223590327329">
+				<ele>941.6131995161995</ele>
+				<time>2017-10-09T19:14:56Z</time>
+				<extensions>
+					<speed>3.09187650680542</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014695726395903" lon="-84.20222731334451">
+				<ele>940.9907817430794</ele>
+				<time>2017-10-09T19:14:57Z</time>
+				<extensions>
+					<speed>0.7331287264823914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014692391423546" lon="-84.202228078354">
+				<ele>940.1340245390311</ele>
+				<time>2017-10-09T19:14:58Z</time>
+				<extensions>
+					<speed>0.890367329120636</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014682102515517" lon="-84.20223334501685">
+				<ele>939.4968608319759</ele>
+				<time>2017-10-09T19:14:59Z</time>
+				<extensions>
+					<speed>1.3425703048706055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01466801909342" lon="-84.20223993570367">
+				<ele>939.24064474646</ele>
+				<time>2017-10-09T19:15:00Z</time>
+				<extensions>
+					<speed>1.4903351068496704</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0146564218507" lon="-84.20224651272959">
+				<ele>939.5941136814654</ele>
+				<time>2017-10-09T19:15:01Z</time>
+				<extensions>
+					<speed>1.1637723445892334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014647387294552" lon="-84.2022502337496">
+				<ele>939.9673558641225</ele>
+				<time>2017-10-09T19:15:02Z</time>
+				<extensions>
+					<speed>0.6788490414619446</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014647387294552" lon="-84.2022502337496">
+				<ele>939.9673558641225</ele>
+				<time>2017-10-09T19:15:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0146402013451" lon="-84.20225059576624">
+				<ele>940.418457986787</ele>
+				<time>2017-10-09T19:15:04Z</time>
+				<extensions>
+					<speed>0.6198388338088989</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0146402013451" lon="-84.20225059576624">
+				<ele>940.418457986787</ele>
+				<time>2017-10-09T19:15:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014636526728543" lon="-84.20224955820336">
+				<ele>941.1069956636056</ele>
+				<time>2017-10-09T19:15:06Z</time>
+				<extensions>
+					<speed>0.015696296468377113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014636526728543" lon="-84.20224955820336">
+				<ele>941.1069956636056</ele>
+				<time>2017-10-09T19:15:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014639034683768" lon="-84.20224032717985">
+				<ele>941.6280182413757</ele>
+				<time>2017-10-09T19:15:08Z</time>
+				<extensions>
+					<speed>1.1534110307693481</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014648712154921" lon="-84.20222862782518">
+				<ele>942.0926619768143</ele>
+				<time>2017-10-09T19:15:09Z</time>
+				<extensions>
+					<speed>2.0609211921691895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014666231635273" lon="-84.20221732630996">
+				<ele>942.5615097852424</ele>
+				<time>2017-10-09T19:15:10Z</time>
+				<extensions>
+					<speed>2.608513116836548</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014699147802208" lon="-84.2022093861244">
+				<ele>942.5315225236118</ele>
+				<time>2017-10-09T19:15:11Z</time>
+				<extensions>
+					<speed>3.6880745887756348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014737642893214" lon="-84.20220250996825">
+				<ele>942.3317072317004</ele>
+				<time>2017-10-09T19:15:12Z</time>
+				<extensions>
+					<speed>4.653753757476807</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014780746792303" lon="-84.20219161451486">
+				<ele>942.0497169904411</ele>
+				<time>2017-10-09T19:15:13Z</time>
+				<extensions>
+					<speed>4.871218681335449</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014827107795648" lon="-84.20216575301065">
+				<ele>941.7216485906392</ele>
+				<time>2017-10-09T19:15:14Z</time>
+				<extensions>
+					<speed>5.6001362800598145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014875174560586" lon="-84.20213948715538">
+				<ele>941.8604506691918</ele>
+				<time>2017-10-09T19:15:15Z</time>
+				<extensions>
+					<speed>5.996245384216309</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014928718717474" lon="-84.20211093329539">
+				<ele>941.9512178497389</ele>
+				<time>2017-10-09T19:15:16Z</time>
+				<extensions>
+					<speed>6.589662075042725</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014985658067475" lon="-84.20207899645065">
+				<ele>942.2695375001058</ele>
+				<time>2017-10-09T19:15:17Z</time>
+				<extensions>
+					<speed>7.277498245239258</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01504604082928" lon="-84.2020502233998">
+				<ele>942.1693730419502</ele>
+				<time>2017-10-09T19:15:18Z</time>
+				<extensions>
+					<speed>7.401705265045166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015106324662076" lon="-84.20201715272881">
+				<ele>942.3512065401301</ele>
+				<time>2017-10-09T19:15:19Z</time>
+				<extensions>
+					<speed>7.385670185089111</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015164844568048" lon="-84.2019823918126">
+				<ele>942.8509772215039</ele>
+				<time>2017-10-09T19:15:20Z</time>
+				<extensions>
+					<speed>7.554798603057861</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015219513617906" lon="-84.20195164845293">
+				<ele>942.8663136409596</ele>
+				<time>2017-10-09T19:15:21Z</time>
+				<extensions>
+					<speed>6.371034622192383</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015264479423017" lon="-84.20192975612876">
+				<ele>942.4401101088151</ele>
+				<time>2017-10-09T19:15:22Z</time>
+				<extensions>
+					<speed>4.310441017150879</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01528781409261" lon="-84.20191163799701">
+				<ele>942.1986419372261</ele>
+				<time>2017-10-09T19:15:23Z</time>
+				<extensions>
+					<speed>1.752358317375183</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015291071926619" lon="-84.2019074075747">
+				<ele>942.0502679413185</ele>
+				<time>2017-10-09T19:15:24Z</time>
+				<extensions>
+					<speed>0.6447262763977051</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015281869436928" lon="-84.20191328532076">
+				<ele>941.5419409517199</ele>
+				<time>2017-10-09T19:15:25Z</time>
+				<extensions>
+					<speed>1.2137820720672607</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0152690393625" lon="-84.20192074063941">
+				<ele>941.3620903519914</ele>
+				<time>2017-10-09T19:15:26Z</time>
+				<extensions>
+					<speed>1.2392241954803467</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015255188034855" lon="-84.20192830053946">
+				<ele>941.2488001519814</ele>
+				<time>2017-10-09T19:15:27Z</time>
+				<extensions>
+					<speed>1.1921669244766235</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015243525987685" lon="-84.20193759581272">
+				<ele>941.0933138327673</ele>
+				<time>2017-10-09T19:15:28Z</time>
+				<extensions>
+					<speed>0.9920337796211243</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015243525987685" lon="-84.20193759581272">
+				<ele>941.0933138327673</ele>
+				<time>2017-10-09T19:15:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015237381127127" lon="-84.20194281151704">
+				<ele>940.7306224461645</ele>
+				<time>2017-10-09T19:15:30Z</time>
+				<extensions>
+					<speed>0.7181674242019653</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015237381127127" lon="-84.20194281151704">
+				<ele>940.7306224461645</ele>
+				<time>2017-10-09T19:15:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015232101249168" lon="-84.20194522066558">
+				<ele>940.3275773301721</ele>
+				<time>2017-10-09T19:15:32Z</time>
+				<extensions>
+					<speed>0.25844427943229675</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015232101249168" lon="-84.20194522066558">
+				<ele>940.3275773301721</ele>
+				<time>2017-10-09T19:15:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015237304531324" lon="-84.20194110191373">
+				<ele>940.4491744535044</ele>
+				<time>2017-10-09T19:15:34Z</time>
+				<extensions>
+					<speed>0.958512008190155</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015247542012416" lon="-84.20192464315741">
+				<ele>940.351515782997</ele>
+				<time>2017-10-09T19:15:35Z</time>
+				<extensions>
+					<speed>2.0215418338775635</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015261575328083" lon="-84.20189920099986">
+				<ele>940.1184697924182</ele>
+				<time>2017-10-09T19:15:36Z</time>
+				<extensions>
+					<speed>2.8785758018493652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015279047146503" lon="-84.20187282179444">
+				<ele>939.6702831378207</ele>
+				<time>2017-10-09T19:15:37Z</time>
+				<extensions>
+					<speed>3.1244823932647705</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015301738364991" lon="-84.20184854842641">
+				<ele>939.0214265119284</ele>
+				<time>2017-10-09T19:15:38Z</time>
+				<extensions>
+					<speed>3.117540121078491</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0153254791968" lon="-84.20182589798473">
+				<ele>938.5275254640728</ele>
+				<time>2017-10-09T19:15:39Z</time>
+				<extensions>
+					<speed>3.32843279838562</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015353570921139" lon="-84.20180745618784">
+				<ele>938.1002487512305</ele>
+				<time>2017-10-09T19:15:40Z</time>
+				<extensions>
+					<speed>3.0440964698791504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015376940487876" lon="-84.20179464282334">
+				<ele>938.3439541142434</ele>
+				<time>2017-10-09T19:15:41Z</time>
+				<extensions>
+					<speed>2.1405675411224365</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015394283055443" lon="-84.20178717472797">
+				<ele>938.4507995955646</ele>
+				<time>2017-10-09T19:15:42Z</time>
+				<extensions>
+					<speed>1.3903300762176514</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01540564818818" lon="-84.20178513283335">
+				<ele>938.5433201603591</ele>
+				<time>2017-10-09T19:15:43Z</time>
+				<extensions>
+					<speed>0.8325324654579163</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01540564818818" lon="-84.20178513283335">
+				<ele>938.5433201603591</ele>
+				<time>2017-10-09T19:15:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015404745201023" lon="-84.20178607688776">
+				<ele>938.7906769113615</ele>
+				<time>2017-10-09T19:15:45Z</time>
+				<extensions>
+					<speed>0.8864588737487793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015401086430336" lon="-84.20178941440876">
+				<ele>938.7162817427889</ele>
+				<time>2017-10-09T19:15:46Z</time>
+				<extensions>
+					<speed>1.1508007049560547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01539420131743" lon="-84.20179349445145">
+				<ele>938.5210209246725</ele>
+				<time>2017-10-09T19:15:47Z</time>
+				<extensions>
+					<speed>1.2680175304412842</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015386215117646" lon="-84.20179614794341">
+				<ele>938.3028223123401</ele>
+				<time>2017-10-09T19:15:48Z</time>
+				<extensions>
+					<speed>1.4141080379486084</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015376561465459" lon="-84.20179710406366">
+				<ele>937.7053324421868</ele>
+				<time>2017-10-09T19:15:49Z</time>
+				<extensions>
+					<speed>1.1532961130142212</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015364750332973" lon="-84.20179770071245">
+				<ele>937.1704363338649</ele>
+				<time>2017-10-09T19:15:50Z</time>
+				<extensions>
+					<speed>1.8873525857925415</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015351722215108" lon="-84.20179654630563">
+				<ele>937.4687524605542</ele>
+				<time>2017-10-09T19:15:51Z</time>
+				<extensions>
+					<speed>1.6781315803527832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015338736739084" lon="-84.20179349877358">
+				<ele>937.2183939153329</ele>
+				<time>2017-10-09T19:15:52Z</time>
+				<extensions>
+					<speed>1.3569080829620361</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015329919909043" lon="-84.20178817282006">
+				<ele>937.5482037644833</ele>
+				<time>2017-10-09T19:15:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015329919909043" lon="-84.20178817282006">
+				<ele>937.5482037644833</ele>
+				<time>2017-10-09T19:15:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015329175194507" lon="-84.20178138789217">
+				<ele>937.5274093486369</ele>
+				<time>2017-10-09T19:15:55Z</time>
+				<extensions>
+					<speed>0.8041083216667175</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015329919909043" lon="-84.20178817282006">
+				<ele>937.5482037644833</ele>
+				<time>2017-10-09T19:15:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015329919909043" lon="-84.20178817282006">
+				<ele>937.5482037644833</ele>
+				<time>2017-10-09T19:15:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015329919909043" lon="-84.20178817282006">
+				<ele>937.5482037644833</ele>
+				<time>2017-10-09T19:15:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015329919909043" lon="-84.20178817282006">
+				<ele>937.5482037644833</ele>
+				<time>2017-10-09T19:15:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015329919909043" lon="-84.20178817282006">
+				<ele>937.5482037644833</ele>
+				<time>2017-10-09T19:16:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015333315072573" lon="-84.20179043931124">
+				<ele>937.6943103531376</ele>
+				<time>2017-10-09T19:16:01Z</time>
+				<extensions>
+					<speed>0.8134259581565857</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015338984202524" lon="-84.20179977459111">
+				<ele>937.5909104514867</ele>
+				<time>2017-10-09T19:16:02Z</time>
+				<extensions>
+					<speed>1.502265214920044</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015347092780102" lon="-84.20180907888924">
+				<ele>937.3876809449866</ele>
+				<time>2017-10-09T19:16:03Z</time>
+				<extensions>
+					<speed>1.1282944679260254</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015355589839176" lon="-84.20181818880124">
+				<ele>937.5297138737515</ele>
+				<time>2017-10-09T19:16:04Z</time>
+				<extensions>
+					<speed>1.2655611038208008</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015363859353847" lon="-84.20182882370756">
+				<ele>937.5308946007863</ele>
+				<time>2017-10-09T19:16:05Z</time>
+				<extensions>
+					<speed>1.5137890577316284</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015370896441974" lon="-84.20184441576215">
+				<ele>937.4385266583413</ele>
+				<time>2017-10-09T19:16:06Z</time>
+				<extensions>
+					<speed>1.7511436939239502</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015375320466893" lon="-84.20186308958631">
+				<ele>937.4130678558722</ele>
+				<time>2017-10-09T19:16:07Z</time>
+				<extensions>
+					<speed>2.2221455574035645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015375659298998" lon="-84.20188763248863">
+				<ele>937.4502117587253</ele>
+				<time>2017-10-09T19:16:08Z</time>
+				<extensions>
+					<speed>3.049882173538208</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015366244285163" lon="-84.20192153305292">
+				<ele>937.30848987028</ele>
+				<time>2017-10-09T19:16:09Z</time>
+				<extensions>
+					<speed>4.315384864807129</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015345760929716" lon="-84.20196025625745">
+				<ele>937.1968247890472</ele>
+				<time>2017-10-09T19:16:10Z</time>
+				<extensions>
+					<speed>4.922261714935303</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015315113649159" lon="-84.2019987916397">
+				<ele>937.5395524222404</ele>
+				<time>2017-10-09T19:16:11Z</time>
+				<extensions>
+					<speed>5.674226760864258</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015268668069904" lon="-84.20203760192916">
+				<ele>937.4485557051376</ele>
+				<time>2017-10-09T19:16:12Z</time>
+				<extensions>
+					<speed>7.111904621124268</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015209335721462" lon="-84.20207392550736">
+				<ele>937.6666477909312</ele>
+				<time>2017-10-09T19:16:13Z</time>
+				<extensions>
+					<speed>8.108442306518555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015137481596797" lon="-84.20210662530101">
+				<ele>937.7279159678146</ele>
+				<time>2017-10-09T19:16:14Z</time>
+				<extensions>
+					<speed>9.093334197998047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015057865975407" lon="-84.20214038574885">
+				<ele>938.1113258106634</ele>
+				<time>2017-10-09T19:16:15Z</time>
+				<extensions>
+					<speed>9.975255966186523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014975942985222" lon="-84.20217917063167">
+				<ele>938.230813389644</ele>
+				<time>2017-10-09T19:16:16Z</time>
+				<extensions>
+					<speed>10.258520126342773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014897183226426" lon="-84.2022174456047">
+				<ele>937.9545074868947</ele>
+				<time>2017-10-09T19:16:17Z</time>
+				<extensions>
+					<speed>9.341612815856934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014824610246901" lon="-84.202254331807">
+				<ele>938.1972019048408</ele>
+				<time>2017-10-09T19:16:18Z</time>
+				<extensions>
+					<speed>8.70205020904541</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014763116859477" lon="-84.20228490564114">
+				<ele>938.3122792150825</ele>
+				<time>2017-10-09T19:16:19Z</time>
+				<extensions>
+					<speed>6.9505181312561035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014722451789154" lon="-84.20230450754515">
+				<ele>938.203040712513</ele>
+				<time>2017-10-09T19:16:20Z</time>
+				<extensions>
+					<speed>3.4510326385498047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014710993349215" lon="-84.20230911606122">
+				<ele>937.8769309557974</ele>
+				<time>2017-10-09T19:16:21Z</time>
+				<extensions>
+					<speed>0.11426812410354614</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014717668134603" lon="-84.20230134688778">
+				<ele>937.392767066136</ele>
+				<time>2017-10-09T19:16:22Z</time>
+				<extensions>
+					<speed>1.2089035511016846</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01472998696796" lon="-84.20229182072299">
+				<ele>937.4320529531687</ele>
+				<time>2017-10-09T19:16:23Z</time>
+				<extensions>
+					<speed>1.614866852760315</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01473932175494" lon="-84.20228312596164">
+				<ele>937.9538114648312</ele>
+				<time>2017-10-09T19:16:24Z</time>
+				<extensions>
+					<speed>0.9958071112632751</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014741400523425" lon="-84.20228178766472">
+				<ele>938.2359521565959</ele>
+				<time>2017-10-09T19:16:25Z</time>
+				<extensions>
+					<speed>0.43730542063713074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014733333778585" lon="-84.20228733149429">
+				<ele>938.4385246708989</ele>
+				<time>2017-10-09T19:16:26Z</time>
+				<extensions>
+					<speed>2.063798427581787</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014712097258979" lon="-84.20230031744357">
+				<ele>938.4535030573606</ele>
+				<time>2017-10-09T19:16:27Z</time>
+				<extensions>
+					<speed>3.7071800231933594</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014677190237974" lon="-84.20232579449512">
+				<ele>938.045344479382</ele>
+				<time>2017-10-09T19:16:28Z</time>
+				<extensions>
+					<speed>5.705299377441406</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014626436008667" lon="-84.20235796308216">
+				<ele>937.711947019212</ele>
+				<time>2017-10-09T19:16:29Z</time>
+				<extensions>
+					<speed>7.218946933746338</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014565004434827" lon="-84.20238958281156">
+				<ele>937.8757589515299</ele>
+				<time>2017-10-09T19:16:30Z</time>
+				<extensions>
+					<speed>7.997313499450684</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014502300839677" lon="-84.20242255213907">
+				<ele>937.8443887373433</ele>
+				<time>2017-10-09T19:16:31Z</time>
+				<extensions>
+					<speed>7.655291557312012</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014442024828812" lon="-84.20245381331374">
+				<ele>937.9553174516186</ele>
+				<time>2017-10-09T19:16:32Z</time>
+				<extensions>
+					<speed>7.256704807281494</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014388059138929" lon="-84.20248338654001">
+				<ele>938.1650721803308</ele>
+				<time>2017-10-09T19:16:33Z</time>
+				<extensions>
+					<speed>6.500946521759033</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014344916981909" lon="-84.2025054226798">
+				<ele>938.1378939552233</ele>
+				<time>2017-10-09T19:16:34Z</time>
+				<extensions>
+					<speed>4.876861095428467</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014311903979925" lon="-84.20251872359282">
+				<ele>938.2308887410909</ele>
+				<time>2017-10-09T19:16:35Z</time>
+				<extensions>
+					<speed>3.1909730434417725</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014295984451595" lon="-84.20251864441522">
+				<ele>937.9373995037749</ele>
+				<time>2017-10-09T19:16:36Z</time>
+				<extensions>
+					<speed>1.4659197330474854</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014290691715583" lon="-84.20251579642321">
+				<ele>937.6304315086454</ele>
+				<time>2017-10-09T19:16:37Z</time>
+				<extensions>
+					<speed>0.5785177946090698</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014290691715583" lon="-84.20251579642321">
+				<ele>937.6304315086454</ele>
+				<time>2017-10-09T19:16:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01429506763954" lon="-84.20250633669974">
+				<ele>937.7610234003514</ele>
+				<time>2017-10-09T19:16:39Z</time>
+				<extensions>
+					<speed>0.42150646448135376</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014291133611763" lon="-84.20249855487099">
+				<ele>937.737537253648</ele>
+				<time>2017-10-09T19:16:40Z</time>
+				<extensions>
+					<speed>1.4354010820388794</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014280179416344" lon="-84.20249085902238">
+				<ele>937.3749906811863</ele>
+				<time>2017-10-09T19:16:41Z</time>
+				<extensions>
+					<speed>1.6217913627624512</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014266698055414" lon="-84.20248598953361">
+				<ele>937.11490560323</ele>
+				<time>2017-10-09T19:16:42Z</time>
+				<extensions>
+					<speed>1.6369878053665161</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014254391647288" lon="-84.20248215246667">
+				<ele>936.929117382504</ele>
+				<time>2017-10-09T19:16:43Z</time>
+				<extensions>
+					<speed>1.4843881130218506</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014240142982006" lon="-84.20247301777722">
+				<ele>936.3347773626447</ele>
+				<time>2017-10-09T19:16:44Z</time>
+				<extensions>
+					<speed>2.0931859016418457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014221612556279" lon="-84.20245693745696">
+				<ele>935.9325934126973</ele>
+				<time>2017-10-09T19:16:45Z</time>
+				<extensions>
+					<speed>2.813708782196045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014201915084385" lon="-84.20243562745135">
+				<ele>935.4477064600214</ele>
+				<time>2017-10-09T19:16:46Z</time>
+				<extensions>
+					<speed>3.286334753036499</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014178908601034" lon="-84.20240253066383">
+				<ele>935.0983326444402</ele>
+				<time>2017-10-09T19:16:47Z</time>
+				<extensions>
+					<speed>4.647085666656494</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014151601638057" lon="-84.20235825512304">
+				<ele>934.7090103868395</ele>
+				<time>2017-10-09T19:16:48Z</time>
+				<extensions>
+					<speed>6.120237827301025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014120402049134" lon="-84.20230296582872">
+				<ele>934.8098726533353</ele>
+				<time>2017-10-09T19:16:49Z</time>
+				<extensions>
+					<speed>6.8075408935546875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014088270092456" lon="-84.20224064393014">
+				<ele>934.8115085205063</ele>
+				<time>2017-10-09T19:16:50Z</time>
+				<extensions>
+					<speed>7.635256290435791</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014053858332643" lon="-84.20217559460049">
+				<ele>934.9011319428682</ele>
+				<time>2017-10-09T19:16:51Z</time>
+				<extensions>
+					<speed>7.660778045654297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014023615545915" lon="-84.20211148128918">
+				<ele>934.9380830796435</ele>
+				<time>2017-10-09T19:16:52Z</time>
+				<extensions>
+					<speed>7.684014797210693</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013992783590941" lon="-84.20205039015211">
+				<ele>935.1886791260913</ele>
+				<time>2017-10-09T19:16:53Z</time>
+				<extensions>
+					<speed>7.425524711608887</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013963501834153" lon="-84.20199295787506">
+				<ele>935.4763018544763</ele>
+				<time>2017-10-09T19:16:54Z</time>
+				<extensions>
+					<speed>6.950747966766357</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013934426775972" lon="-84.20194201600661">
+				<ele>935.8617540393025</ele>
+				<time>2017-10-09T19:16:55Z</time>
+				<extensions>
+					<speed>6.513619422912598</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013904859129468" lon="-84.20189623791752">
+				<ele>936.0568525455892</ele>
+				<time>2017-10-09T19:16:56Z</time>
+				<extensions>
+					<speed>6.136501312255859</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013876410458428" lon="-84.20185439450424">
+				<ele>936.7255670595914</ele>
+				<time>2017-10-09T19:16:57Z</time>
+				<extensions>
+					<speed>5.203976631164551</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013851905630347" lon="-84.20181551882567">
+				<ele>937.3172127893195</ele>
+				<time>2017-10-09T19:16:58Z</time>
+				<extensions>
+					<speed>4.924450397491455</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013829225929147" lon="-84.20177852351394">
+				<ele>937.8250417904928</ele>
+				<time>2017-10-09T19:16:59Z</time>
+				<extensions>
+					<speed>4.697404861450195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013810342553917" lon="-84.20174835571426">
+				<ele>938.120872204192</ele>
+				<time>2017-10-09T19:17:00Z</time>
+				<extensions>
+					<speed>3.7641501426696777</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013792505957003" lon="-84.20171927656955">
+				<ele>938.3069434110075</ele>
+				<time>2017-10-09T19:17:01Z</time>
+				<extensions>
+					<speed>3.707488775253296</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013773270138824" lon="-84.20169034388223">
+				<ele>938.6106652542949</ele>
+				<time>2017-10-09T19:17:02Z</time>
+				<extensions>
+					<speed>3.8319034576416016</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0137514328962" lon="-84.20166288197677">
+				<ele>938.6948674963787</ele>
+				<time>2017-10-09T19:17:03Z</time>
+				<extensions>
+					<speed>3.858308792114258</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013729444587371" lon="-84.20163701396389">
+				<ele>938.5186069654301</ele>
+				<time>2017-10-09T19:17:04Z</time>
+				<extensions>
+					<speed>4.069331169128418</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013704037208083" lon="-84.20160903566723">
+				<ele>938.3942561540753</ele>
+				<time>2017-10-09T19:17:05Z</time>
+				<extensions>
+					<speed>4.415530204772949</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013676672627051" lon="-84.20157939424585">
+				<ele>938.3210135465488</ele>
+				<time>2017-10-09T19:17:06Z</time>
+				<extensions>
+					<speed>4.413459777832031</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01364958001137" lon="-84.20154764571639">
+				<ele>938.6462714700028</ele>
+				<time>2017-10-09T19:17:07Z</time>
+				<extensions>
+					<speed>4.762360572814941</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013623705271705" lon="-84.20151528564207">
+				<ele>938.3659570328891</ele>
+				<time>2017-10-09T19:17:08Z</time>
+				<extensions>
+					<speed>4.579876899719238</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013598111462446" lon="-84.20148157739163">
+				<ele>937.894310887903</ele>
+				<time>2017-10-09T19:17:09Z</time>
+				<extensions>
+					<speed>4.829709529876709</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013570050876954" lon="-84.20144870633405">
+				<ele>937.8531773351133</ele>
+				<time>2017-10-09T19:17:10Z</time>
+				<extensions>
+					<speed>4.562746047973633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013542642295832" lon="-84.20141413475389">
+				<ele>937.7330234386027</ele>
+				<time>2017-10-09T19:17:11Z</time>
+				<extensions>
+					<speed>4.645087242126465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01351510526729" lon="-84.20137979796229">
+				<ele>937.6863167900592</ele>
+				<time>2017-10-09T19:17:12Z</time>
+				<extensions>
+					<speed>4.523344039916992</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013489528057992" lon="-84.20134322161209">
+				<ele>937.5239952430129</ele>
+				<time>2017-10-09T19:17:13Z</time>
+				<extensions>
+					<speed>4.5805745124816895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01346145296527" lon="-84.20130763809738">
+				<ele>937.684961550869</ele>
+				<time>2017-10-09T19:17:14Z</time>
+				<extensions>
+					<speed>4.692339897155762</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013428935909532" lon="-84.20127221665028">
+				<ele>938.3762035490945</ele>
+				<time>2017-10-09T19:17:15Z</time>
+				<extensions>
+					<speed>4.558921813964844</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013400106291245" lon="-84.20123764576603">
+				<ele>938.689259189181</ele>
+				<time>2017-10-09T19:17:16Z</time>
+				<extensions>
+					<speed>4.247891426086426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013376723708287" lon="-84.2012048774323">
+				<ele>939.503004712984</ele>
+				<time>2017-10-09T19:17:17Z</time>
+				<extensions>
+					<speed>3.562325954437256</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013353860658787" lon="-84.20117869556314">
+				<ele>939.761186116375</ele>
+				<time>2017-10-09T19:17:18Z</time>
+				<extensions>
+					<speed>2.9613888263702393</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013335292770574" lon="-84.20115912657413">
+				<ele>939.8084135614336</ele>
+				<time>2017-10-09T19:17:19Z</time>
+				<extensions>
+					<speed>2.2695209980010986</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01332231549546" lon="-84.20114506198772">
+				<ele>940.1954898415133</ele>
+				<time>2017-10-09T19:17:20Z</time>
+				<extensions>
+					<speed>1.5457602739334106</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013313722101712" lon="-84.20113883187284">
+				<ele>940.7902597812936</ele>
+				<time>2017-10-09T19:17:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013312467746175" lon="-84.20113953815137">
+				<ele>940.698667676188</ele>
+				<time>2017-10-09T19:17:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013312467746175" lon="-84.20113953815137">
+				<ele>940.698667676188</ele>
+				<time>2017-10-09T19:17:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013312467746175" lon="-84.20113953815137">
+				<ele>940.698667676188</ele>
+				<time>2017-10-09T19:17:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013312467746175" lon="-84.20113953815137">
+				<ele>940.698667676188</ele>
+				<time>2017-10-09T19:17:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013312467746175" lon="-84.20113953815137">
+				<ele>940.698667676188</ele>
+				<time>2017-10-09T19:17:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013312467746175" lon="-84.20113953815137">
+				<ele>940.698667676188</ele>
+				<time>2017-10-09T19:17:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013312467746175" lon="-84.20113953815137">
+				<ele>940.698667676188</ele>
+				<time>2017-10-09T19:17:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013312467746175" lon="-84.20113953815137">
+				<ele>940.698667676188</ele>
+				<time>2017-10-09T19:17:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013309999221711" lon="-84.20113342047867">
+				<ele>941.3204206172377</ele>
+				<time>2017-10-09T19:17:30Z</time>
+				<extensions>
+					<speed>0.9263527989387512</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013302315998494" lon="-84.20112195102227">
+				<ele>941.7897264696658</ele>
+				<time>2017-10-09T19:17:31Z</time>
+				<extensions>
+					<speed>1.6130295991897583</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013289345012913" lon="-84.20110906223435">
+				<ele>942.4797241985798</ele>
+				<time>2017-10-09T19:17:32Z</time>
+				<extensions>
+					<speed>1.9169597625732422</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013270505815685" lon="-84.20109459842887">
+				<ele>942.6830995855853</ele>
+				<time>2017-10-09T19:17:33Z</time>
+				<extensions>
+					<speed>2.351533889770508</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013251318792873" lon="-84.20107825592346">
+				<ele>942.819297183305</ele>
+				<time>2017-10-09T19:17:34Z</time>
+				<extensions>
+					<speed>2.0497868061065674</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013234043116114" lon="-84.20106459248622">
+				<ele>943.1540703838691</ele>
+				<time>2017-10-09T19:17:35Z</time>
+				<extensions>
+					<speed>1.527806043624878</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013221929095806" lon="-84.2010552912766">
+				<ele>943.4746942734346</ele>
+				<time>2017-10-09T19:17:36Z</time>
+				<extensions>
+					<speed>1.226278305053711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013213789893566" lon="-84.20104695959247">
+				<ele>943.2592596365139</ele>
+				<time>2017-10-09T19:17:37Z</time>
+				<extensions>
+					<speed>0.8628743886947632</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013213789893566" lon="-84.20104695959247">
+				<ele>943.2592596365139</ele>
+				<time>2017-10-09T19:17:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01320983282893" lon="-84.20104474305376">
+				<ele>943.0291446782649</ele>
+				<time>2017-10-09T19:17:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01320983282893" lon="-84.20104474305376">
+				<ele>943.0291446782649</ele>
+				<time>2017-10-09T19:17:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01320983282893" lon="-84.20104474305376">
+				<ele>943.0291446782649</ele>
+				<time>2017-10-09T19:17:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01320983282893" lon="-84.20104474305376">
+				<ele>943.0291446782649</ele>
+				<time>2017-10-09T19:17:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01320983282893" lon="-84.20104474305376">
+				<ele>943.0291446782649</ele>
+				<time>2017-10-09T19:17:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013208476640353" lon="-84.20103877429436">
+				<ele>942.3274350473657</ele>
+				<time>2017-10-09T19:17:44Z</time>
+				<extensions>
+					<speed>1.3774125576019287</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013199364429441" lon="-84.20102597867121">
+				<ele>941.8442126251757</ele>
+				<time>2017-10-09T19:17:45Z</time>
+				<extensions>
+					<speed>1.8634988069534302</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01318624746581" lon="-84.20101086827434">
+				<ele>941.3684950638562</ele>
+				<time>2017-10-09T19:17:46Z</time>
+				<extensions>
+					<speed>2.353753089904785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013173586824422" lon="-84.20099056909619">
+				<ele>941.1560586402193</ele>
+				<time>2017-10-09T19:17:47Z</time>
+				<extensions>
+					<speed>2.992175340652466</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01316047427718" lon="-84.20096723172966">
+				<ele>941.2122735399753</ele>
+				<time>2017-10-09T19:17:48Z</time>
+				<extensions>
+					<speed>3.05784010887146</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013148546995483" lon="-84.20094251465041">
+				<ele>941.4151717834175</ele>
+				<time>2017-10-09T19:17:49Z</time>
+				<extensions>
+					<speed>3.052497625350952</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013136133088596" lon="-84.20092057550455">
+				<ele>941.9974675262347</ele>
+				<time>2017-10-09T19:17:50Z</time>
+				<extensions>
+					<speed>2.562767267227173</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013124802985544" lon="-84.20090242269217">
+				<ele>942.1353808026761</ele>
+				<time>2017-10-09T19:17:51Z</time>
+				<extensions>
+					<speed>2.1656439304351807</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01311739392383" lon="-84.20088595010802">
+				<ele>941.9850687915459</ele>
+				<time>2017-10-09T19:17:52Z</time>
+				<extensions>
+					<speed>1.6176667213439941</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013113042284093" lon="-84.20086827053927">
+				<ele>941.784255838953</ele>
+				<time>2017-10-09T19:17:53Z</time>
+				<extensions>
+					<speed>1.3946037292480469</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013105566601865" lon="-84.20085489308602">
+				<ele>942.0755947995931</ele>
+				<time>2017-10-09T19:17:54Z</time>
+				<extensions>
+					<speed>1.582592248916626</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013097039934147" lon="-84.20084093357718">
+				<ele>942.0978931291029</ele>
+				<time>2017-10-09T19:17:55Z</time>
+				<extensions>
+					<speed>1.7489267587661743</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01308836202937" lon="-84.20082599600147">
+				<ele>941.8937104400247</ele>
+				<time>2017-10-09T19:17:56Z</time>
+				<extensions>
+					<speed>1.8625942468643188</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013078929191275" lon="-84.20081160017654">
+				<ele>942.1616945397109</ele>
+				<time>2017-10-09T19:17:57Z</time>
+				<extensions>
+					<speed>1.938366413116455</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013070508917131" lon="-84.20079809637849">
+				<ele>942.1318168370053</ele>
+				<time>2017-10-09T19:17:58Z</time>
+				<extensions>
+					<speed>1.6213667392730713</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013062369593927" lon="-84.20078515634931">
+				<ele>942.2156465221196</ele>
+				<time>2017-10-09T19:17:59Z</time>
+				<extensions>
+					<speed>1.5127841234207153</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013054130604791" lon="-84.2007704748987">
+				<ele>942.5857788370922</ele>
+				<time>2017-10-09T19:18:00Z</time>
+				<extensions>
+					<speed>1.8104058504104614</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0130472282223" lon="-84.20075002504186">
+				<ele>942.9009507540613</ele>
+				<time>2017-10-09T19:18:01Z</time>
+				<extensions>
+					<speed>2.198021650314331</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013045579095573" lon="-84.20072364309318">
+				<ele>943.857139297761</ele>
+				<time>2017-10-09T19:18:02Z</time>
+				<extensions>
+					<speed>2.9053752422332764</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01305010925435" lon="-84.2006942102431">
+				<ele>944.3467984814197</ele>
+				<time>2017-10-09T19:18:03Z</time>
+				<extensions>
+					<speed>3.449976921081543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01305870729917" lon="-84.20066210303246">
+				<ele>944.356060737744</ele>
+				<time>2017-10-09T19:18:04Z</time>
+				<extensions>
+					<speed>4.061270236968994</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013077547711562" lon="-84.20063360724244">
+				<ele>943.9153028782457</ele>
+				<time>2017-10-09T19:18:05Z</time>
+				<extensions>
+					<speed>3.7476799488067627</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013101472792659" lon="-84.20060674606313">
+				<ele>943.6876043956727</ele>
+				<time>2017-10-09T19:18:06Z</time>
+				<extensions>
+					<speed>4.130343914031982</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013134394251397" lon="-84.20057925957428">
+				<ele>943.5402669040486</ele>
+				<time>2017-10-09T19:18:07Z</time>
+				<extensions>
+					<speed>5.269073486328125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01317711389784" lon="-84.20055573559256">
+				<ele>943.4780927440152</ele>
+				<time>2017-10-09T19:18:08Z</time>
+				<extensions>
+					<speed>5.289781093597412</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013222660611167" lon="-84.20053321690526">
+				<ele>943.6145913330838</ele>
+				<time>2017-10-09T19:18:09Z</time>
+				<extensions>
+					<speed>5.65795373916626</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013266207239468" lon="-84.20050808541947">
+				<ele>943.951767001301</ele>
+				<time>2017-10-09T19:18:10Z</time>
+				<extensions>
+					<speed>5.596447944641113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013306607156482" lon="-84.20048154859641">
+				<ele>944.365545659326</ele>
+				<time>2017-10-09T19:18:11Z</time>
+				<extensions>
+					<speed>5.4177470207214355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01334572386431" lon="-84.20045379898598">
+				<ele>944.822402025573</ele>
+				<time>2017-10-09T19:18:12Z</time>
+				<extensions>
+					<speed>5.418337821960449</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013385055193513" lon="-84.20042488468947">
+				<ele>945.5745519744232</ele>
+				<time>2017-10-09T19:18:13Z</time>
+				<extensions>
+					<speed>5.318669319152832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013424052286874" lon="-84.20039491102575">
+				<ele>945.9698903718963</ele>
+				<time>2017-10-09T19:18:14Z</time>
+				<extensions>
+					<speed>5.4425482749938965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013465193255392" lon="-84.20036951723952">
+				<ele>946.0216847183183</ele>
+				<time>2017-10-09T19:18:15Z</time>
+				<extensions>
+					<speed>5.125070095062256</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01350819957572" lon="-84.20034539146452">
+				<ele>946.0301787918434</ele>
+				<time>2017-10-09T19:18:16Z</time>
+				<extensions>
+					<speed>5.374843597412109</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013554633870381" lon="-84.20031918850631">
+				<ele>946.030502977781</ele>
+				<time>2017-10-09T19:18:17Z</time>
+				<extensions>
+					<speed>5.546250343322754</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01360209906554" lon="-84.20029266623773">
+				<ele>945.9172509554774</ele>
+				<time>2017-10-09T19:18:18Z</time>
+				<extensions>
+					<speed>5.810256481170654</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0136509700859" lon="-84.20026280244434">
+				<ele>945.7074317317456</ele>
+				<time>2017-10-09T19:18:19Z</time>
+				<extensions>
+					<speed>6.1468305587768555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013700262065884" lon="-84.20022826469938">
+				<ele>945.5611440008506</ele>
+				<time>2017-10-09T19:18:20Z</time>
+				<extensions>
+					<speed>6.491080284118652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013749529164173" lon="-84.2001895806095">
+				<ele>945.2307935701683</ele>
+				<time>2017-10-09T19:18:21Z</time>
+				<extensions>
+					<speed>6.699810028076172</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013798453506077" lon="-84.20014960800026">
+				<ele>944.9960373872891</ele>
+				<time>2017-10-09T19:18:22Z</time>
+				<extensions>
+					<speed>6.566072463989258</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013844679140165" lon="-84.20010553732736">
+				<ele>944.8375130519271</ele>
+				<time>2017-10-09T19:18:23Z</time>
+				<extensions>
+					<speed>6.991567611694336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01389023663293" lon="-84.20005410988769">
+				<ele>944.6896891891956</ele>
+				<time>2017-10-09T19:18:24Z</time>
+				<extensions>
+					<speed>6.906759262084961</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013933257482945" lon="-84.20000698494802">
+				<ele>944.8088619122282</ele>
+				<time>2017-10-09T19:18:25Z</time>
+				<extensions>
+					<speed>6.925925254821777</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013976919292908" lon="-84.19995683009456">
+				<ele>945.061080461368</ele>
+				<time>2017-10-09T19:18:26Z</time>
+				<extensions>
+					<speed>6.914417266845703</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014020288546702" lon="-84.19990900136875">
+				<ele>945.316199385561</ele>
+				<time>2017-10-09T19:18:27Z</time>
+				<extensions>
+					<speed>6.914469242095947</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014062913828798" lon="-84.19986123750336">
+				<ele>946.2462812857702</ele>
+				<time>2017-10-09T19:18:28Z</time>
+				<extensions>
+					<speed>6.931616306304932</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014107901238033" lon="-84.19981150742433">
+				<ele>947.1173174399883</ele>
+				<time>2017-10-09T19:18:29Z</time>
+				<extensions>
+					<speed>7.213132858276367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014154851417265" lon="-84.19976188284967">
+				<ele>947.7612292030826</ele>
+				<time>2017-10-09T19:18:30Z</time>
+				<extensions>
+					<speed>7.336865425109863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014205875459698" lon="-84.1997144075563">
+				<ele>948.5366095881909</ele>
+				<time>2017-10-09T19:18:31Z</time>
+				<extensions>
+					<speed>7.124832630157471</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014257588760065" lon="-84.19966862178043">
+				<ele>948.983749140054</ele>
+				<time>2017-10-09T19:18:32Z</time>
+				<extensions>
+					<speed>7.103753566741943</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014308024252431" lon="-84.19962331504674">
+				<ele>949.1146649075672</ele>
+				<time>2017-10-09T19:18:33Z</time>
+				<extensions>
+					<speed>6.912943363189697</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014358752406542" lon="-84.19958084500857">
+				<ele>949.3852948537096</ele>
+				<time>2017-10-09T19:18:34Z</time>
+				<extensions>
+					<speed>7.2145256996154785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01441121255589" lon="-84.1995383127649">
+				<ele>949.901680810377</ele>
+				<time>2017-10-09T19:18:35Z</time>
+				<extensions>
+					<speed>7.173349380493164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014463812592425" lon="-84.1994973532567">
+				<ele>950.48695767764</ele>
+				<time>2017-10-09T19:18:36Z</time>
+				<extensions>
+					<speed>6.978540897369385</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014516056501497" lon="-84.1994566408114">
+				<ele>951.4391866242513</ele>
+				<time>2017-10-09T19:18:37Z</time>
+				<extensions>
+					<speed>7.2133355140686035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014568336133213" lon="-84.19941474284754">
+				<ele>952.6881894012913</ele>
+				<time>2017-10-09T19:18:38Z</time>
+				<extensions>
+					<speed>7.210342884063721</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014619416788223" lon="-84.19937210101">
+				<ele>953.198364675045</ele>
+				<time>2017-10-09T19:18:39Z</time>
+				<extensions>
+					<speed>7.165093898773193</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014670654056593" lon="-84.19932903591712">
+				<ele>953.6063449103385</ele>
+				<time>2017-10-09T19:18:40Z</time>
+				<extensions>
+					<speed>7.37900447845459</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01472382775794" lon="-84.19928724359059">
+				<ele>953.643042832613</ele>
+				<time>2017-10-09T19:18:41Z</time>
+				<extensions>
+					<speed>7.318350791931152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014777701717678" lon="-84.19924577677574">
+				<ele>953.9248133646324</ele>
+				<time>2017-10-09T19:18:42Z</time>
+				<extensions>
+					<speed>7.393647193908691</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014831004607437" lon="-84.19920280617764">
+				<ele>953.9685191065073</ele>
+				<time>2017-10-09T19:18:43Z</time>
+				<extensions>
+					<speed>7.474379062652588</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014884987175567" lon="-84.19915757404152">
+				<ele>953.6539553347975</ele>
+				<time>2017-10-09T19:18:44Z</time>
+				<extensions>
+					<speed>7.592143535614014</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014940696356804" lon="-84.19911447648165">
+				<ele>953.9959044419229</ele>
+				<time>2017-10-09T19:18:45Z</time>
+				<extensions>
+					<speed>7.557518005371094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014996094284703" lon="-84.19907135375196">
+				<ele>953.900606084615</ele>
+				<time>2017-10-09T19:18:46Z</time>
+				<extensions>
+					<speed>7.469124794006348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015051146398903" lon="-84.19902730173725">
+				<ele>954.0600345758721</ele>
+				<time>2017-10-09T19:18:47Z</time>
+				<extensions>
+					<speed>7.454610347747803</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015107844008877" lon="-84.19898217463722">
+				<ele>954.6578236790374</ele>
+				<time>2017-10-09T19:18:48Z</time>
+				<extensions>
+					<speed>7.767337322235107</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015164271196666" lon="-84.19893630978024">
+				<ele>955.1866059284657</ele>
+				<time>2017-10-09T19:18:49Z</time>
+				<extensions>
+					<speed>7.7937493324279785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015221018107866" lon="-84.1988882025616">
+				<ele>956.1147075518966</ele>
+				<time>2017-10-09T19:18:50Z</time>
+				<extensions>
+					<speed>8.194263458251953</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01527718088082" lon="-84.19883831566696">
+				<ele>956.476627628319</ele>
+				<time>2017-10-09T19:18:51Z</time>
+				<extensions>
+					<speed>8.011322975158691</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015331806943312" lon="-84.19878765474886">
+				<ele>957.3599067917094</ele>
+				<time>2017-10-09T19:18:52Z</time>
+				<extensions>
+					<speed>8.105615615844727</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015384800381122" lon="-84.19872954308467">
+				<ele>957.9141426160932</ele>
+				<time>2017-10-09T19:18:53Z</time>
+				<extensions>
+					<speed>8.168932914733887</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015431081259747" lon="-84.19866663699673">
+				<ele>958.3769687162712</ele>
+				<time>2017-10-09T19:18:54Z</time>
+				<extensions>
+					<speed>8.666058540344238</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01547402593267" lon="-84.19859698075496">
+				<ele>958.6346822939813</ele>
+				<time>2017-10-09T19:18:55Z</time>
+				<extensions>
+					<speed>8.88734245300293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015510949797967" lon="-84.19852313743232">
+				<ele>959.1850254843011</ele>
+				<time>2017-10-09T19:18:56Z</time>
+				<extensions>
+					<speed>9.011743545532227</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015542258353417" lon="-84.19844383552227">
+				<ele>959.6430456824601</ele>
+				<time>2017-10-09T19:18:57Z</time>
+				<extensions>
+					<speed>9.366253852844238</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015570165052226" lon="-84.19835865256556">
+				<ele>960.0355783384293</ele>
+				<time>2017-10-09T19:18:58Z</time>
+				<extensions>
+					<speed>9.3486909866333</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015597373873739" lon="-84.19827451550516">
+				<ele>960.5078972503543</ele>
+				<time>2017-10-09T19:18:59Z</time>
+				<extensions>
+					<speed>9.304400444030762</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015627520260962" lon="-84.19819370677213">
+				<ele>961.0814362419769</ele>
+				<time>2017-10-09T19:19:00Z</time>
+				<extensions>
+					<speed>9.372294425964355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01566046992403" lon="-84.19811453188653">
+				<ele>961.3223171737045</ele>
+				<time>2017-10-09T19:19:01Z</time>
+				<extensions>
+					<speed>9.259638786315918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015695029899593" lon="-84.19803635749616">
+				<ele>961.3859363645315</ele>
+				<time>2017-10-09T19:19:02Z</time>
+				<extensions>
+					<speed>9.157038688659668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015730538296209" lon="-84.19795762019831">
+				<ele>961.6992523288354</ele>
+				<time>2017-10-09T19:19:03Z</time>
+				<extensions>
+					<speed>9.16295051574707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015766356814108" lon="-84.19787899367229">
+				<ele>962.0692946873605</ele>
+				<time>2017-10-09T19:19:04Z</time>
+				<extensions>
+					<speed>9.446279525756836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015802187317066" lon="-84.19779891245166">
+				<ele>962.6145069003105</ele>
+				<time>2017-10-09T19:19:05Z</time>
+				<extensions>
+					<speed>9.680038452148438</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015839036365232" lon="-84.19771703248759">
+				<ele>963.1851340346038</ele>
+				<time>2017-10-09T19:19:06Z</time>
+				<extensions>
+					<speed>9.74992561340332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015878128167236" lon="-84.19763430290098">
+				<ele>964.2804660275578</ele>
+				<time>2017-10-09T19:19:07Z</time>
+				<extensions>
+					<speed>9.789108276367188</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015916023429986" lon="-84.19755618658503">
+				<ele>965.1533911693841</ele>
+				<time>2017-10-09T19:19:08Z</time>
+				<extensions>
+					<speed>9.766620635986328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01595268884096" lon="-84.19747486478437">
+				<ele>965.766858138144</ele>
+				<time>2017-10-09T19:19:09Z</time>
+				<extensions>
+					<speed>9.5130033493042</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01598979638268" lon="-84.19739474364073">
+				<ele>966.4316272493452</ele>
+				<time>2017-10-09T19:19:10Z</time>
+				<extensions>
+					<speed>9.438126564025879</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01602799286654" lon="-84.19731475327828">
+				<ele>967.5142099345103</ele>
+				<time>2017-10-09T19:19:11Z</time>
+				<extensions>
+					<speed>9.43087100982666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016067711274307" lon="-84.19723718050554">
+				<ele>968.1589718423784</ele>
+				<time>2017-10-09T19:19:12Z</time>
+				<extensions>
+					<speed>9.411500930786133</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016107789936486" lon="-84.19716042981901">
+				<ele>968.6922353059053</ele>
+				<time>2017-10-09T19:19:13Z</time>
+				<extensions>
+					<speed>9.293367385864258</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016149682711633" lon="-84.19708562509896">
+				<ele>968.4725680239499</ele>
+				<time>2017-10-09T19:19:14Z</time>
+				<extensions>
+					<speed>9.002050399780273</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016190691644676" lon="-84.19701253217791">
+				<ele>968.2976435292512</ele>
+				<time>2017-10-09T19:19:15Z</time>
+				<extensions>
+					<speed>8.91023063659668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016231788251863" lon="-84.19694201182955">
+				<ele>968.5528724603355</ele>
+				<time>2017-10-09T19:19:16Z</time>
+				<extensions>
+					<speed>8.755080223083496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01627460493485" lon="-84.19687463772522">
+				<ele>968.7143813632429</ele>
+				<time>2017-10-09T19:19:17Z</time>
+				<extensions>
+					<speed>8.572710037231445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016316345024963" lon="-84.19681520152479">
+				<ele>969.0621719090268</ele>
+				<time>2017-10-09T19:19:18Z</time>
+				<extensions>
+					<speed>7.3522491455078125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01635397920356" lon="-84.19676718590071">
+				<ele>969.5458915624768</ele>
+				<time>2017-10-09T19:19:19Z</time>
+				<extensions>
+					<speed>5.898205757141113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01638486307787" lon="-84.19673132616307">
+				<ele>969.9990460192785</ele>
+				<time>2017-10-09T19:19:20Z</time>
+				<extensions>
+					<speed>4.089264392852783</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016406432027805" lon="-84.19670962656248">
+				<ele>969.827427928336</ele>
+				<time>2017-10-09T19:19:21Z</time>
+				<extensions>
+					<speed>2.368072032928467</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016417647821378" lon="-84.19669925757968">
+				<ele>970.2297094818205</ele>
+				<time>2017-10-09T19:19:22Z</time>
+				<extensions>
+					<speed>0.8562890887260437</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01641619890495" lon="-84.19669509081407">
+				<ele>971.0547781735659</ele>
+				<time>2017-10-09T19:19:23Z</time>
+				<extensions>
+					<speed>0.42153501510620117</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01641619890495" lon="-84.19669509081407">
+				<ele>971.0547781735659</ele>
+				<time>2017-10-09T19:19:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016408321781572" lon="-84.19670013597924">
+				<ele>971.2769474834204</ele>
+				<time>2017-10-09T19:19:25Z</time>
+				<extensions>
+					<speed>0.7350032925605774</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016408321781572" lon="-84.19670013597924">
+				<ele>971.2769474834204</ele>
+				<time>2017-10-09T19:19:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016415245574157" lon="-84.19669515010644">
+				<ele>971.1202722815797</ele>
+				<time>2017-10-09T19:19:27Z</time>
+				<extensions>
+					<speed>1.762654423713684</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016431332216703" lon="-84.19667703145748">
+				<ele>971.3854006901383</ele>
+				<time>2017-10-09T19:19:28Z</time>
+				<extensions>
+					<speed>3.3411154747009277</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01645243207874" lon="-84.1966489122884">
+				<ele>971.740681248717</ele>
+				<time>2017-10-09T19:19:29Z</time>
+				<extensions>
+					<speed>4.192817211151123</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016481122351015" lon="-84.19661542328937">
+				<ele>971.6902803443372</ele>
+				<time>2017-10-09T19:19:30Z</time>
+				<extensions>
+					<speed>5.300598621368408</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016514596117066" lon="-84.19657450427675">
+				<ele>971.4948619939387</ele>
+				<time>2017-10-09T19:19:31Z</time>
+				<extensions>
+					<speed>6.288819789886475</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016552994241179" lon="-84.1965300087476">
+				<ele>971.1960781989619</ele>
+				<time>2017-10-09T19:19:32Z</time>
+				<extensions>
+					<speed>6.515101432800293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016595960437884" lon="-84.19648373744623">
+				<ele>971.1471156682819</ele>
+				<time>2017-10-09T19:19:33Z</time>
+				<extensions>
+					<speed>6.5177412033081055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016645436782802" lon="-84.19643540693089">
+				<ele>971.95559139736</ele>
+				<time>2017-10-09T19:19:34Z</time>
+				<extensions>
+					<speed>6.722157955169678</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016692594944239" lon="-84.19639335857413">
+				<ele>972.1349815530702</ele>
+				<time>2017-10-09T19:19:35Z</time>
+				<extensions>
+					<speed>6.569066047668457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016735542152093" lon="-84.19635940912913">
+				<ele>972.1287840325385</ele>
+				<time>2017-10-09T19:19:36Z</time>
+				<extensions>
+					<speed>5.168806552886963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016768966920788" lon="-84.19633632830057">
+				<ele>972.0837085489184</ele>
+				<time>2017-10-09T19:19:37Z</time>
+				<extensions>
+					<speed>3.3542721271514893</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016791371705178" lon="-84.19632099820784">
+				<ele>972.2009077025577</ele>
+				<time>2017-10-09T19:19:38Z</time>
+				<extensions>
+					<speed>2.1131527423858643</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016805881626562" lon="-84.19630886616709">
+				<ele>972.1845261491835</ele>
+				<time>2017-10-09T19:19:39Z</time>
+				<extensions>
+					<speed>1.9020217657089233</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016819534921064" lon="-84.19629672716616">
+				<ele>972.1723766960204</ele>
+				<time>2017-10-09T19:19:40Z</time>
+				<extensions>
+					<speed>1.93204665184021</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016833103996758" lon="-84.1962811079686">
+				<ele>972.4690776299685</ele>
+				<time>2017-10-09T19:19:41Z</time>
+				<extensions>
+					<speed>2.107754707336426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016847518195197" lon="-84.19626303399937">
+				<ele>972.9850057372823</ele>
+				<time>2017-10-09T19:19:42Z</time>
+				<extensions>
+					<speed>2.6206247806549072</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01686625685368" lon="-84.19623997785995">
+				<ele>973.367176271975</ele>
+				<time>2017-10-09T19:19:43Z</time>
+				<extensions>
+					<speed>3.334512233734131</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016893112175211" lon="-84.19621313117628">
+				<ele>973.5915648154914</ele>
+				<time>2017-10-09T19:19:44Z</time>
+				<extensions>
+					<speed>4.5192718505859375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016925428402523" lon="-84.19618558719463">
+				<ele>973.3843676233664</ele>
+				<time>2017-10-09T19:19:45Z</time>
+				<extensions>
+					<speed>5.000119209289551</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016959053362472" lon="-84.19615879919355">
+				<ele>973.4758260296658</ele>
+				<time>2017-10-09T19:19:46Z</time>
+				<extensions>
+					<speed>4.8825812339782715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016994948919823" lon="-84.19612833662313">
+				<ele>973.4916397593915</ele>
+				<time>2017-10-09T19:19:47Z</time>
+				<extensions>
+					<speed>5.511044979095459</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01702923714161" lon="-84.19609528896325">
+				<ele>973.8583865705878</ele>
+				<time>2017-10-09T19:19:48Z</time>
+				<extensions>
+					<speed>5.145845413208008</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017055961291113" lon="-84.19607301340125">
+				<ele>974.6065201796591</ele>
+				<time>2017-10-09T19:19:49Z</time>
+				<extensions>
+					<speed>3.083495855331421</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01707841926894" lon="-84.19605466726681">
+				<ele>975.145978430286</ele>
+				<time>2017-10-09T19:19:50Z</time>
+				<extensions>
+					<speed>2.9628798961639404</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01709984308497" lon="-84.1960348090935">
+				<ele>975.3546169679612</ele>
+				<time>2017-10-09T19:19:51Z</time>
+				<extensions>
+					<speed>2.754072427749634</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017117150704486" lon="-84.19601613072619">
+				<ele>975.7190841287374</ele>
+				<time>2017-10-09T19:19:52Z</time>
+				<extensions>
+					<speed>2.419689416885376</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017131977592728" lon="-84.19599921060892">
+				<ele>976.0591100109741</ele>
+				<time>2017-10-09T19:19:53Z</time>
+				<extensions>
+					<speed>2.6347274780273438</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017151308746897" lon="-84.19598388987757">
+				<ele>976.5750193586573</ele>
+				<time>2017-10-09T19:19:54Z</time>
+				<extensions>
+					<speed>2.7211573123931885</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017174923060013" lon="-84.19597330035177">
+				<ele>977.1252523707226</ele>
+				<time>2017-10-09T19:19:55Z</time>
+				<extensions>
+					<speed>2.394564390182495</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017197916760336" lon="-84.19596881265426">
+				<ele>977.4697706820443</ele>
+				<time>2017-10-09T19:19:56Z</time>
+				<extensions>
+					<speed>1.821725606918335</speed>
+				</extensions>
+			</trkpt>
+		</trkseg>
+	</trk>
+</gpx>

--- a/bus_alajuela-targuases/asistentes/fran_2017_11_13.gpx
+++ b/bus_alajuela-targuases/asistentes/fran_2017_11_13.gpx
@@ -1,0 +1,16475 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="OSMTracker for Android™ - https://github.com/nguillaumin/osmtracker-android" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd ">
+	<wpt lat="10.015290012651647" lon="-84.21340506782886">
+		<ele>966.3718075221404</ele>
+		<time>2017-11-13T17:49:21Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015290012651647" lon="-84.21340506782886">
+		<ele>966.3718075221404</ele>
+		<time>2017-11-13T17:49:22Z</time>
+		<name><![CDATA[3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.010100060847174" lon="-84.21376589753274">
+		<ele>956.3696697503328</ele>
+		<time>2017-11-13T18:04:44Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.010100060847174" lon="-84.21376589753274">
+		<ele>956.3696697503328</ele>
+		<time>2017-11-13T18:04:44Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008560317506456" lon="-84.21032745121671">
+		<ele>917.7477244660258</ele>
+		<time>2017-11-13T18:06:13Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008531696176943" lon="-84.21034226234114">
+		<ele>909.0780306383967</ele>
+		<time>2017-11-13T18:06:15Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008452949981931" lon="-84.20842868377727">
+		<ele>861.5657477816567</ele>
+		<time>2017-11-13T18:07:44Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008452949981931" lon="-84.20842868377727">
+		<ele>861.5657477816567</ele>
+		<time>2017-11-13T18:07:48Z</time>
+		<name><![CDATA[1
+]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.00579564692458" lon="-84.20587828613121">
+		<ele>959.3572421781719</ele>
+		<time>2017-11-13T18:08:52Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.00579564692458" lon="-84.20587828613121">
+		<ele>959.3572421781719</ele>
+		<time>2017-11-13T18:08:53Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.00599916979412" lon="-84.20418674953606">
+		<ele>925.672490471974</ele>
+		<time>2017-11-13T18:10:44Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.005964790934847" lon="-84.20423582294981">
+		<ele>922.9711900744587</ele>
+		<time>2017-11-13T18:10:50Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.006815775450097" lon="-84.20442613503663">
+		<ele>905.6465886402875</ele>
+		<time>2017-11-13T18:11:41Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.006808573932139" lon="-84.20439598245525">
+		<ele>906.1695148767903</ele>
+		<time>2017-11-13T18:11:42Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.007360583994897" lon="-84.20452297027317">
+		<ele>919.1782437441871</ele>
+		<time>2017-11-13T18:12:19Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.00737474947112" lon="-84.20453733090348">
+		<ele>919.3691905895248</ele>
+		<time>2017-11-13T18:12:21Z</time>
+		<name><![CDATA[3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008818012127351" lon="-84.20313031797998">
+		<ele>935.2839201558381</ele>
+		<time>2017-11-13T18:13:11Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008814565173406" lon="-84.20312895321456">
+		<ele>935.0268536107615</ele>
+		<time>2017-11-13T18:13:13Z</time>
+		<name><![CDATA[3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.010063545673832" lon="-84.20202331942849">
+		<ele>921.6030736174434</ele>
+		<time>2017-11-13T18:14:09Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.010075792649594" lon="-84.2019816251046">
+		<ele>916.4559231698513</ele>
+		<time>2017-11-13T18:14:11Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.011505508253826" lon="-84.20136065448474">
+		<ele>932.5822177408263</ele>
+		<time>2017-11-13T18:14:57Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.011513078084835" lon="-84.20139281428362">
+		<ele>932.0383936269209</ele>
+		<time>2017-11-13T18:14:59Z</time>
+		<name><![CDATA[2]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.01539377861645" lon="-84.20174028117823">
+		<ele>933.1781846145168</ele>
+		<time>2017-11-13T18:18:06Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015378725136186" lon="-84.20174847384806">
+		<ele>933.8627359047532</ele>
+		<time>2017-11-13T18:18:07Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.014494837505344" lon="-84.19949443030644">
+		<ele>971.2862386144698</ele>
+		<time>2017-11-13T18:21:04Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.014484058876343" lon="-84.19951715779595">
+		<ele>972.5293657118455</ele>
+		<time>2017-11-13T18:21:07Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<trk>
+		<name><![CDATA[Trazado con OSMTracker para Android™]]></name>
+		<trkseg>
+			<trkpt lat="10.014328534216219" lon="-84.21695518073831">
+				<ele>960.5126571143046</ele>
+				<time>2017-11-13T17:42:59Z</time>
+				<extensions>
+					<speed>0.4890930652618408</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012030572309843" lon="-84.19851496046515">
+				<ele>4168.17060262803</ele>
+				<time>2017-11-13T17:42:59Z</time>
+				<extensions>
+					<speed>2.9652554988861084</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014273274069946" lon="-84.21693345008613">
+				<ele>942.6229873560369</ele>
+				<time>2017-11-13T17:43:00Z</time>
+				<extensions>
+					<speed>1.2549046277999878</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345430216485" lon="-84.21694754436776">
+				<ele>956.5233958764002</ele>
+				<time>2017-11-13T17:43:01Z</time>
+				<extensions>
+					<speed>1.325683355331421</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014384522226964" lon="-84.216942078574">
+				<ele>972.4178849952295</ele>
+				<time>2017-11-13T17:43:02Z</time>
+				<extensions>
+					<speed>0.7210051417350769</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014309547646915" lon="-84.21686246411588">
+				<ele>951.6282407632098</ele>
+				<time>2017-11-13T17:43:03Z</time>
+				<extensions>
+					<speed>0.806764543056488</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01424852502857" lon="-84.21689204978442">
+				<ele>949.7601525327191</ele>
+				<time>2017-11-13T17:43:04Z</time>
+				<extensions>
+					<speed>0.1523590385913849</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:05Z</time>
+				<extensions>
+					<speed>0.19857405126094818</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:43:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:44:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:44:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:44:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:44:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:44:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:44:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014229926553247" lon="-84.21688909223246">
+				<ele>957.4486072221771</ele>
+				<time>2017-11-13T17:44:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014237316807835" lon="-84.21688159742237">
+				<ele>957.1627527633682</ele>
+				<time>2017-11-13T17:44:07Z</time>
+				<extensions>
+					<speed>0.7549943923950195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01424498344293" lon="-84.21687075298979">
+				<ele>957.2108162734658</ele>
+				<time>2017-11-13T17:44:08Z</time>
+				<extensions>
+					<speed>1.1849114894866943</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01425416159998" lon="-84.21686159287886">
+				<ele>957.6089916387573</ele>
+				<time>2017-11-13T17:44:09Z</time>
+				<extensions>
+					<speed>1.4492543935775757</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014262372723582" lon="-84.21684607619312">
+				<ele>957.5298969289288</ele>
+				<time>2017-11-13T17:44:10Z</time>
+				<extensions>
+					<speed>1.9570919275283813</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014275731842229" lon="-84.21683223568958">
+				<ele>957.4903198350221</ele>
+				<time>2017-11-13T17:44:11Z</time>
+				<extensions>
+					<speed>2.2063984870910645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014291038824505" lon="-84.21681600044795">
+				<ele>957.3841897882521</ele>
+				<time>2017-11-13T17:44:12Z</time>
+				<extensions>
+					<speed>2.349548101425171</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014305960977465" lon="-84.21679952245304">
+				<ele>957.2363453991711</ele>
+				<time>2017-11-13T17:44:13Z</time>
+				<extensions>
+					<speed>2.39274263381958</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320650500375" lon="-84.21678544259626">
+				<ele>957.3362199002877</ele>
+				<time>2017-11-13T17:44:14Z</time>
+				<extensions>
+					<speed>2.1619033813476563</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014329902435835" lon="-84.21678408074328">
+				<ele>956.7794723268598</ele>
+				<time>2017-11-13T17:44:15Z</time>
+				<extensions>
+					<speed>1.3199963569641113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014342161164945" lon="-84.21678971691222">
+				<ele>956.4624757980928</ele>
+				<time>2017-11-13T17:44:16Z</time>
+				<extensions>
+					<speed>0.5718103051185608</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014354249898922" lon="-84.21678695472829">
+				<ele>957.2843219609931</ele>
+				<time>2017-11-13T17:44:17Z</time>
+				<extensions>
+					<speed>0.2169790118932724</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014354249898922" lon="-84.21678695472829">
+				<ele>957.2843219609931</ele>
+				<time>2017-11-13T17:44:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014354249898922" lon="-84.21678695472829">
+				<ele>957.2843219609931</ele>
+				<time>2017-11-13T17:44:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014354249898922" lon="-84.21678695472829">
+				<ele>957.2843219609931</ele>
+				<time>2017-11-13T17:44:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014354249898922" lon="-84.21678695472829">
+				<ele>957.2843219609931</ele>
+				<time>2017-11-13T17:44:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014354249898922" lon="-84.21678695472829">
+				<ele>957.2843219609931</ele>
+				<time>2017-11-13T17:44:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014354249898922" lon="-84.21678695472829">
+				<ele>957.2843219609931</ele>
+				<time>2017-11-13T17:44:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014354249898922" lon="-84.21678695472829">
+				<ele>957.2843219609931</ele>
+				<time>2017-11-13T17:44:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014354249898922" lon="-84.21678695472829">
+				<ele>957.2843219609931</ele>
+				<time>2017-11-13T17:44:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014354249898922" lon="-84.21678695472829">
+				<ele>957.2843219609931</ele>
+				<time>2017-11-13T17:44:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014354249898922" lon="-84.21678695472829">
+				<ele>957.2843219609931</ele>
+				<time>2017-11-13T17:44:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014354249898922" lon="-84.21678695472829">
+				<ele>957.2843219609931</ele>
+				<time>2017-11-13T17:44:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014354249898922" lon="-84.21678695472829">
+				<ele>957.2843219609931</ele>
+				<time>2017-11-13T17:44:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014354249898922" lon="-84.21678695472829">
+				<ele>957.2843219609931</ele>
+				<time>2017-11-13T17:44:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014352803221524" lon="-84.21678061038028">
+				<ele>956.9904585070908</ele>
+				<time>2017-11-13T17:44:31Z</time>
+				<extensions>
+					<speed>0.6661408543586731</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0143495809059" lon="-84.21677199833682">
+				<ele>956.5452475380152</ele>
+				<time>2017-11-13T17:44:32Z</time>
+				<extensions>
+					<speed>0.9022377729415894</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014344215860621" lon="-84.21675790258168">
+				<ele>955.6174774393439</ele>
+				<time>2017-11-13T17:44:33Z</time>
+				<extensions>
+					<speed>0.9943928122520447</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014339694880467" lon="-84.216750298737">
+				<ele>955.5385459093377</ele>
+				<time>2017-11-13T17:44:34Z</time>
+				<extensions>
+					<speed>0.9277085661888123</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014334894686321" lon="-84.2167440326603">
+				<ele>955.9135743929073</ele>
+				<time>2017-11-13T17:44:35Z</time>
+				<extensions>
+					<speed>1.1193174123764038</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01433301936042" lon="-84.21673880545497">
+				<ele>956.3073989357799</ele>
+				<time>2017-11-13T17:44:36Z</time>
+				<extensions>
+					<speed>1.0813500881195068</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014328302643138" lon="-84.21673227868556">
+				<ele>956.3514501778409</ele>
+				<time>2017-11-13T17:44:37Z</time>
+				<extensions>
+					<speed>1.0772277116775513</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014328106596826" lon="-84.21672676295296">
+				<ele>956.3317109094933</ele>
+				<time>2017-11-13T17:44:38Z</time>
+				<extensions>
+					<speed>1.060199499130249</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014331779991295" lon="-84.21671888936349">
+				<ele>956.0015389500186</ele>
+				<time>2017-11-13T17:44:39Z</time>
+				<extensions>
+					<speed>1.3186707496643066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014341662448842" lon="-84.21670312341975">
+				<ele>955.7481565773487</ele>
+				<time>2017-11-13T17:44:40Z</time>
+				<extensions>
+					<speed>1.710665225982666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014351117703551" lon="-84.21669020519457">
+				<ele>955.6932549402118</ele>
+				<time>2017-11-13T17:44:41Z</time>
+				<extensions>
+					<speed>1.7830936908721924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014359309638637" lon="-84.2166786801046">
+				<ele>955.6309769516811</ele>
+				<time>2017-11-13T17:44:42Z</time>
+				<extensions>
+					<speed>1.6919301748275757</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436527858823" lon="-84.21666785198231">
+				<ele>955.5565156964585</ele>
+				<time>2017-11-13T17:44:43Z</time>
+				<extensions>
+					<speed>1.4821940660476685</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437159272849" lon="-84.21666708199085">
+				<ele>955.5197823625058</ele>
+				<time>2017-11-13T17:44:44Z</time>
+				<extensions>
+					<speed>1.0215457677841187</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014371917726379" lon="-84.21666783670908">
+				<ele>955.4067418668419</ele>
+				<time>2017-11-13T17:44:45Z</time>
+				<extensions>
+					<speed>0.5353804230690002</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014366488234428" lon="-84.21666732493237">
+				<ele>955.055640370585</ele>
+				<time>2017-11-13T17:44:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014366488234428" lon="-84.21666732493237">
+				<ele>955.055640370585</ele>
+				<time>2017-11-13T17:44:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014366488234428" lon="-84.21666732493237">
+				<ele>955.055640370585</ele>
+				<time>2017-11-13T17:44:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014366488234428" lon="-84.21666732493237">
+				<ele>955.055640370585</ele>
+				<time>2017-11-13T17:44:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014366488234428" lon="-84.21666732493237">
+				<ele>955.055640370585</ele>
+				<time>2017-11-13T17:44:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014366488234428" lon="-84.21666732493237">
+				<ele>955.055640370585</ele>
+				<time>2017-11-13T17:44:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014366222114436" lon="-84.21665571716437">
+				<ele>954.9384369561449</ele>
+				<time>2017-11-13T17:44:52Z</time>
+				<extensions>
+					<speed>0.6551223993301392</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014366411419354" lon="-84.21664684637685">
+				<ele>954.3298300215974</ele>
+				<time>2017-11-13T17:44:53Z</time>
+				<extensions>
+					<speed>0.7806457281112671</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014370007688907" lon="-84.21663893167">
+				<ele>954.1712114531547</ele>
+				<time>2017-11-13T17:44:54Z</time>
+				<extensions>
+					<speed>0.9694526791572571</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437113850449" lon="-84.21661837274137">
+				<ele>953.3273297129199</ele>
+				<time>2017-11-13T17:44:55Z</time>
+				<extensions>
+					<speed>1.1281076669692993</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014373337311897" lon="-84.21660830811945">
+				<ele>952.7529888730496</ele>
+				<time>2017-11-13T17:44:56Z</time>
+				<extensions>
+					<speed>0.8726212978363037</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014375640851657" lon="-84.2166019775423">
+				<ele>952.283318691887</ele>
+				<time>2017-11-13T17:44:57Z</time>
+				<extensions>
+					<speed>0.5049367547035217</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:44:58Z</time>
+				<extensions>
+					<speed>0.38364917039871216</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:44:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437263235755" lon="-84.21658834765603">
+				<ele>951.1716060051695</ele>
+				<time>2017-11-13T17:45:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436792658966" lon="-84.21658367778362">
+				<ele>949.9107897644863</ele>
+				<time>2017-11-13T17:45:25Z</time>
+				<extensions>
+					<speed>0.632236123085022</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014375640015201" lon="-84.21658514893342">
+				<ele>949.2029913589358</ele>
+				<time>2017-11-13T17:45:26Z</time>
+				<extensions>
+					<speed>1.0466934442520142</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014384330923896" lon="-84.21657073250368">
+				<ele>948.6753028696403</ele>
+				<time>2017-11-13T17:45:27Z</time>
+				<extensions>
+					<speed>1.2480400800704956</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01439337510506" lon="-84.2165516661248">
+				<ele>948.2716631684452</ele>
+				<time>2017-11-13T17:45:28Z</time>
+				<extensions>
+					<speed>1.4927136898040771</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014399468382374" lon="-84.21653113087538">
+				<ele>947.9871767889708</ele>
+				<time>2017-11-13T17:45:29Z</time>
+				<extensions>
+					<speed>1.5919712781906128</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014406155266261" lon="-84.2165144344988">
+				<ele>948.0361738177016</ele>
+				<time>2017-11-13T17:45:30Z</time>
+				<extensions>
+					<speed>1.6336205005645752</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014410326695362" lon="-84.21649770310137">
+				<ele>948.4605934880674</ele>
+				<time>2017-11-13T17:45:31Z</time>
+				<extensions>
+					<speed>1.6006054878234863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01441321083189" lon="-84.216491959276">
+				<ele>948.5454159257933</ele>
+				<time>2017-11-13T17:45:32Z</time>
+				<extensions>
+					<speed>1.456165075302124</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014412992988634" lon="-84.21649638266359">
+				<ele>948.8812466282398</ele>
+				<time>2017-11-13T17:45:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014409748972863" lon="-84.21650230162776">
+				<ele>949.2933720629662</ele>
+				<time>2017-11-13T17:45:34Z</time>
+				<extensions>
+					<speed>0.2880103886127472</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01440308842378" lon="-84.21651041175076">
+				<ele>949.6740106269717</ele>
+				<time>2017-11-13T17:45:35Z</time>
+				<extensions>
+					<speed>0.5301755666732788</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014396984049963" lon="-84.2165158662385">
+				<ele>949.9782075854018</ele>
+				<time>2017-11-13T17:45:36Z</time>
+				<extensions>
+					<speed>0.7292324900627136</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014394648234662" lon="-84.21651861761225">
+				<ele>950.36028058175</ele>
+				<time>2017-11-13T17:45:37Z</time>
+				<extensions>
+					<speed>0.6714723110198975</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014390450280132" lon="-84.2165201022537">
+				<ele>950.6787140630186</ele>
+				<time>2017-11-13T17:45:38Z</time>
+				<extensions>
+					<speed>0.7286732792854309</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014384461812275" lon="-84.21652553643018">
+				<ele>950.9859903035685</ele>
+				<time>2017-11-13T17:45:39Z</time>
+				<extensions>
+					<speed>0.7899526357650757</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01438081829832" lon="-84.21652706134404">
+				<ele>951.5431511858478</ele>
+				<time>2017-11-13T17:45:40Z</time>
+				<extensions>
+					<speed>0.7095663547515869</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437406449397" lon="-84.21653207345092">
+				<ele>952.0158730493858</ele>
+				<time>2017-11-13T17:45:41Z</time>
+				<extensions>
+					<speed>0.7083210349082947</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014367849272023" lon="-84.21653562461582">
+				<ele>952.4506277982146</ele>
+				<time>2017-11-13T17:45:42Z</time>
+				<extensions>
+					<speed>0.6876115798950195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014363425886284" lon="-84.21653832605159">
+				<ele>952.9234256893396</ele>
+				<time>2017-11-13T17:45:43Z</time>
+				<extensions>
+					<speed>0.6724627614021301</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014362551534402" lon="-84.2165341127857">
+				<ele>953.2684484878555</ele>
+				<time>2017-11-13T17:45:44Z</time>
+				<extensions>
+					<speed>0.48388931155204773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014360245622193" lon="-84.21653407444924">
+				<ele>953.0531078791246</ele>
+				<time>2017-11-13T17:45:45Z</time>
+				<extensions>
+					<speed>0.3736710548400879</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014360245622193" lon="-84.21653407444924">
+				<ele>953.0531078791246</ele>
+				<time>2017-11-13T17:45:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014360245622193" lon="-84.21653407444924">
+				<ele>953.0531078791246</ele>
+				<time>2017-11-13T17:45:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014360245622193" lon="-84.21653407444924">
+				<ele>953.0531078791246</ele>
+				<time>2017-11-13T17:45:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014360245622193" lon="-84.21653407444924">
+				<ele>953.0531078791246</ele>
+				<time>2017-11-13T17:45:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014353231583994" lon="-84.21654677893694">
+				<ele>952.7741274544969</ele>
+				<time>2017-11-13T17:45:50Z</time>
+				<extensions>
+					<speed>0.607753574848175</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014348659827588" lon="-84.21655787252558">
+				<ele>952.3313263216987</ele>
+				<time>2017-11-13T17:45:51Z</time>
+				<extensions>
+					<speed>0.660932183265686</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014353437684631" lon="-84.21656154630776">
+				<ele>952.0228914730251</ele>
+				<time>2017-11-13T17:45:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014358072043256" lon="-84.21656194916092">
+				<ele>951.5397564675659</ele>
+				<time>2017-11-13T17:45:53Z</time>
+				<extensions>
+					<speed>0.21699769794940948</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014358072043256" lon="-84.21656194916092">
+				<ele>951.5397564675659</ele>
+				<time>2017-11-13T17:45:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014358072043256" lon="-84.21656194916092">
+				<ele>951.5397564675659</ele>
+				<time>2017-11-13T17:45:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014358072043256" lon="-84.21656194916092">
+				<ele>951.5397564675659</ele>
+				<time>2017-11-13T17:45:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014358072043256" lon="-84.21656194916092">
+				<ele>951.5397564675659</ele>
+				<time>2017-11-13T17:45:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014358072043256" lon="-84.21656194916092">
+				<ele>951.5397564675659</ele>
+				<time>2017-11-13T17:45:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014358072043256" lon="-84.21656194916092">
+				<ele>951.5397564675659</ele>
+				<time>2017-11-13T17:45:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014358072043256" lon="-84.21656194916092">
+				<ele>951.5397564675659</ele>
+				<time>2017-11-13T17:46:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014358072043256" lon="-84.21656194916092">
+				<ele>951.5397564675659</ele>
+				<time>2017-11-13T17:46:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014358072043256" lon="-84.21656194916092">
+				<ele>951.5397564675659</ele>
+				<time>2017-11-13T17:46:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014358072043256" lon="-84.21656194916092">
+				<ele>951.5397564675659</ele>
+				<time>2017-11-13T17:46:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014358072043256" lon="-84.21656194916092">
+				<ele>951.5397564675659</ele>
+				<time>2017-11-13T17:46:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014358072043256" lon="-84.21656194916092">
+				<ele>951.5397564675659</ele>
+				<time>2017-11-13T17:46:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014376713822875" lon="-84.21654907472545">
+				<ele>950.6719553517178</ele>
+				<time>2017-11-13T17:46:06Z</time>
+				<extensions>
+					<speed>1.1280484199523926</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014392112693006" lon="-84.21652726415022">
+				<ele>950.4458379866555</ele>
+				<time>2017-11-13T17:46:07Z</time>
+				<extensions>
+					<speed>1.7336596250534058</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014403727569816" lon="-84.2165011298649">
+				<ele>950.5012656776235</ele>
+				<time>2017-11-13T17:46:08Z</time>
+				<extensions>
+					<speed>2.148343324661255</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01440961878479" lon="-84.21647619207164">
+				<ele>950.6854896200821</ele>
+				<time>2017-11-13T17:46:09Z</time>
+				<extensions>
+					<speed>2.0622646808624268</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01441691040805" lon="-84.21645128112571">
+				<ele>951.0365262357518</ele>
+				<time>2017-11-13T17:46:10Z</time>
+				<extensions>
+					<speed>1.888411283493042</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014419328736933" lon="-84.21643959597337">
+				<ele>951.2985849473625</ele>
+				<time>2017-11-13T17:46:11Z</time>
+				<extensions>
+					<speed>1.2535220384597778</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014425401169543" lon="-84.21642730080356">
+				<ele>951.48789609503</ele>
+				<time>2017-11-13T17:46:12Z</time>
+				<extensions>
+					<speed>0.8046638369560242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014429306570666" lon="-84.21641784306401">
+				<ele>951.4173976164311</ele>
+				<time>2017-11-13T17:46:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014431925417464" lon="-84.21641295938531">
+				<ele>951.3060358371586</ele>
+				<time>2017-11-13T17:46:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014431925417464" lon="-84.21641295938531">
+				<ele>951.3060358371586</ele>
+				<time>2017-11-13T17:46:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014431925417464" lon="-84.21641295938531">
+				<ele>951.3060358371586</ele>
+				<time>2017-11-13T17:46:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014444739506251" lon="-84.21640366492518">
+				<ele>951.4460076289251</ele>
+				<time>2017-11-13T17:46:17Z</time>
+				<extensions>
+					<speed>0.7418869137763977</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014455640958316" lon="-84.21639421343615">
+				<ele>951.643947718665</ele>
+				<time>2017-11-13T17:46:18Z</time>
+				<extensions>
+					<speed>0.7006756663322449</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014462043277932" lon="-84.21638758727164">
+				<ele>951.7979915309697</ele>
+				<time>2017-11-13T17:46:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014465928517762" lon="-84.21638731524392">
+				<ele>951.8111184760928</ele>
+				<time>2017-11-13T17:46:20Z</time>
+				<extensions>
+					<speed>0.19580502808094025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014465928517762" lon="-84.21638731524392">
+				<ele>951.8111184760928</ele>
+				<time>2017-11-13T17:46:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014465928517762" lon="-84.21638731524392">
+				<ele>951.8111184760928</ele>
+				<time>2017-11-13T17:46:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014465928517762" lon="-84.21638731524392">
+				<ele>951.8111184760928</ele>
+				<time>2017-11-13T17:46:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014465928517762" lon="-84.21638731524392">
+				<ele>951.8111184760928</ele>
+				<time>2017-11-13T17:46:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014465928517762" lon="-84.21638731524392">
+				<ele>951.8111184760928</ele>
+				<time>2017-11-13T17:46:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014465928517762" lon="-84.21638731524392">
+				<ele>951.8111184760928</ele>
+				<time>2017-11-13T17:46:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014465928517762" lon="-84.21638731524392">
+				<ele>951.8111184760928</ele>
+				<time>2017-11-13T17:46:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014464214625466" lon="-84.21637361558507">
+				<ele>951.8895339211449</ele>
+				<time>2017-11-13T17:46:28Z</time>
+				<extensions>
+					<speed>0.8326890468597412</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01446906704207" lon="-84.2163526186988">
+				<ele>951.982313580811</ele>
+				<time>2017-11-13T17:46:29Z</time>
+				<extensions>
+					<speed>1.2343015670776367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014480805806325" lon="-84.21633311386546">
+				<ele>952.2522121630609</ele>
+				<time>2017-11-13T17:46:30Z</time>
+				<extensions>
+					<speed>1.6959812641143799</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014505937781873" lon="-84.21630661007633">
+				<ele>952.9985873000696</ele>
+				<time>2017-11-13T17:46:31Z</time>
+				<extensions>
+					<speed>2.4242117404937744</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014520864958492" lon="-84.21628194533265">
+				<ele>953.1288634957746</ele>
+				<time>2017-11-13T17:46:32Z</time>
+				<extensions>
+					<speed>2.220449686050415</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01454195153809" lon="-84.21625626297651">
+				<ele>953.612965375185</ele>
+				<time>2017-11-13T17:46:33Z</time>
+				<extensions>
+					<speed>1.877457857131958</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014563860907575" lon="-84.21624134741363">
+				<ele>954.357650318183</ele>
+				<time>2017-11-13T17:46:34Z</time>
+				<extensions>
+					<speed>1.4005835056304932</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014576978493068" lon="-84.21622715520095">
+				<ele>954.5732308002189</ele>
+				<time>2017-11-13T17:46:35Z</time>
+				<extensions>
+					<speed>1.2220666408538818</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014585598357357" lon="-84.21621367243405">
+				<ele>954.7878263052553</ele>
+				<time>2017-11-13T17:46:36Z</time>
+				<extensions>
+					<speed>1.141825556755066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014590949459393" lon="-84.21619944267678">
+				<ele>954.8395496392623</ele>
+				<time>2017-11-13T17:46:37Z</time>
+				<extensions>
+					<speed>1.3565062284469604</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014600400703923" lon="-84.2161865472196">
+				<ele>954.99662623927</ele>
+				<time>2017-11-13T17:46:38Z</time>
+				<extensions>
+					<speed>1.4344921112060547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014609063738872" lon="-84.21618235197818">
+				<ele>955.6076625790447</ele>
+				<time>2017-11-13T17:46:39Z</time>
+				<extensions>
+					<speed>1.3459036350250244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01461635514148" lon="-84.21618745210169">
+				<ele>956.4598389239982</ele>
+				<time>2017-11-13T17:46:40Z</time>
+				<extensions>
+					<speed>1.129955530166626</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014624463423202" lon="-84.21617967992466">
+				<ele>957.4028593683615</ele>
+				<time>2017-11-13T17:46:41Z</time>
+				<extensions>
+					<speed>1.0038063526153564</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014627458115248" lon="-84.21616733444026">
+				<ele>957.948061532341</ele>
+				<time>2017-11-13T17:46:42Z</time>
+				<extensions>
+					<speed>1.045425295829773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01463111816501" lon="-84.21614756105195">
+				<ele>958.4669286645949</ele>
+				<time>2017-11-13T17:46:43Z</time>
+				<extensions>
+					<speed>1.3657280206680298</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014633168378241" lon="-84.2161267794387">
+				<ele>958.5801698798314</ele>
+				<time>2017-11-13T17:46:44Z</time>
+				<extensions>
+					<speed>1.6703946590423584</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014633598977426" lon="-84.21610125019343">
+				<ele>958.7162707364187</ele>
+				<time>2017-11-13T17:46:45Z</time>
+				<extensions>
+					<speed>2.1751320362091064</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014637215643617" lon="-84.21607014950233">
+				<ele>958.7383866645396</ele>
+				<time>2017-11-13T17:46:46Z</time>
+				<extensions>
+					<speed>2.5666768550872803</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01463939580744" lon="-84.21603798688831">
+				<ele>958.7287619300187</ele>
+				<time>2017-11-13T17:46:47Z</time>
+				<extensions>
+					<speed>2.8032119274139404</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0146443583851" lon="-84.2160050683131">
+				<ele>958.8425023974851</ele>
+				<time>2017-11-13T17:46:48Z</time>
+				<extensions>
+					<speed>2.845816135406494</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01464775700309" lon="-84.21597311532362">
+				<ele>959.2038637483492</ele>
+				<time>2017-11-13T17:46:49Z</time>
+				<extensions>
+					<speed>2.969001293182373</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01465167059365" lon="-84.21593890356019">
+				<ele>959.9726503007114</ele>
+				<time>2017-11-13T17:46:50Z</time>
+				<extensions>
+					<speed>3.1619832515716553</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01465363364907" lon="-84.21590701329816">
+				<ele>960.5965642426163</ele>
+				<time>2017-11-13T17:46:51Z</time>
+				<extensions>
+					<speed>3.296687126159668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01466049425608" lon="-84.21587435921036">
+				<ele>961.1000375580043</ele>
+				<time>2017-11-13T17:46:52Z</time>
+				<extensions>
+					<speed>3.2443039417266846</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014668872604359" lon="-84.21585028295057">
+				<ele>961.3541031852365</ele>
+				<time>2017-11-13T17:46:53Z</time>
+				<extensions>
+					<speed>2.929245948791504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014674474968727" lon="-84.21583186295125">
+				<ele>961.4661710252985</ele>
+				<time>2017-11-13T17:46:54Z</time>
+				<extensions>
+					<speed>2.4944522380828857</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014679364484753" lon="-84.21582009808546">
+				<ele>961.4414152409881</ele>
+				<time>2017-11-13T17:46:55Z</time>
+				<extensions>
+					<speed>1.956084966659546</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014679552253499" lon="-84.21581966565503">
+				<ele>961.4425705848262</ele>
+				<time>2017-11-13T17:46:56Z</time>
+				<extensions>
+					<speed>1.0765141248703003</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014682748207616" lon="-84.21581642951021">
+				<ele>961.2720232550055</ele>
+				<time>2017-11-13T17:46:57Z</time>
+				<extensions>
+					<speed>0.447473406791687</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014682748207616" lon="-84.21581642951021">
+				<ele>961.2720232550055</ele>
+				<time>2017-11-13T17:46:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:46:59Z</time>
+				<extensions>
+					<speed>0.04407433047890663</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014683814745565" lon="-84.21581619061367">
+				<ele>961.0983911277726</ele>
+				<time>2017-11-13T17:47:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014685989288113" lon="-84.21580000052164">
+				<ele>960.8129135612398</ele>
+				<time>2017-11-13T17:47:22Z</time>
+				<extensions>
+					<speed>0.7933698296546936</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014687171127958" lon="-84.21578387289745">
+				<ele>960.8529755901545</ele>
+				<time>2017-11-13T17:47:23Z</time>
+				<extensions>
+					<speed>1.066970705986023</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014691178321057" lon="-84.21576198965943">
+				<ele>961.4276723824441</ele>
+				<time>2017-11-13T17:47:24Z</time>
+				<extensions>
+					<speed>1.5759437084197998</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014701245180579" lon="-84.21572583303883">
+				<ele>962.6085442090407</ele>
+				<time>2017-11-13T17:47:25Z</time>
+				<extensions>
+					<speed>2.6342625617980957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014712904399428" lon="-84.21566931243832">
+				<ele>962.8647925211117</ele>
+				<time>2017-11-13T17:47:26Z</time>
+				<extensions>
+					<speed>4.390852451324463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014725683959492" lon="-84.21561426370518">
+				<ele>963.2931681023911</ele>
+				<time>2017-11-13T17:47:27Z</time>
+				<extensions>
+					<speed>5.742122173309326</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014740120018569" lon="-84.21555336435499">
+				<ele>963.7055006576702</ele>
+				<time>2017-11-13T17:47:28Z</time>
+				<extensions>
+					<speed>6.362939357757568</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014756184281278" lon="-84.21549602181084">
+				<ele>963.8044514805079</ele>
+				<time>2017-11-13T17:47:29Z</time>
+				<extensions>
+					<speed>6.492980003356934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014772754637738" lon="-84.21544173335114">
+				<ele>963.7124276561663</ele>
+				<time>2017-11-13T17:47:30Z</time>
+				<extensions>
+					<speed>6.310840129852295</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014789737222522" lon="-84.21538875516315">
+				<ele>963.5859417598695</ele>
+				<time>2017-11-13T17:47:31Z</time>
+				<extensions>
+					<speed>6.023146629333496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014805361663345" lon="-84.21534615765948">
+				<ele>963.3321355255321</ele>
+				<time>2017-11-13T17:47:32Z</time>
+				<extensions>
+					<speed>5.33235502243042</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014818340137111" lon="-84.21531583988867">
+				<ele>963.1595228007063</ele>
+				<time>2017-11-13T17:47:33Z</time>
+				<extensions>
+					<speed>4.382523059844971</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014831954952621" lon="-84.21529395144815">
+				<ele>963.0870539117604</ele>
+				<time>2017-11-13T17:47:34Z</time>
+				<extensions>
+					<speed>3.528053045272827</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014842219097645" lon="-84.21527214303396">
+				<ele>963.1588051151484</ele>
+				<time>2017-11-13T17:47:35Z</time>
+				<extensions>
+					<speed>3.029268980026245</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01485143323027" lon="-84.21525787882811">
+				<ele>963.5659008473158</ele>
+				<time>2017-11-13T17:47:36Z</time>
+				<extensions>
+					<speed>2.4949028491973877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014854114042999" lon="-84.21524187554338">
+				<ele>964.1061569601297</ele>
+				<time>2017-11-13T17:47:37Z</time>
+				<extensions>
+					<speed>1.9863979816436768</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014848771607564" lon="-84.21523425012874">
+				<ele>964.537964832969</ele>
+				<time>2017-11-13T17:47:38Z</time>
+				<extensions>
+					<speed>1.223848819732666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014841456929515" lon="-84.21522912046613">
+				<ele>964.8572332877666</ele>
+				<time>2017-11-13T17:47:39Z</time>
+				<extensions>
+					<speed>0.5980732440948486</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014841456929515" lon="-84.21522912046613">
+				<ele>964.8572332877666</ele>
+				<time>2017-11-13T17:47:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014837038716177" lon="-84.21522070808143">
+				<ele>965.2449191175401</ele>
+				<time>2017-11-13T17:47:41Z</time>
+				<extensions>
+					<speed>0.3152831494808197</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014837038716177" lon="-84.21522070808143">
+				<ele>965.2449191175401</ele>
+				<time>2017-11-13T17:47:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014837038716177" lon="-84.21522070808143">
+				<ele>965.2449191175401</ele>
+				<time>2017-11-13T17:47:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014837038716177" lon="-84.21522070808143">
+				<ele>965.2449191175401</ele>
+				<time>2017-11-13T17:47:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014837038716177" lon="-84.21522070808143">
+				<ele>965.2449191175401</ele>
+				<time>2017-11-13T17:47:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014837038716177" lon="-84.21522070808143">
+				<ele>965.2449191175401</ele>
+				<time>2017-11-13T17:47:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014837038716177" lon="-84.21522070808143">
+				<ele>965.2449191175401</ele>
+				<time>2017-11-13T17:47:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014837038716177" lon="-84.21522070808143">
+				<ele>965.2449191175401</ele>
+				<time>2017-11-13T17:47:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014844592857683" lon="-84.21519689905463">
+				<ele>965.2682657474652</ele>
+				<time>2017-11-13T17:47:49Z</time>
+				<extensions>
+					<speed>0.8531403541564941</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014844842592527" lon="-84.21517501610558">
+				<ele>964.9970292840153</ele>
+				<time>2017-11-13T17:47:50Z</time>
+				<extensions>
+					<speed>1.0976165533065796</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014844420316633" lon="-84.21515171147388">
+				<ele>964.8161717122421</ele>
+				<time>2017-11-13T17:47:51Z</time>
+				<extensions>
+					<speed>1.3002833127975464</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014847169425984" lon="-84.21513269810275">
+				<ele>964.5867773769423</ele>
+				<time>2017-11-13T17:47:52Z</time>
+				<extensions>
+					<speed>1.2578612565994263</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014847535996454" lon="-84.21511749748649">
+				<ele>964.4094610009342</ele>
+				<time>2017-11-13T17:47:53Z</time>
+				<extensions>
+					<speed>1.1848104000091553</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014842992970083" lon="-84.21510271160291">
+				<ele>963.6212161406875</ele>
+				<time>2017-11-13T17:47:54Z</time>
+				<extensions>
+					<speed>0.8886166214942932</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014842992970083" lon="-84.21510271160291">
+				<ele>963.6212161406875</ele>
+				<time>2017-11-13T17:47:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014835417984521" lon="-84.21507860570169">
+				<ele>962.8237544894218</ele>
+				<time>2017-11-13T17:47:56Z</time>
+				<extensions>
+					<speed>0.620865523815155</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014835417984521" lon="-84.21507860570169">
+				<ele>962.8237544894218</ele>
+				<time>2017-11-13T17:47:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014848135755267" lon="-84.21505323913125">
+				<ele>961.9649078436196</ele>
+				<time>2017-11-13T17:47:58Z</time>
+				<extensions>
+					<speed>0.5740765929222107</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014848135755267" lon="-84.21505323913125">
+				<ele>961.9649078436196</ele>
+				<time>2017-11-13T17:47:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014856613576015" lon="-84.21505046928304">
+				<ele>961.4409097703174</ele>
+				<time>2017-11-13T17:48:00Z</time>
+				<extensions>
+					<speed>0.45896074175834656</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014856613576015" lon="-84.21505046928304">
+				<ele>961.4409097703174</ele>
+				<time>2017-11-13T17:48:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858389121567" lon="-84.21504756265405">
+				<ele>961.1521421363577</ele>
+				<time>2017-11-13T17:48:02Z</time>
+				<extensions>
+					<speed>0.4089216887950897</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858389121567" lon="-84.21504756265405">
+				<ele>961.1521421363577</ele>
+				<time>2017-11-13T17:48:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:04Z</time>
+				<extensions>
+					<speed>0.3624991476535797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858323619782" lon="-84.21504173330334">
+				<ele>960.8716116221622</ele>
+				<time>2017-11-13T17:48:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014858311217745" lon="-84.21501274421227">
+				<ele>960.5905491178855</ele>
+				<time>2017-11-13T17:48:30Z</time>
+				<extensions>
+					<speed>1.8292790651321411</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014862371961472" lon="-84.21498169452694">
+				<ele>959.7194893471897</ele>
+				<time>2017-11-13T17:48:31Z</time>
+				<extensions>
+					<speed>2.743104934692383</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014865158077791" lon="-84.21492477500573">
+				<ele>957.5029555112123</ele>
+				<time>2017-11-13T17:48:32Z</time>
+				<extensions>
+					<speed>3.9603466987609863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014872131646447" lon="-84.21487209024333">
+				<ele>957.0970618249848</ele>
+				<time>2017-11-13T17:48:33Z</time>
+				<extensions>
+					<speed>4.986735820770264</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01488504760456" lon="-84.21481794741331">
+				<ele>956.6444721911103</ele>
+				<time>2017-11-13T17:48:34Z</time>
+				<extensions>
+					<speed>5.789004325866699</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01489495733555" lon="-84.21475394050982">
+				<ele>956.3959756232798</ele>
+				<time>2017-11-13T17:48:35Z</time>
+				<extensions>
+					<speed>6.500715255737305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014905875306377" lon="-84.21469725519896">
+				<ele>956.1502603599802</ele>
+				<time>2017-11-13T17:48:36Z</time>
+				<extensions>
+					<speed>6.678355693817139</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014926888454625" lon="-84.21463613682258">
+				<ele>956.0881246589124</ele>
+				<time>2017-11-13T17:48:37Z</time>
+				<extensions>
+					<speed>6.888303756713867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014951999907918" lon="-84.21455041568301">
+				<ele>956.537207627669</ele>
+				<time>2017-11-13T17:48:38Z</time>
+				<extensions>
+					<speed>7.64847993850708</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014970437063718" lon="-84.21448560887909">
+				<ele>956.1747247083113</ele>
+				<time>2017-11-13T17:48:39Z</time>
+				<extensions>
+					<speed>7.552099227905273</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014987263199007" lon="-84.21442032999556">
+				<ele>956.28857681714</ele>
+				<time>2017-11-13T17:48:40Z</time>
+				<extensions>
+					<speed>7.443940162658691</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014998223335313" lon="-84.21435294580513">
+				<ele>956.2663001297042</ele>
+				<time>2017-11-13T17:48:41Z</time>
+				<extensions>
+					<speed>7.27985143661499</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015000577478341" lon="-84.21429872263384">
+				<ele>956.7580242911354</ele>
+				<time>2017-11-13T17:48:42Z</time>
+				<extensions>
+					<speed>6.818038463592529</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014990612497677" lon="-84.21426805447719">
+				<ele>956.9909667475149</ele>
+				<time>2017-11-13T17:48:43Z</time>
+				<extensions>
+					<speed>5.720569133758545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014983332231377" lon="-84.21424196548182">
+				<ele>957.4230899717659</ele>
+				<time>2017-11-13T17:48:44Z</time>
+				<extensions>
+					<speed>4.513577938079834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014979216515023" lon="-84.21424341731534">
+				<ele>957.6574577009305</ele>
+				<time>2017-11-13T17:48:45Z</time>
+				<extensions>
+					<speed>0.9686059355735779</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014980038432842" lon="-84.21423466131924">
+				<ele>957.8710470637307</ele>
+				<time>2017-11-13T17:48:46Z</time>
+				<extensions>
+					<speed>0.12169747054576874</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014980038432842" lon="-84.21423466131924">
+				<ele>957.8710470637307</ele>
+				<time>2017-11-13T17:48:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014980038432842" lon="-84.21423466131924">
+				<ele>957.8710470637307</ele>
+				<time>2017-11-13T17:48:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014980038432842" lon="-84.21423466131924">
+				<ele>957.8710470637307</ele>
+				<time>2017-11-13T17:48:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014980038432842" lon="-84.21423466131924">
+				<ele>957.8710470637307</ele>
+				<time>2017-11-13T17:48:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014980038432842" lon="-84.21423466131924">
+				<ele>957.8710470637307</ele>
+				<time>2017-11-13T17:48:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014980038432842" lon="-84.21423466131924">
+				<ele>957.8710470637307</ele>
+				<time>2017-11-13T17:48:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014980038432842" lon="-84.21423466131924">
+				<ele>957.8710470637307</ele>
+				<time>2017-11-13T17:48:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014980038432842" lon="-84.21423466131924">
+				<ele>957.8710470637307</ele>
+				<time>2017-11-13T17:48:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014980038432842" lon="-84.21423466131924">
+				<ele>957.8710470637307</ele>
+				<time>2017-11-13T17:48:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014980038432842" lon="-84.21423466131924">
+				<ele>957.8710470637307</ele>
+				<time>2017-11-13T17:48:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014980038432842" lon="-84.21423466131924">
+				<ele>957.8710470637307</ele>
+				<time>2017-11-13T17:48:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014981904851826" lon="-84.21422585971183">
+				<ele>957.7824928183109</ele>
+				<time>2017-11-13T17:48:58Z</time>
+				<extensions>
+					<speed>0.14250148832798004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014983832199512" lon="-84.21421983275862">
+				<ele>957.8064391957596</ele>
+				<time>2017-11-13T17:48:59Z</time>
+				<extensions>
+					<speed>0.042076680809259415</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014983832199512" lon="-84.21421983275862">
+				<ele>957.8064391957596</ele>
+				<time>2017-11-13T17:49:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014986928513746" lon="-84.21421339921538">
+				<ele>958.1174818826839</ele>
+				<time>2017-11-13T17:49:01Z</time>
+				<extensions>
+					<speed>0.14403297007083893</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014986928513746" lon="-84.21421339921538">
+				<ele>958.1174818826839</ele>
+				<time>2017-11-13T17:49:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014992153449695" lon="-84.21419352946496">
+				<ele>958.2689008973539</ele>
+				<time>2017-11-13T17:49:03Z</time>
+				<extensions>
+					<speed>1.0910179615020752</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014998227366643" lon="-84.21417306190787">
+				<ele>958.3495439663529</ele>
+				<time>2017-11-13T17:49:04Z</time>
+				<extensions>
+					<speed>1.4081687927246094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015009874611934" lon="-84.2141369293392">
+				<ele>958.5339779583737</ele>
+				<time>2017-11-13T17:49:05Z</time>
+				<extensions>
+					<speed>2.4309208393096924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015025998309163" lon="-84.21408953147241">
+				<ele>958.678140996024</ele>
+				<time>2017-11-13T17:49:06Z</time>
+				<extensions>
+					<speed>3.5701775550842285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015030606762299" lon="-84.21402187383217">
+				<ele>956.9603055780753</ele>
+				<time>2017-11-13T17:49:07Z</time>
+				<extensions>
+					<speed>5.225031852722168</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015042142364836" lon="-84.21396165589563">
+				<ele>956.317562783137</ele>
+				<time>2017-11-13T17:49:08Z</time>
+				<extensions>
+					<speed>5.416585922241211</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015058848950375" lon="-84.21389922974572">
+				<ele>954.229474416934</ele>
+				<time>2017-11-13T17:49:09Z</time>
+				<extensions>
+					<speed>5.654056549072266</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015077252609041" lon="-84.21378902017182">
+				<ele>954.1031134026125</ele>
+				<time>2017-11-13T17:49:10Z</time>
+				<extensions>
+					<speed>5.803330421447754</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015104657838858" lon="-84.21372312776349">
+				<ele>954.3233449310064</ele>
+				<time>2017-11-13T17:49:11Z</time>
+				<extensions>
+					<speed>5.781400680541992</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015129321876149" lon="-84.21366573387327">
+				<ele>954.5921411728486</ele>
+				<time>2017-11-13T17:49:12Z</time>
+				<extensions>
+					<speed>5.812419414520264</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015137224829614" lon="-84.21360915559228">
+				<ele>955.1694467123598</ele>
+				<time>2017-11-13T17:49:13Z</time>
+				<extensions>
+					<speed>5.539618492126465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015148529652166" lon="-84.21347333876298">
+				<ele>956.2174167744815</ele>
+				<time>2017-11-13T17:49:16Z</time>
+				<extensions>
+					<speed>5.010858535766602</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015229748320962" lon="-84.21338322609675">
+				<ele>966.9851325303316</ele>
+				<time>2017-11-13T17:49:17Z</time>
+				<extensions>
+					<speed>4.599331378936768</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01524144860603" lon="-84.21335107174968">
+				<ele>967.6269598733634</ele>
+				<time>2017-11-13T17:49:18Z</time>
+				<extensions>
+					<speed>4.228287220001221</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015262278985059" lon="-84.21336235225512">
+				<ele>967.3232958735898</ele>
+				<time>2017-11-13T17:49:19Z</time>
+				<extensions>
+					<speed>2.798197031021118</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015278575074621" lon="-84.2133833855349">
+				<ele>967.0035668145865</ele>
+				<time>2017-11-13T17:49:20Z</time>
+				<extensions>
+					<speed>1.12508225440979</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015290012651647" lon="-84.21340506782886">
+				<ele>966.3718075221404</ele>
+				<time>2017-11-13T17:49:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015290012651647" lon="-84.21340506782886">
+				<ele>966.3718075221404</ele>
+				<time>2017-11-13T17:49:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015290012651647" lon="-84.21340506782886">
+				<ele>966.3718075221404</ele>
+				<time>2017-11-13T17:49:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015290012651647" lon="-84.21340506782886">
+				<ele>966.3718075221404</ele>
+				<time>2017-11-13T17:49:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015290012651647" lon="-84.21340506782886">
+				<ele>966.3718075221404</ele>
+				<time>2017-11-13T17:49:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015290012651647" lon="-84.21340506782886">
+				<ele>966.3718075221404</ele>
+				<time>2017-11-13T17:49:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015290012651647" lon="-84.21340506782886">
+				<ele>966.3718075221404</ele>
+				<time>2017-11-13T17:49:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015290012651647" lon="-84.21340506782886">
+				<ele>966.3718075221404</ele>
+				<time>2017-11-13T17:49:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015290012651647" lon="-84.21340506782886">
+				<ele>966.3718075221404</ele>
+				<time>2017-11-13T17:49:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015290012651647" lon="-84.21340506782886">
+				<ele>966.3718075221404</ele>
+				<time>2017-11-13T17:49:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015290012651647" lon="-84.21340506782886">
+				<ele>966.3718075221404</ele>
+				<time>2017-11-13T17:49:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015290012651647" lon="-84.21340506782886">
+				<ele>966.3718075221404</ele>
+				<time>2017-11-13T17:49:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:33Z</time>
+				<extensions>
+					<speed>0.026611758396029472</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:49:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:50:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:50:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:50:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:50:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015289203095227" lon="-84.2134053754061">
+				<ele>966.3621698021889</ele>
+				<time>2017-11-13T17:50:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015270492706149" lon="-84.21342351491272">
+				<ele>966.4120917292312</ele>
+				<time>2017-11-13T17:50:05Z</time>
+				<extensions>
+					<speed>0.6014278531074524</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015257539393707" lon="-84.2134473829202">
+				<ele>966.5291739478707</ele>
+				<time>2017-11-13T17:50:06Z</time>
+				<extensions>
+					<speed>0.6634243726730347</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015253168424344" lon="-84.21345958964177">
+				<ele>966.6999936606735</ele>
+				<time>2017-11-13T17:50:07Z</time>
+				<extensions>
+					<speed>0.70535808801651</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015253477729072" lon="-84.2134637668599">
+				<ele>966.8234155792743</ele>
+				<time>2017-11-13T17:50:08Z</time>
+				<extensions>
+					<speed>0.7101367712020874</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015245236324622" lon="-84.2134782977902">
+				<ele>966.5805349024013</ele>
+				<time>2017-11-13T17:50:09Z</time>
+				<extensions>
+					<speed>0.7668105959892273</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015230228368324" lon="-84.21349992431166">
+				<ele>966.0460657319054</ele>
+				<time>2017-11-13T17:50:10Z</time>
+				<extensions>
+					<speed>0.8068895936012268</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015218826379506" lon="-84.21346823236162">
+				<ele>966.0718723218888</ele>
+				<time>2017-11-13T17:50:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015216020835275" lon="-84.21344869258068">
+				<ele>965.5807917807251</ele>
+				<time>2017-11-13T17:50:12Z</time>
+				<extensions>
+					<speed>0.2212459146976471</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015206991113994" lon="-84.21344174937549">
+				<ele>965.1309233447537</ele>
+				<time>2017-11-13T17:50:13Z</time>
+				<extensions>
+					<speed>0.6690570116043091</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015195024257842" lon="-84.21345227879958">
+				<ele>965.034865767695</ele>
+				<time>2017-11-13T17:50:14Z</time>
+				<extensions>
+					<speed>0.8729327917098999</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015188685286365" lon="-84.21344881450317">
+				<ele>964.9578839642927</ele>
+				<time>2017-11-13T17:50:15Z</time>
+				<extensions>
+					<speed>0.9946956634521484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015189887640872" lon="-84.21343883755577">
+				<ele>963.6112170023844</ele>
+				<time>2017-11-13T17:50:16Z</time>
+				<extensions>
+					<speed>1.2656641006469727</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015194589921185" lon="-84.21341464483103">
+				<ele>962.9621834056452</ele>
+				<time>2017-11-13T17:50:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01519574088803" lon="-84.21339760202585">
+				<ele>962.9718269528821</ele>
+				<time>2017-11-13T17:50:18Z</time>
+				<extensions>
+					<speed>0.6223661303520203</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015199081018093" lon="-84.21338147166725">
+				<ele>962.8492332100868</ele>
+				<time>2017-11-13T17:50:19Z</time>
+				<extensions>
+					<speed>0.8553954362869263</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015204741777918" lon="-84.21336263675136">
+				<ele>963.052707400173</ele>
+				<time>2017-11-13T17:50:20Z</time>
+				<extensions>
+					<speed>1.0368592739105225</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015210710814033" lon="-84.2133461021792">
+				<ele>963.4893860956654</ele>
+				<time>2017-11-13T17:50:21Z</time>
+				<extensions>
+					<speed>1.1570496559143066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0152138432706" lon="-84.21332097696394">
+				<ele>963.9136032126844</ele>
+				<time>2017-11-13T17:50:22Z</time>
+				<extensions>
+					<speed>1.4509871006011963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015215416220693" lon="-84.21328629581932">
+				<ele>964.3317779451609</ele>
+				<time>2017-11-13T17:50:23Z</time>
+				<extensions>
+					<speed>1.7943170070648193</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015229203109532" lon="-84.21324271676306">
+				<ele>965.2843939401209</ele>
+				<time>2017-11-13T17:50:24Z</time>
+				<extensions>
+					<speed>2.3118691444396973</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015239280259165" lon="-84.21319958962899">
+				<ele>965.5248051686212</ele>
+				<time>2017-11-13T17:50:25Z</time>
+				<extensions>
+					<speed>2.905247688293457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015249818064149" lon="-84.21316178351482">
+				<ele>966.033004947938</ele>
+				<time>2017-11-13T17:50:26Z</time>
+				<extensions>
+					<speed>3.4200527667999268</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015263105886802" lon="-84.21312268870322">
+				<ele>966.3590548420325</ele>
+				<time>2017-11-13T17:50:27Z</time>
+				<extensions>
+					<speed>3.8238179683685303</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015279943362213" lon="-84.21307242617576">
+				<ele>967.0117352977395</ele>
+				<time>2017-11-13T17:50:28Z</time>
+				<extensions>
+					<speed>4.388176918029785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01529499125909" lon="-84.21301930043568">
+				<ele>967.5974950809032</ele>
+				<time>2017-11-13T17:50:29Z</time>
+				<extensions>
+					<speed>4.660504341125488</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015314822019722" lon="-84.21295885984433">
+				<ele>967.9423921387643</ele>
+				<time>2017-11-13T17:50:30Z</time>
+				<extensions>
+					<speed>5.113422870635986</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015351670237333" lon="-84.21288341776118">
+				<ele>968.9726655399427</ele>
+				<time>2017-11-13T17:50:31Z</time>
+				<extensions>
+					<speed>5.594086170196533</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015377033313026" lon="-84.21281426796837">
+				<ele>969.8638400910422</ele>
+				<time>2017-11-13T17:50:32Z</time>
+				<extensions>
+					<speed>5.6699748039245605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015394178552283" lon="-84.21275326395649">
+				<ele>970.32173013594</ele>
+				<time>2017-11-13T17:50:33Z</time>
+				<extensions>
+					<speed>5.740519046783447</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01541533185355" lon="-84.21269076999783">
+				<ele>970.7179011031985</ele>
+				<time>2017-11-13T17:50:34Z</time>
+				<extensions>
+					<speed>5.874722003936768</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015430661121847" lon="-84.21263190088925">
+				<ele>971.0891883196309</ele>
+				<time>2017-11-13T17:50:35Z</time>
+				<extensions>
+					<speed>5.931994915008545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015445191526014" lon="-84.21257810648224">
+				<ele>971.3652782179415</ele>
+				<time>2017-11-13T17:50:36Z</time>
+				<extensions>
+					<speed>5.913936614990234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01545712751275" lon="-84.21252754421997">
+				<ele>971.653093018569</ele>
+				<time>2017-11-13T17:50:37Z</time>
+				<extensions>
+					<speed>5.796673774719238</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01547646782867" lon="-84.21247772004774">
+				<ele>971.84782268852</ele>
+				<time>2017-11-13T17:50:38Z</time>
+				<extensions>
+					<speed>5.684792518615723</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015492360210844" lon="-84.21243373218708">
+				<ele>972.1529657235369</ele>
+				<time>2017-11-13T17:50:39Z</time>
+				<extensions>
+					<speed>5.586747646331787</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01551241421209" lon="-84.21239118636204">
+				<ele>972.3863283824176</ele>
+				<time>2017-11-13T17:50:40Z</time>
+				<extensions>
+					<speed>5.576155185699463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01552563449333" lon="-84.21234672994845">
+				<ele>972.4212513938546</ele>
+				<time>2017-11-13T17:50:41Z</time>
+				<extensions>
+					<speed>5.474701881408691</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015539172439153" lon="-84.21229875901659">
+				<ele>972.2510064858943</ele>
+				<time>2017-11-13T17:50:42Z</time>
+				<extensions>
+					<speed>5.3503313064575195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015548997584016" lon="-84.2122535515869">
+				<ele>971.5759515408427</ele>
+				<time>2017-11-13T17:50:43Z</time>
+				<extensions>
+					<speed>5.335272312164307</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015565274358272" lon="-84.21221163865498">
+				<ele>971.2460317444056</ele>
+				<time>2017-11-13T17:50:44Z</time>
+				<extensions>
+					<speed>5.469422340393066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015581945864707" lon="-84.21217453842188">
+				<ele>971.372144411318</ele>
+				<time>2017-11-13T17:50:45Z</time>
+				<extensions>
+					<speed>5.510066986083984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015603290512495" lon="-84.21212796028615">
+				<ele>971.5935214506462</ele>
+				<time>2017-11-13T17:50:46Z</time>
+				<extensions>
+					<speed>5.433294296264648</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015625014852256" lon="-84.21207402408088">
+				<ele>971.9843112817034</ele>
+				<time>2017-11-13T17:50:47Z</time>
+				<extensions>
+					<speed>5.779892921447754</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01564375870063" lon="-84.21201991431006">
+				<ele>972.3125434936956</ele>
+				<time>2017-11-13T17:50:48Z</time>
+				<extensions>
+					<speed>5.925446510314941</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015661744133569" lon="-84.21196053245176">
+				<ele>972.3803566265851</ele>
+				<time>2017-11-13T17:50:49Z</time>
+				<extensions>
+					<speed>6.0166544914245605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015673249686603" lon="-84.21191414000543">
+				<ele>972.5980310449377</ele>
+				<time>2017-11-13T17:50:50Z</time>
+				<extensions>
+					<speed>5.876121520996094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015677137585294" lon="-84.21186956427044">
+				<ele>972.7426471589133</ele>
+				<time>2017-11-13T17:50:51Z</time>
+				<extensions>
+					<speed>5.657834529876709</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015681208502908" lon="-84.2118377331886">
+				<ele>973.0387545665726</ele>
+				<time>2017-11-13T17:50:52Z</time>
+				<extensions>
+					<speed>5.3581976890563965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015689336319252" lon="-84.21179981852465">
+				<ele>973.1446953164414</ele>
+				<time>2017-11-13T17:50:53Z</time>
+				<extensions>
+					<speed>5.2148003578186035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015692850997205" lon="-84.21176713903854">
+				<ele>973.2490352839231</ele>
+				<time>2017-11-13T17:50:54Z</time>
+				<extensions>
+					<speed>4.936408042907715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015697713697863" lon="-84.21172715243517">
+				<ele>973.169223417528</ele>
+				<time>2017-11-13T17:50:55Z</time>
+				<extensions>
+					<speed>4.848492622375488</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015702888387802" lon="-84.2116794704901">
+				<ele>973.0968844015151</ele>
+				<time>2017-11-13T17:50:56Z</time>
+				<extensions>
+					<speed>4.768763065338135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01570604907972" lon="-84.21163929077588">
+				<ele>973.1862141462043</ele>
+				<time>2017-11-13T17:50:57Z</time>
+				<extensions>
+					<speed>4.626986980438232</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015712939991927" lon="-84.21160292264996">
+				<ele>973.010052530095</ele>
+				<time>2017-11-13T17:50:58Z</time>
+				<extensions>
+					<speed>4.45599889755249</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015717273260655" lon="-84.2115669140416">
+				<ele>972.9071073709056</ele>
+				<time>2017-11-13T17:50:59Z</time>
+				<extensions>
+					<speed>4.260109901428223</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015713547529097" lon="-84.21151840508978">
+				<ele>972.3594242539257</ele>
+				<time>2017-11-13T17:51:00Z</time>
+				<extensions>
+					<speed>4.168224334716797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015708512446263" lon="-84.21148223144891">
+				<ele>972.2304008081555</ele>
+				<time>2017-11-13T17:51:01Z</time>
+				<extensions>
+					<speed>3.937777519226074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015690216135557" lon="-84.21147117584411">
+				<ele>971.9246587082744</ele>
+				<time>2017-11-13T17:51:02Z</time>
+				<extensions>
+					<speed>3.3650505542755127</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01568598078851" lon="-84.21145490692905">
+				<ele>971.8602196164429</ele>
+				<time>2017-11-13T17:51:03Z</time>
+				<extensions>
+					<speed>2.7381224632263184</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015687201634966" lon="-84.21144897676122">
+				<ele>971.8864308325574</ele>
+				<time>2017-11-13T17:51:04Z</time>
+				<extensions>
+					<speed>2.0764143466949463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015687701893853" lon="-84.21144927311214">
+				<ele>971.8519335873425</ele>
+				<time>2017-11-13T17:51:05Z</time>
+				<extensions>
+					<speed>1.4490619897842407</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015686735440122" lon="-84.21144769019395">
+				<ele>971.8820368126035</ele>
+				<time>2017-11-13T17:51:06Z</time>
+				<extensions>
+					<speed>0.8635849952697754</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015686735440122" lon="-84.21144769019395">
+				<ele>971.8820368126035</ele>
+				<time>2017-11-13T17:51:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015683339067948" lon="-84.21145601085676">
+				<ele>971.9584427559748</ele>
+				<time>2017-11-13T17:51:08Z</time>
+				<extensions>
+					<speed>0.30525949597358704</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015683339067948" lon="-84.21145601085676">
+				<ele>971.9584427559748</ele>
+				<time>2017-11-13T17:51:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015683339067948" lon="-84.21145601085676">
+				<ele>971.9584427559748</ele>
+				<time>2017-11-13T17:51:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015683339067948" lon="-84.21145601085676">
+				<ele>971.9584427559748</ele>
+				<time>2017-11-13T17:51:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015683339067948" lon="-84.21145601085676">
+				<ele>971.9584427559748</ele>
+				<time>2017-11-13T17:51:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015683339067948" lon="-84.21145601085676">
+				<ele>971.9584427559748</ele>
+				<time>2017-11-13T17:51:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015687898440854" lon="-84.21145016407982">
+				<ele>971.9374466901645</ele>
+				<time>2017-11-13T17:51:14Z</time>
+				<extensions>
+					<speed>0.11973139643669128</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015687898440854" lon="-84.21145016407982">
+				<ele>971.9374466901645</ele>
+				<time>2017-11-13T17:51:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015675434557464" lon="-84.21143716930784">
+				<ele>972.3952814666554</ele>
+				<time>2017-11-13T17:51:16Z</time>
+				<extensions>
+					<speed>0.8356457948684692</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015672696377244" lon="-84.21143016419536">
+				<ele>972.9433949198574</ele>
+				<time>2017-11-13T17:51:17Z</time>
+				<extensions>
+					<speed>1.0472089052200317</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01567096642685" lon="-84.2114430098953">
+				<ele>973.8792086811736</ele>
+				<time>2017-11-13T17:51:18Z</time>
+				<extensions>
+					<speed>0.8356319069862366</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01567096642685" lon="-84.2114430098953">
+				<ele>973.8792086811736</ele>
+				<time>2017-11-13T17:51:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015695409602628" lon="-84.2114418857627">
+				<ele>973.9844070626423</ele>
+				<time>2017-11-13T17:51:20Z</time>
+				<extensions>
+					<speed>0.3615823984146118</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015695409602628" lon="-84.2114418857627">
+				<ele>973.9844070626423</ele>
+				<time>2017-11-13T17:51:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015695409602628" lon="-84.2114418857627">
+				<ele>973.9844070626423</ele>
+				<time>2017-11-13T17:51:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015750546920353" lon="-84.21143186670122">
+				<ele>972.9760545613244</ele>
+				<time>2017-11-13T17:51:23Z</time>
+				<extensions>
+					<speed>0.7516374588012695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015787352001901" lon="-84.21141339583865">
+				<ele>972.2089365599677</ele>
+				<time>2017-11-13T17:51:24Z</time>
+				<extensions>
+					<speed>1.2732785940170288</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015823472419706" lon="-84.21138879518699">
+				<ele>972.1466540824622</ele>
+				<time>2017-11-13T17:51:25Z</time>
+				<extensions>
+					<speed>1.6367130279541016</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015873163423754" lon="-84.21134311659104">
+				<ele>972.4586196327582</ele>
+				<time>2017-11-13T17:51:26Z</time>
+				<extensions>
+					<speed>2.105703830718994</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015889973968108" lon="-84.21131862160408">
+				<ele>972.6705470224842</ele>
+				<time>2017-11-13T17:51:27Z</time>
+				<extensions>
+					<speed>2.144216775894165</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015878902168913" lon="-84.21130142214001">
+				<ele>972.5316060660407</ele>
+				<time>2017-11-13T17:51:28Z</time>
+				<extensions>
+					<speed>2.061603307723999</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015851724031123" lon="-84.21128968381309">
+				<ele>972.447928446345</ele>
+				<time>2017-11-13T17:51:29Z</time>
+				<extensions>
+					<speed>1.8347562551498413</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015817479092474" lon="-84.21128834962512">
+				<ele>972.2445995286107</ele>
+				<time>2017-11-13T17:51:30Z</time>
+				<extensions>
+					<speed>1.676614761352539</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01578501791605" lon="-84.21130080822032">
+				<ele>971.9360265545547</ele>
+				<time>2017-11-13T17:51:31Z</time>
+				<extensions>
+					<speed>1.5143369436264038</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015742035616146" lon="-84.21130823863878">
+				<ele>971.4867260726169</ele>
+				<time>2017-11-13T17:51:32Z</time>
+				<extensions>
+					<speed>1.5750105381011963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015704261718275" lon="-84.21131731690451">
+				<ele>970.864689366892</ele>
+				<time>2017-11-13T17:51:33Z</time>
+				<extensions>
+					<speed>1.6647292375564575</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015664734906387" lon="-84.21132021698887">
+				<ele>970.909095030278</ele>
+				<time>2017-11-13T17:51:34Z</time>
+				<extensions>
+					<speed>1.7303520441055298</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015619231249255" lon="-84.21130816508293">
+				<ele>970.7229303382337</ele>
+				<time>2017-11-13T17:51:35Z</time>
+				<extensions>
+					<speed>2.0577147006988525</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015589106129575" lon="-84.2113000891327">
+				<ele>971.2085710624233</ele>
+				<time>2017-11-13T17:51:36Z</time>
+				<extensions>
+					<speed>2.220456600189209</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01556357242136" lon="-84.21129184651495">
+				<ele>972.0825438955799</ele>
+				<time>2017-11-13T17:51:37Z</time>
+				<extensions>
+					<speed>2.234239101409912</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015537833483862" lon="-84.21129363296937">
+				<ele>972.8328819032758</ele>
+				<time>2017-11-13T17:51:38Z</time>
+				<extensions>
+					<speed>2.2539124488830566</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015510430100662" lon="-84.2112969065213">
+				<ele>973.3896405696869</ele>
+				<time>2017-11-13T17:51:39Z</time>
+				<extensions>
+					<speed>2.298814296722412</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015485875354514" lon="-84.21131408613921">
+				<ele>973.7885322533548</ele>
+				<time>2017-11-13T17:51:40Z</time>
+				<extensions>
+					<speed>2.3231492042541504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015459517092344" lon="-84.21132386525785">
+				<ele>974.2202033130452</ele>
+				<time>2017-11-13T17:51:41Z</time>
+				<extensions>
+					<speed>2.481933355331421</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015428726218158" lon="-84.21133940428226">
+				<ele>974.6071571270004</ele>
+				<time>2017-11-13T17:51:42Z</time>
+				<extensions>
+					<speed>2.6598339080810547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015391072531385" lon="-84.2113560685019">
+				<ele>975.5531660914421</ele>
+				<time>2017-11-13T17:51:43Z</time>
+				<extensions>
+					<speed>2.882850170135498</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015348888304565" lon="-84.21135681597566">
+				<ele>976.1486219130456</ele>
+				<time>2017-11-13T17:51:44Z</time>
+				<extensions>
+					<speed>3.0453872680664063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015303043609746" lon="-84.21135776787472">
+				<ele>976.5938950134441</ele>
+				<time>2017-11-13T17:51:45Z</time>
+				<extensions>
+					<speed>3.249854326248169</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015249953155635" lon="-84.21134294959265">
+				<ele>976.4611643543467</ele>
+				<time>2017-11-13T17:51:46Z</time>
+				<extensions>
+					<speed>3.4966647624969482</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015205954206124" lon="-84.21132843953237">
+				<ele>976.2329986859113</ele>
+				<time>2017-11-13T17:51:47Z</time>
+				<extensions>
+					<speed>3.6498024463653564</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015168717254678" lon="-84.21127517037478">
+				<ele>975.4918102966622</ele>
+				<time>2017-11-13T17:51:48Z</time>
+				<extensions>
+					<speed>3.84234881401062</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01513482834781" lon="-84.21124141417108">
+				<ele>975.0862936582416</ele>
+				<time>2017-11-13T17:51:49Z</time>
+				<extensions>
+					<speed>3.786803722381592</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015101627611045" lon="-84.21121295050168">
+				<ele>974.1116210343316</ele>
+				<time>2017-11-13T17:51:50Z</time>
+				<extensions>
+					<speed>3.5329301357269287</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015087459997561" lon="-84.21117199905245">
+				<ele>973.3588155526668</ele>
+				<time>2017-11-13T17:51:51Z</time>
+				<extensions>
+					<speed>3.413900375366211</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015074548030181" lon="-84.21113665690126">
+				<ele>972.8959827404469</ele>
+				<time>2017-11-13T17:51:52Z</time>
+				<extensions>
+					<speed>3.3480217456817627</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015067016921527" lon="-84.21109827493669">
+				<ele>972.4159483956173</ele>
+				<time>2017-11-13T17:51:53Z</time>
+				<extensions>
+					<speed>3.357919931411743</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01506291119713" lon="-84.2110765324208">
+				<ele>971.9543408099562</ele>
+				<time>2017-11-13T17:51:54Z</time>
+				<extensions>
+					<speed>3.1311545372009277</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015061750377559" lon="-84.21105769355874">
+				<ele>971.7005575485528</ele>
+				<time>2017-11-13T17:51:55Z</time>
+				<extensions>
+					<speed>3.000730514526367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015066602000644" lon="-84.21104655281567">
+				<ele>971.3777934480458</ele>
+				<time>2017-11-13T17:51:56Z</time>
+				<extensions>
+					<speed>2.818507432937622</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015079190052079" lon="-84.21103049249324">
+				<ele>970.9919249555096</ele>
+				<time>2017-11-13T17:51:57Z</time>
+				<extensions>
+					<speed>2.6705541610717773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0151067077532" lon="-84.21102511096238">
+				<ele>970.390476831235</ele>
+				<time>2017-11-13T17:51:58Z</time>
+				<extensions>
+					<speed>2.420691967010498</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015130411065943" lon="-84.21102287465902">
+				<ele>970.0528419818729</ele>
+				<time>2017-11-13T17:51:59Z</time>
+				<extensions>
+					<speed>2.1942551136016846</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01514945622333" lon="-84.21100502493631">
+				<ele>969.8428191132843</ele>
+				<time>2017-11-13T17:52:00Z</time>
+				<extensions>
+					<speed>2.1055753231048584</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015164492054051" lon="-84.21101401900762">
+				<ele>969.6382468091324</ele>
+				<time>2017-11-13T17:52:01Z</time>
+				<extensions>
+					<speed>1.801410436630249</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015175218364481" lon="-84.21101965032588">
+				<ele>969.1028929427266</ele>
+				<time>2017-11-13T17:52:02Z</time>
+				<extensions>
+					<speed>1.7744592428207397</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015186162228616" lon="-84.2110201758277">
+				<ele>968.2268774854019</ele>
+				<time>2017-11-13T17:52:03Z</time>
+				<extensions>
+					<speed>1.765723466873169</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015194430175185" lon="-84.21103434715006">
+				<ele>967.5736049460247</ele>
+				<time>2017-11-13T17:52:04Z</time>
+				<extensions>
+					<speed>1.388800024986267</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015199272712085" lon="-84.21105594097637">
+				<ele>966.640058029443</ele>
+				<time>2017-11-13T17:52:05Z</time>
+				<extensions>
+					<speed>0.9316466450691223</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015199272712085" lon="-84.21105594097637">
+				<ele>966.640058029443</ele>
+				<time>2017-11-13T17:52:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015194609763164" lon="-84.21109166079317">
+				<ele>966.187276378274</ele>
+				<time>2017-11-13T17:52:07Z</time>
+				<extensions>
+					<speed>0.24274766445159912</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015194609763164" lon="-84.21109166079317">
+				<ele>966.187276378274</ele>
+				<time>2017-11-13T17:52:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01518185927822" lon="-84.21111879035202">
+				<ele>965.6791517641395</ele>
+				<time>2017-11-13T17:52:09Z</time>
+				<extensions>
+					<speed>0.7163535952568054</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015163116186873" lon="-84.21114686148849">
+				<ele>965.2018423937261</ele>
+				<time>2017-11-13T17:52:10Z</time>
+				<extensions>
+					<speed>1.0383739471435547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015148786042786" lon="-84.21116837078027">
+				<ele>964.8903449475765</ele>
+				<time>2017-11-13T17:52:11Z</time>
+				<extensions>
+					<speed>1.2554985284805298</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015135862704897" lon="-84.21118672592645">
+				<ele>964.5178099479526</ele>
+				<time>2017-11-13T17:52:12Z</time>
+				<extensions>
+					<speed>1.3297069072723389</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015123312068715" lon="-84.21121708964826">
+				<ele>964.2166800098494</ele>
+				<time>2017-11-13T17:52:13Z</time>
+				<extensions>
+					<speed>1.5537028312683105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015114312882435" lon="-84.2112413815472">
+				<ele>964.0601280825213</ele>
+				<time>2017-11-13T17:52:14Z</time>
+				<extensions>
+					<speed>1.5902708768844604</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015106197159573" lon="-84.2112651866458">
+				<ele>964.4726793803275</ele>
+				<time>2017-11-13T17:52:15Z</time>
+				<extensions>
+					<speed>1.5984045267105103</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015110595042628" lon="-84.21128690841627">
+				<ele>965.120175043121</ele>
+				<time>2017-11-13T17:52:16Z</time>
+				<extensions>
+					<speed>1.5154615640640259</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015111057652785" lon="-84.21130530382861">
+				<ele>965.5921547217295</ele>
+				<time>2017-11-13T17:52:17Z</time>
+				<extensions>
+					<speed>1.377658724784851</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015121745792126" lon="-84.21131501405848">
+				<ele>965.5879423553124</ele>
+				<time>2017-11-13T17:52:18Z</time>
+				<extensions>
+					<speed>1.211482286453247</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015133763386531" lon="-84.21131615014284">
+				<ele>965.57637841627</ele>
+				<time>2017-11-13T17:52:19Z</time>
+				<extensions>
+					<speed>0.9324873089790344</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015133763386531" lon="-84.21131615014284">
+				<ele>965.57637841627</ele>
+				<time>2017-11-13T17:52:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015137604768295" lon="-84.21131111146734">
+				<ele>965.3433076795191</ele>
+				<time>2017-11-13T17:52:21Z</time>
+				<extensions>
+					<speed>0.5167999863624573</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015137604768295" lon="-84.21131111146734">
+				<ele>965.3433076795191</ele>
+				<time>2017-11-13T17:52:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015148601663073" lon="-84.21129963633297">
+				<ele>965.4126203991473</ele>
+				<time>2017-11-13T17:52:23Z</time>
+				<extensions>
+					<speed>0.31702908873558044</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015148601663073" lon="-84.21129963633297">
+				<ele>965.4126203991473</ele>
+				<time>2017-11-13T17:52:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015148601663073" lon="-84.21129963633297">
+				<ele>965.4126203991473</ele>
+				<time>2017-11-13T17:52:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015148601663073" lon="-84.21129963633297">
+				<ele>965.4126203991473</ele>
+				<time>2017-11-13T17:52:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015148601663073" lon="-84.21129963633297">
+				<ele>965.4126203991473</ele>
+				<time>2017-11-13T17:52:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015148601663073" lon="-84.21129963633297">
+				<ele>965.4126203991473</ele>
+				<time>2017-11-13T17:52:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015148601663073" lon="-84.21129963633297">
+				<ele>965.4126203991473</ele>
+				<time>2017-11-13T17:52:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015148601663073" lon="-84.21129963633297">
+				<ele>965.4126203991473</ele>
+				<time>2017-11-13T17:52:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015148601663073" lon="-84.21129963633297">
+				<ele>965.4126203991473</ele>
+				<time>2017-11-13T17:52:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015136899878993" lon="-84.21127888962053">
+				<ele>965.2601562459022</ele>
+				<time>2017-11-13T17:52:32Z</time>
+				<extensions>
+					<speed>0.8352531790733337</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015119288037955" lon="-84.21127192685724">
+				<ele>965.3091092593968</ele>
+				<time>2017-11-13T17:52:33Z</time>
+				<extensions>
+					<speed>1.1288901567459106</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015095746440862" lon="-84.21127030382392">
+				<ele>965.4062515459955</ele>
+				<time>2017-11-13T17:52:34Z</time>
+				<extensions>
+					<speed>1.328337550163269</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015051852029062" lon="-84.21125486329774">
+				<ele>965.381537954323</ele>
+				<time>2017-11-13T17:52:35Z</time>
+				<extensions>
+					<speed>1.8428548574447632</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014993320136401" lon="-84.21125437550955">
+				<ele>965.527558141388</ele>
+				<time>2017-11-13T17:52:36Z</time>
+				<extensions>
+					<speed>2.499779224395752</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014864869788676" lon="-84.21127007490641">
+				<ele>965.318434712477</ele>
+				<time>2017-11-13T17:52:37Z</time>
+				<extensions>
+					<speed>4.13548469543457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014750955834776" lon="-84.21125513337533">
+				<ele>965.2013163119555</ele>
+				<time>2017-11-13T17:52:38Z</time>
+				<extensions>
+					<speed>5.400422096252441</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014662109494722" lon="-84.21124277983989">
+				<ele>965.3579886769876</ele>
+				<time>2017-11-13T17:52:39Z</time>
+				<extensions>
+					<speed>6.085638523101807</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014567562398463" lon="-84.21126625190249">
+				<ele>965.5705640427768</ele>
+				<time>2017-11-13T17:52:40Z</time>
+				<extensions>
+					<speed>6.728285312652588</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014464718047298" lon="-84.21122153475132">
+				<ele>965.7351489905268</ele>
+				<time>2017-11-13T17:52:41Z</time>
+				<extensions>
+					<speed>7.5565056800842285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014374177780311" lon="-84.21118023953292">
+				<ele>965.7834462150931</ele>
+				<time>2017-11-13T17:52:42Z</time>
+				<extensions>
+					<speed>7.682542324066162</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01431285562307" lon="-84.21113636292132">
+				<ele>965.7948991144076</ele>
+				<time>2017-11-13T17:52:43Z</time>
+				<extensions>
+					<speed>7.3059306144714355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014256352213325" lon="-84.21108643303756">
+				<ele>965.6549782427028</ele>
+				<time>2017-11-13T17:52:44Z</time>
+				<extensions>
+					<speed>7.101000785827637</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014195613405299" lon="-84.21102540967482">
+				<ele>965.4872835082933</ele>
+				<time>2017-11-13T17:52:45Z</time>
+				<extensions>
+					<speed>7.270978927612305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014133949278307" lon="-84.21094694789483">
+				<ele>965.8050016667694</ele>
+				<time>2017-11-13T17:52:46Z</time>
+				<extensions>
+					<speed>7.237407684326172</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014097962360212" lon="-84.21088973423133">
+				<ele>965.9223293419927</ele>
+				<time>2017-11-13T17:52:47Z</time>
+				<extensions>
+					<speed>7.019445419311523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014056179900136" lon="-84.21081271366965">
+				<ele>966.2004930395633</ele>
+				<time>2017-11-13T17:52:48Z</time>
+				<extensions>
+					<speed>6.890169620513916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014013573378968" lon="-84.21073814352533">
+				<ele>966.4065234027803</ele>
+				<time>2017-11-13T17:52:49Z</time>
+				<extensions>
+					<speed>6.937777042388916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013984627288066" lon="-84.21069883116277">
+				<ele>966.5874437158927</ele>
+				<time>2017-11-13T17:52:50Z</time>
+				<extensions>
+					<speed>6.773795127868652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013959952023278" lon="-84.21066379107616">
+				<ele>966.7284288424999</ele>
+				<time>2017-11-13T17:52:51Z</time>
+				<extensions>
+					<speed>6.5910491943359375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013943136130706" lon="-84.21064515387711">
+				<ele>966.9309191117063</ele>
+				<time>2017-11-13T17:52:52Z</time>
+				<extensions>
+					<speed>6.264896869659424</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013930248294965" lon="-84.21063508806277">
+				<ele>967.153200908564</ele>
+				<time>2017-11-13T17:52:53Z</time>
+				<extensions>
+					<speed>5.895965576171875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013926821773941" lon="-84.21062187054662">
+				<ele>967.3553957985714</ele>
+				<time>2017-11-13T17:52:54Z</time>
+				<extensions>
+					<speed>5.536584377288818</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013897961984538" lon="-84.21059267999942">
+				<ele>967.6579710459337</ele>
+				<time>2017-11-13T17:52:55Z</time>
+				<extensions>
+					<speed>5.433537006378174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013846067573851" lon="-84.21052761678608">
+				<ele>968.1027005184442</ele>
+				<time>2017-11-13T17:52:56Z</time>
+				<extensions>
+					<speed>5.679605960845947</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013795683884652" lon="-84.21045436582435">
+				<ele>968.4275159481913</ele>
+				<time>2017-11-13T17:52:57Z</time>
+				<extensions>
+					<speed>5.960118293762207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013756004001591" lon="-84.2104104207166">
+				<ele>968.6402444923297</ele>
+				<time>2017-11-13T17:52:58Z</time>
+				<extensions>
+					<speed>5.990137100219727</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013714837982082" lon="-84.21037289514379">
+				<ele>968.7464993139729</ele>
+				<time>2017-11-13T17:52:59Z</time>
+				<extensions>
+					<speed>5.992166519165039</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013678977513178" lon="-84.21033493810845">
+				<ele>968.7764058364555</ele>
+				<time>2017-11-13T17:53:00Z</time>
+				<extensions>
+					<speed>5.975678443908691</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013660893399392" lon="-84.2103438853114">
+				<ele>968.9457425633445</ele>
+				<time>2017-11-13T17:53:01Z</time>
+				<extensions>
+					<speed>5.585304260253906</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013636260029246" lon="-84.21032376556806">
+				<ele>968.9083637446165</ele>
+				<time>2017-11-13T17:53:02Z</time>
+				<extensions>
+					<speed>5.433196067810059</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445139074025" lon="-84.2127372521372">
+				<ele>863.3814561357722</ele>
+				<time>2017-11-13T17:53:15Z</time>
+				<extensions>
+					<speed>27.129783630371094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014379295115187" lon="-84.2125150183018">
+				<ele>887.8342615123838</ele>
+				<time>2017-11-13T17:53:16Z</time>
+				<extensions>
+					<speed>25.448122024536133</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014219234429834" lon="-84.21233194428135">
+				<ele>869.3615675978363</ele>
+				<time>2017-11-13T17:53:17Z</time>
+				<extensions>
+					<speed>23.848690032958984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014219234429834" lon="-84.21233194428135">
+				<ele>876.7704115770757</ele>
+				<time>2017-11-13T17:53:18Z</time>
+				<extensions>
+					<speed>28.242279052734375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014219234429834" lon="-84.21233194428135">
+				<ele>887.2091513955966</ele>
+				<time>2017-11-13T17:53:19Z</time>
+				<extensions>
+					<speed>32.30735778808594</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014219234429834" lon="-84.21233194428135">
+				<ele>919.5668826000765</ele>
+				<time>2017-11-13T17:53:20Z</time>
+				<extensions>
+					<speed>47.52558135986328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013235271615875" lon="-84.21040163601712">
+				<ele>933.8012279337272</ele>
+				<time>2017-11-13T17:53:21Z</time>
+				<extensions>
+					<speed>46.336952209472656</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013077435757669" lon="-84.2101312286193">
+				<ele>943.8613290414214</ele>
+				<time>2017-11-13T17:53:22Z</time>
+				<extensions>
+					<speed>44.48225021362305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012993123824412" lon="-84.2100267048596">
+				<ele>947.9241625517607</ele>
+				<time>2017-11-13T17:53:23Z</time>
+				<extensions>
+					<speed>40.29646682739258</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012859897606868" lon="-84.20977682347984">
+				<ele>958.0399771630764</ele>
+				<time>2017-11-13T17:53:24Z</time>
+				<extensions>
+					<speed>39.23836135864258</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012757626018962" lon="-84.20955830540879">
+				<ele>965.8768017143011</ele>
+				<time>2017-11-13T17:53:25Z</time>
+				<extensions>
+					<speed>37.65175247192383</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012642758256138" lon="-84.20930240151009">
+				<ele>976.439352594316</ele>
+				<time>2017-11-13T17:53:26Z</time>
+				<extensions>
+					<speed>36.837520599365234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012510698288098" lon="-84.20900066858319">
+				<ele>987.7317770672962</ele>
+				<time>2017-11-13T17:53:27Z</time>
+				<extensions>
+					<speed>36.747135162353516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012386087047638" lon="-84.20870170276599">
+				<ele>1000.4526571696624</ele>
+				<time>2017-11-13T17:53:28Z</time>
+				<extensions>
+					<speed>36.59013748168945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01228214607699" lon="-84.20845583455073">
+				<ele>1008.7973419092596</ele>
+				<time>2017-11-13T17:53:29Z</time>
+				<extensions>
+					<speed>35.8873405456543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012150932809996" lon="-84.20817030758973">
+				<ele>1018.2493462953717</ele>
+				<time>2017-11-13T17:53:30Z</time>
+				<extensions>
+					<speed>35.7529182434082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01202273063591" lon="-84.20794862736949">
+				<ele>1019.0503521189094</ele>
+				<time>2017-11-13T17:53:31Z</time>
+				<extensions>
+					<speed>35.167510986328125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011910533530468" lon="-84.20772660620298">
+				<ele>1029.0045233499259</ele>
+				<time>2017-11-13T17:53:32Z</time>
+				<extensions>
+					<speed>34.523494720458984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011785165941824" lon="-84.20748557738789">
+				<ele>1038.2939195921645</ele>
+				<time>2017-11-13T17:53:33Z</time>
+				<extensions>
+					<speed>34.16071319580078</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011671669986177" lon="-84.20723658347399">
+				<ele>1052.4206004505977</ele>
+				<time>2017-11-13T17:53:34Z</time>
+				<extensions>
+					<speed>33.814537048339844</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011556459454077" lon="-84.20701014157815">
+				<ele>1063.2817539405078</ele>
+				<time>2017-11-13T17:53:35Z</time>
+				<extensions>
+					<speed>33.39703369140625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01151198818495" lon="-84.20684541299109">
+				<ele>1101.3211745154113</ele>
+				<time>2017-11-13T17:53:47Z</time>
+				<extensions>
+					<speed>18.475177764892578</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01151198818495" lon="-84.20684541299109">
+				<ele>1098.6164928888902</ele>
+				<time>2017-11-13T17:53:48Z</time>
+				<extensions>
+					<speed>16.441143035888672</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01151198818495" lon="-84.20684541299109">
+				<ele>1043.395202409476</ele>
+				<time>2017-11-13T17:53:49Z</time>
+				<extensions>
+					<speed>9.14514446258545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01151198818495" lon="-84.20684541299109">
+				<ele>1046.7983283475041</ele>
+				<time>2017-11-13T17:53:50Z</time>
+				<extensions>
+					<speed>7.829183101654053</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012514263056941" lon="-84.20919005753208">
+				<ele>1032.3134457441047</ele>
+				<time>2017-11-13T17:53:51Z</time>
+				<extensions>
+					<speed>3.35243558883667</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012514263056941" lon="-84.20919005753208">
+				<ele>1026.9545937571675</ele>
+				<time>2017-11-13T17:53:52Z</time>
+				<extensions>
+					<speed>0.7716801166534424</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012527210361931" lon="-84.20916614165014">
+				<ele>1046.5349986758083</ele>
+				<time>2017-11-13T17:53:53Z</time>
+				<extensions>
+					<speed>1.0103718042373657</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012546164587924" lon="-84.20921028334529">
+				<ele>1047.7451280597597</ele>
+				<time>2017-11-13T17:53:54Z</time>
+				<extensions>
+					<speed>0.9936125874519348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012572238794553" lon="-84.20928958447121">
+				<ele>1044.855055858381</ele>
+				<time>2017-11-13T17:53:55Z</time>
+				<extensions>
+					<speed>1.8013584613800049</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012594309602965" lon="-84.20934725552472">
+				<ele>1042.7430449808016</ele>
+				<time>2017-11-13T17:53:56Z</time>
+				<extensions>
+					<speed>2.0080535411834717</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012620295532795" lon="-84.20940832514191">
+				<ele>1041.0904603041708</ele>
+				<time>2017-11-13T17:53:57Z</time>
+				<extensions>
+					<speed>1.8206363916397095</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012648901653094" lon="-84.20946569927634">
+				<ele>1039.1049023605883</ele>
+				<time>2017-11-13T17:53:58Z</time>
+				<extensions>
+					<speed>1.673404574394226</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012677087325411" lon="-84.20952458054647">
+				<ele>1038.2512144846842</ele>
+				<time>2017-11-13T17:53:59Z</time>
+				<extensions>
+					<speed>1.433632254600525</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012700482762318" lon="-84.2095801901876">
+				<ele>1037.1408994607627</ele>
+				<time>2017-11-13T17:54:00Z</time>
+				<extensions>
+					<speed>1.2637170553207397</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012723286525171" lon="-84.20964595033819">
+				<ele>1034.4410759992898</ele>
+				<time>2017-11-13T17:54:01Z</time>
+				<extensions>
+					<speed>1.2508817911148071</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012748626282669" lon="-84.20970658994767">
+				<ele>1031.9017310030758</ele>
+				<time>2017-11-13T17:54:02Z</time>
+				<extensions>
+					<speed>1.28022038936615</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012748626282669" lon="-84.20970658994767">
+				<ele>1022.369432062842</ele>
+				<time>2017-11-13T17:54:03Z</time>
+				<extensions>
+					<speed>1.2426913976669312</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01282586449761" lon="-84.2099186718778">
+				<ele>1016.9464439777657</ele>
+				<time>2017-11-13T17:54:04Z</time>
+				<extensions>
+					<speed>1.093444585800171</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012849472668039" lon="-84.20998022714136">
+				<ele>1012.6374328834936</ele>
+				<time>2017-11-13T17:54:05Z</time>
+				<extensions>
+					<speed>1.0358808040618896</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012873279409787" lon="-84.21003552153623">
+				<ele>1010.9902206165716</ele>
+				<time>2017-11-13T17:54:06Z</time>
+				<extensions>
+					<speed>1.0126724243164063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01289394797812" lon="-84.21007435208854">
+				<ele>1010.7618542714044</ele>
+				<time>2017-11-13T17:54:07Z</time>
+				<extensions>
+					<speed>0.9394896030426025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012927125940239" lon="-84.21016640790255">
+				<ele>1005.8969353651628</ele>
+				<time>2017-11-13T17:54:08Z</time>
+				<extensions>
+					<speed>0.8049755096435547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012946063993827" lon="-84.21020932713432">
+				<ele>1005.1167665831745</ele>
+				<time>2017-11-13T17:54:09Z</time>
+				<extensions>
+					<speed>0.8615090847015381</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012938539413184" lon="-84.21020543160382">
+				<ele>1000.5208965223283</ele>
+				<time>2017-11-13T17:54:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:54:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:55:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:55:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:55:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:55:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:55:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:55:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:55:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:55:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:55:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:55:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:55:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:55:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:55:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:55:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:55:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:55:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:55:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:55:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:55:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01292851032826" lon="-84.21019841492766">
+				<ele>995.1135698519647</ele>
+				<time>2017-11-13T17:55:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012919814166679" lon="-84.21023723855744">
+				<ele>993.0903003914282</ele>
+				<time>2017-11-13T17:55:20Z</time>
+				<extensions>
+					<speed>0.820638120174408</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01289568736066" lon="-84.2102509050563">
+				<ele>991.5065388670191</ele>
+				<time>2017-11-13T17:55:21Z</time>
+				<extensions>
+					<speed>1.4110826253890991</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01286595385546" lon="-84.2102472461767">
+				<ele>990.1281616119668</ele>
+				<time>2017-11-13T17:55:22Z</time>
+				<extensions>
+					<speed>1.758593201637268</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012835686164163" lon="-84.21023817363934">
+				<ele>988.8514673328027</ele>
+				<time>2017-11-13T17:55:23Z</time>
+				<extensions>
+					<speed>1.8124921321868896</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012808080453183" lon="-84.2102278974562">
+				<ele>987.8578871302307</ele>
+				<time>2017-11-13T17:55:24Z</time>
+				<extensions>
+					<speed>1.6770169734954834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012783462072143" lon="-84.21021190472258">
+				<ele>986.8798361513764</ele>
+				<time>2017-11-13T17:55:25Z</time>
+				<extensions>
+					<speed>1.5955804586410522</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012766909121783" lon="-84.21019840256379">
+				<ele>986.4865268357098</ele>
+				<time>2017-11-13T17:55:26Z</time>
+				<extensions>
+					<speed>1.412021279335022</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012748968124168" lon="-84.21018030065062">
+				<ele>986.0015553683043</ele>
+				<time>2017-11-13T17:55:27Z</time>
+				<extensions>
+					<speed>1.3734936714172363</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012737360755821" lon="-84.21016559324225">
+				<ele>985.3660090491176</ele>
+				<time>2017-11-13T17:55:28Z</time>
+				<extensions>
+					<speed>1.2430856227874756</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012732538141693" lon="-84.21015407589285">
+				<ele>984.6133430125192</ele>
+				<time>2017-11-13T17:55:29Z</time>
+				<extensions>
+					<speed>1.1379919052124023</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012730628133632" lon="-84.21014994802059">
+				<ele>984.2429857505485</ele>
+				<time>2017-11-13T17:55:30Z</time>
+				<extensions>
+					<speed>1.0092066526412964</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012730860609379" lon="-84.21015187715223">
+				<ele>983.9662177367136</ele>
+				<time>2017-11-13T17:55:31Z</time>
+				<extensions>
+					<speed>0.7643521428108215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01272749197693" lon="-84.21014442536038">
+				<ele>983.7968481499702</ele>
+				<time>2017-11-13T17:55:32Z</time>
+				<extensions>
+					<speed>0.7135741114616394</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012721282964222" lon="-84.21013553398888">
+				<ele>983.4433699687943</ele>
+				<time>2017-11-13T17:55:33Z</time>
+				<extensions>
+					<speed>0.7378482222557068</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012712813339673" lon="-84.21012936055041">
+				<ele>983.1176909003407</ele>
+				<time>2017-11-13T17:55:34Z</time>
+				<extensions>
+					<speed>0.7355694770812988</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012698532641103" lon="-84.21011524183545">
+				<ele>983.0919159306213</ele>
+				<time>2017-11-13T17:55:35Z</time>
+				<extensions>
+					<speed>0.812772810459137</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689681750848" lon="-84.21010599449865">
+				<ele>982.8051959266886</ele>
+				<time>2017-11-13T17:55:36Z</time>
+				<extensions>
+					<speed>0.8485317230224609</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012682189272292" lon="-84.21009753809734">
+				<ele>982.7049605567008</ele>
+				<time>2017-11-13T17:55:37Z</time>
+				<extensions>
+					<speed>0.8492412567138672</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012673922466762" lon="-84.21009114212818">
+				<ele>982.3747844761238</ele>
+				<time>2017-11-13T17:55:38Z</time>
+				<extensions>
+					<speed>0.8569875359535217</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0126660557441" lon="-84.21009272656299">
+				<ele>981.9805281739682</ele>
+				<time>2017-11-13T17:55:39Z</time>
+				<extensions>
+					<speed>0.8019402027130127</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012662046214832" lon="-84.21008532065895">
+				<ele>981.3067173231393</ele>
+				<time>2017-11-13T17:55:40Z</time>
+				<extensions>
+					<speed>0.8255605101585388</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012668324195781" lon="-84.21010313503855">
+				<ele>980.9557232251391</ele>
+				<time>2017-11-13T17:55:41Z</time>
+				<extensions>
+					<speed>0.6373049020767212</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012679644997803" lon="-84.21011454725767">
+				<ele>980.7516659395769</ele>
+				<time>2017-11-13T17:55:42Z</time>
+				<extensions>
+					<speed>0.5415592193603516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:55:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:55:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:55:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:55:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:55:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:55:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:55:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:55:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:55:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:55:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:55:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:55:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:55:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:55:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:55:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:55:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:55:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:56:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:56:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:56:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:56:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:56:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:56:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:56:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:56:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:56:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:56:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:56:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:56:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:56:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:56:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:56:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012689263100722" lon="-84.2101216600604">
+				<ele>980.8252977505326</ele>
+				<time>2017-11-13T17:56:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012678827346276" lon="-84.21015458441428">
+				<ele>981.0768138179556</ele>
+				<time>2017-11-13T17:56:16Z</time>
+				<extensions>
+					<speed>0.737490713596344</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012671884593638" lon="-84.21019753776494">
+				<ele>980.7232692269608</ele>
+				<time>2017-11-13T17:56:17Z</time>
+				<extensions>
+					<speed>1.0105332136154175</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012667228966189" lon="-84.21022423629364">
+				<ele>980.9235715242103</ele>
+				<time>2017-11-13T17:56:18Z</time>
+				<extensions>
+					<speed>1.0661873817443848</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012669644505921" lon="-84.21023867895774">
+				<ele>981.1409683367237</ele>
+				<time>2017-11-13T17:56:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:20Z</time>
+				<extensions>
+					<speed>0.37370753288269043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012675416106257" lon="-84.2102488957411">
+				<ele>981.9492859160528</ele>
+				<time>2017-11-13T17:56:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012659292934014" lon="-84.2102334137038">
+				<ele>982.180741392076</ele>
+				<time>2017-11-13T17:56:54Z</time>
+				<extensions>
+					<speed>0.6460350751876831</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012642019676873" lon="-84.21021813674334">
+				<ele>982.5681290039793</ele>
+				<time>2017-11-13T17:56:55Z</time>
+				<extensions>
+					<speed>0.9165668487548828</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0126227233137" lon="-84.21020458226207">
+				<ele>982.4442807035521</ele>
+				<time>2017-11-13T17:56:56Z</time>
+				<extensions>
+					<speed>1.0880026817321777</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01260608133196" lon="-84.21019332814674">
+				<ele>981.754032291472</ele>
+				<time>2017-11-13T17:56:57Z</time>
+				<extensions>
+					<speed>1.1926352977752686</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012597249821956" lon="-84.21019149390037">
+				<ele>981.2632236219943</ele>
+				<time>2017-11-13T17:56:58Z</time>
+				<extensions>
+					<speed>1.0866096019744873</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012589826543143" lon="-84.21019120306319">
+				<ele>980.6483742976561</ele>
+				<time>2017-11-13T17:56:59Z</time>
+				<extensions>
+					<speed>0.9652920961380005</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0125885626039" lon="-84.21019864101102">
+				<ele>979.6981397615746</ele>
+				<time>2017-11-13T17:57:00Z</time>
+				<extensions>
+					<speed>0.754585862159729</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0125816820286" lon="-84.21020559820998">
+				<ele>979.01121909637</ele>
+				<time>2017-11-13T17:57:01Z</time>
+				<extensions>
+					<speed>0.8320537805557251</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012571668329423" lon="-84.21020653556515">
+				<ele>978.3252695715055</ele>
+				<time>2017-11-13T17:57:02Z</time>
+				<extensions>
+					<speed>0.9888874888420105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012562049712322" lon="-84.21020142325193">
+				<ele>978.0191233949736</ele>
+				<time>2017-11-13T17:57:03Z</time>
+				<extensions>
+					<speed>0.9987940192222595</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012556312611297" lon="-84.21020036360595">
+				<ele>977.5774719612673</ele>
+				<time>2017-11-13T17:57:04Z</time>
+				<extensions>
+					<speed>0.9042656421661377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012551333368384" lon="-84.21020512608636">
+				<ele>977.2332809930667</ele>
+				<time>2017-11-13T17:57:05Z</time>
+				<extensions>
+					<speed>0.7533552646636963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012547501157174" lon="-84.2102068444251">
+				<ele>976.7645086282864</ele>
+				<time>2017-11-13T17:57:06Z</time>
+				<extensions>
+					<speed>0.530844509601593</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012548788215465" lon="-84.21020915668414">
+				<ele>976.5799774536863</ele>
+				<time>2017-11-13T17:57:07Z</time>
+				<extensions>
+					<speed>0.32827135920524597</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012551117380932" lon="-84.21020794002986">
+				<ele>976.5216496791691</ele>
+				<time>2017-11-13T17:57:08Z</time>
+				<extensions>
+					<speed>0.1952088177204132</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012552872240294" lon="-84.21020542782217">
+				<ele>976.6597423627973</ele>
+				<time>2017-11-13T17:57:09Z</time>
+				<extensions>
+					<speed>0.16505776345729828</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012553019508816" lon="-84.21020642081916">
+				<ele>976.46157836169</ele>
+				<time>2017-11-13T17:57:10Z</time>
+				<extensions>
+					<speed>0.017461581155657768</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012553019508816" lon="-84.21020642081916">
+				<ele>976.46157836169</ele>
+				<time>2017-11-13T17:57:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012553019508816" lon="-84.21020642081916">
+				<ele>976.46157836169</ele>
+				<time>2017-11-13T17:57:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012553019508816" lon="-84.21020642081916">
+				<ele>976.46157836169</ele>
+				<time>2017-11-13T17:57:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012553019508816" lon="-84.21020642081916">
+				<ele>976.46157836169</ele>
+				<time>2017-11-13T17:57:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01254725573315" lon="-84.21020878368148">
+				<ele>976.5604639900848</ele>
+				<time>2017-11-13T17:57:15Z</time>
+				<extensions>
+					<speed>0.09044807404279709</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01254448061572" lon="-84.21021367543473">
+				<ele>976.4590723169968</ele>
+				<time>2017-11-13T17:57:16Z</time>
+				<extensions>
+					<speed>0.09296676516532898</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01254448061572" lon="-84.21021367543473">
+				<ele>976.4590723169968</ele>
+				<time>2017-11-13T17:57:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01254448061572" lon="-84.21021367543473">
+				<ele>976.4590723169968</ele>
+				<time>2017-11-13T17:57:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01254448061572" lon="-84.21021367543473">
+				<ele>976.4590723169968</ele>
+				<time>2017-11-13T17:57:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01254448061572" lon="-84.21021367543473">
+				<ele>976.4590723169968</ele>
+				<time>2017-11-13T17:57:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01254448061572" lon="-84.21021367543473">
+				<ele>976.4590723169968</ele>
+				<time>2017-11-13T17:57:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01254448061572" lon="-84.21021367543473">
+				<ele>976.4590723169968</ele>
+				<time>2017-11-13T17:57:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01254448061572" lon="-84.21021367543473">
+				<ele>976.4590723169968</ele>
+				<time>2017-11-13T17:57:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01254448061572" lon="-84.21021367543473">
+				<ele>976.4590723169968</ele>
+				<time>2017-11-13T17:57:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01254763631275" lon="-84.2102308538574">
+				<ele>976.6153650954366</ele>
+				<time>2017-11-13T17:57:25Z</time>
+				<extensions>
+					<speed>0.30010950565338135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01254763631275" lon="-84.2102308538574">
+				<ele>976.6153650954366</ele>
+				<time>2017-11-13T17:57:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01254763631275" lon="-84.2102308538574">
+				<ele>976.6153650954366</ele>
+				<time>2017-11-13T17:57:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01254763631275" lon="-84.2102308538574">
+				<ele>976.6153650954366</ele>
+				<time>2017-11-13T17:57:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01254763631275" lon="-84.2102308538574">
+				<ele>976.6153650954366</ele>
+				<time>2017-11-13T17:57:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01254763631275" lon="-84.2102308538574">
+				<ele>976.6153650954366</ele>
+				<time>2017-11-13T17:57:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012556591825467" lon="-84.21025709105443">
+				<ele>976.4749213755131</ele>
+				<time>2017-11-13T17:57:31Z</time>
+				<extensions>
+					<speed>0.4770676791667938</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01256609648359" lon="-84.21028222698259">
+				<ele>976.261406565085</ele>
+				<time>2017-11-13T17:57:32Z</time>
+				<extensions>
+					<speed>0.6439666748046875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012578040691738" lon="-84.21031458389835">
+				<ele>975.9703259505332</ele>
+				<time>2017-11-13T17:57:33Z</time>
+				<extensions>
+					<speed>0.884633481502533</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012596316334433" lon="-84.21033219393072">
+				<ele>975.6204569786787</ele>
+				<time>2017-11-13T17:57:34Z</time>
+				<extensions>
+					<speed>1.055912971496582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012608761669753" lon="-84.21035797855804">
+				<ele>975.4231674196199</ele>
+				<time>2017-11-13T17:57:35Z</time>
+				<extensions>
+					<speed>1.1577630043029785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012620442901554" lon="-84.21037459488781">
+				<ele>975.4048555511981</ele>
+				<time>2017-11-13T17:57:36Z</time>
+				<extensions>
+					<speed>1.1869539022445679</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012629908309123" lon="-84.2103865554103">
+				<ele>975.3614815501496</ele>
+				<time>2017-11-13T17:57:37Z</time>
+				<extensions>
+					<speed>1.1628293991088867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012636554851746" lon="-84.21039147766767">
+				<ele>975.386257939972</ele>
+				<time>2017-11-13T17:57:38Z</time>
+				<extensions>
+					<speed>1.0417734384536743</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012640256796875" lon="-84.21039782472559">
+				<ele>975.3741004979238</ele>
+				<time>2017-11-13T17:57:39Z</time>
+				<extensions>
+					<speed>0.9754601716995239</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012641438730109" lon="-84.21041081579735">
+				<ele>975.3539214702323</ele>
+				<time>2017-11-13T17:57:40Z</time>
+				<extensions>
+					<speed>0.9222031831741333</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012636910609997" lon="-84.21040967805885">
+				<ele>975.3034163108096</ele>
+				<time>2017-11-13T17:57:41Z</time>
+				<extensions>
+					<speed>0.7224239706993103</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012631122496662" lon="-84.21040772295025">
+				<ele>975.2351211979985</ele>
+				<time>2017-11-13T17:57:42Z</time>
+				<extensions>
+					<speed>0.5177554488182068</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012620194688296" lon="-84.21040349741116">
+				<ele>975.1065935436636</ele>
+				<time>2017-11-13T17:57:43Z</time>
+				<extensions>
+					<speed>0.33072635531425476</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012609670339302" lon="-84.21039925283623">
+				<ele>975.0167047400028</ele>
+				<time>2017-11-13T17:57:44Z</time>
+				<extensions>
+					<speed>0.21850696206092834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012597257415743" lon="-84.21040399617205">
+				<ele>974.8690447788686</ele>
+				<time>2017-11-13T17:57:45Z</time>
+				<extensions>
+					<speed>0.21946044266223907</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012587547435228" lon="-84.21040284770177">
+				<ele>974.7159676877782</ele>
+				<time>2017-11-13T17:57:46Z</time>
+				<extensions>
+					<speed>0.23620836436748505</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012575955236505" lon="-84.2104010568577">
+				<ele>974.3027832219377</ele>
+				<time>2017-11-13T17:57:47Z</time>
+				<extensions>
+					<speed>0.3300226330757141</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01256890527196" lon="-84.2103961860353">
+				<ele>974.0085221780464</ele>
+				<time>2017-11-13T17:57:48Z</time>
+				<extensions>
+					<speed>0.383532851934433</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012562743087644" lon="-84.21039168202472">
+				<ele>973.8103846656159</ele>
+				<time>2017-11-13T17:57:49Z</time>
+				<extensions>
+					<speed>0.37263765931129456</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012555485423349" lon="-84.21037986190284">
+				<ele>973.633521778509</ele>
+				<time>2017-11-13T17:57:50Z</time>
+				<extensions>
+					<speed>0.43147292733192444</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012550780681272" lon="-84.21037779544932">
+				<ele>973.5595618430525</ele>
+				<time>2017-11-13T17:57:51Z</time>
+				<extensions>
+					<speed>0.43883419036865234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012545615751643" lon="-84.2103712229382">
+				<ele>973.5045775631443</ele>
+				<time>2017-11-13T17:57:52Z</time>
+				<extensions>
+					<speed>0.4671417474746704</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01253938993199" lon="-84.2103692290508">
+				<ele>973.4564315481111</ele>
+				<time>2017-11-13T17:57:53Z</time>
+				<extensions>
+					<speed>0.4869682788848877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012534025318317" lon="-84.21036468900255">
+				<ele>973.4389726584777</ele>
+				<time>2017-11-13T17:57:54Z</time>
+				<extensions>
+					<speed>0.5142717361450195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01253399454137" lon="-84.21036394201305">
+				<ele>973.4831584105268</ele>
+				<time>2017-11-13T17:57:55Z</time>
+				<extensions>
+					<speed>0.49970340728759766</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012539372480392" lon="-84.21036387216047">
+				<ele>973.5922585688531</ele>
+				<time>2017-11-13T17:57:56Z</time>
+				<extensions>
+					<speed>0.45223188400268555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012541450661406" lon="-84.21036920487677">
+				<ele>973.7591803735122</ele>
+				<time>2017-11-13T17:57:57Z</time>
+				<extensions>
+					<speed>0.4317493438720703</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012534833607509" lon="-84.21037139339953">
+				<ele>973.8088781945407</ele>
+				<time>2017-11-13T17:57:58Z</time>
+				<extensions>
+					<speed>0.49609240889549255</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012529313240295" lon="-84.21037634519794">
+				<ele>973.864331105724</ele>
+				<time>2017-11-13T17:57:59Z</time>
+				<extensions>
+					<speed>0.549340009689331</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012521380897292" lon="-84.2103868560393">
+				<ele>973.9082827251405</ele>
+				<time>2017-11-13T17:58:00Z</time>
+				<extensions>
+					<speed>0.6691526174545288</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012511953392345" lon="-84.2104042777105">
+				<ele>973.9092894401401</ele>
+				<time>2017-11-13T17:58:01Z</time>
+				<extensions>
+					<speed>0.7631638050079346</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012511632213117" lon="-84.21044679693473">
+				<ele>973.587513727136</ele>
+				<time>2017-11-13T17:58:02Z</time>
+				<extensions>
+					<speed>0.8867353796958923</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01253295989248" lon="-84.21052400547784">
+				<ele>972.7314488943666</ele>
+				<time>2017-11-13T17:58:03Z</time>
+				<extensions>
+					<speed>0.893187940120697</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012553085953112" lon="-84.2105976962575">
+				<ele>971.9848506627604</ele>
+				<time>2017-11-13T17:58:04Z</time>
+				<extensions>
+					<speed>1.133719801902771</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012547161932966" lon="-84.21055967528405">
+				<ele>972.4948829896748</ele>
+				<time>2017-11-13T17:58:05Z</time>
+				<extensions>
+					<speed>0.39795637130737305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012541204114488" lon="-84.21054507834015">
+				<ele>971.9113752041012</ele>
+				<time>2017-11-13T17:58:06Z</time>
+				<extensions>
+					<speed>0.7269924879074097</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012550281709967" lon="-84.21056186545476">
+				<ele>971.5438791047782</ele>
+				<time>2017-11-13T17:58:07Z</time>
+				<extensions>
+					<speed>0.5629940629005432</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012561274022625" lon="-84.21058099451376">
+				<ele>971.2693099156022</ele>
+				<time>2017-11-13T17:58:08Z</time>
+				<extensions>
+					<speed>0.33499354124069214</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012570638727029" lon="-84.21060312750537">
+				<ele>970.97596260719</ele>
+				<time>2017-11-13T17:58:09Z</time>
+				<extensions>
+					<speed>0.37251904606819153</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012578967723869" lon="-84.21062242982683">
+				<ele>970.5188276600093</ele>
+				<time>2017-11-13T17:58:10Z</time>
+				<extensions>
+					<speed>0.5521349310874939</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012582828151803" lon="-84.21063948852601">
+				<ele>970.0157911693677</ele>
+				<time>2017-11-13T17:58:11Z</time>
+				<extensions>
+					<speed>0.7748414874076843</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01258856026547" lon="-84.2106631586969">
+				<ele>969.7012214455754</ele>
+				<time>2017-11-13T17:58:12Z</time>
+				<extensions>
+					<speed>1.262803316116333</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01259407245084" lon="-84.21069276955903">
+				<ele>969.159918663092</ele>
+				<time>2017-11-13T17:58:13Z</time>
+				<extensions>
+					<speed>1.8011945486068726</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012599334731902" lon="-84.21071840114462">
+				<ele>968.6972369188443</ele>
+				<time>2017-11-13T17:58:14Z</time>
+				<extensions>
+					<speed>1.8741523027420044</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012603040298343" lon="-84.2107423190088">
+				<ele>968.174295800738</ele>
+				<time>2017-11-13T17:58:15Z</time>
+				<extensions>
+					<speed>1.93887197971344</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012597222479794" lon="-84.21075761728393">
+				<ele>967.3942382289097</ele>
+				<time>2017-11-13T17:58:16Z</time>
+				<extensions>
+					<speed>1.8007681369781494</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01258930081491" lon="-84.21077556913389">
+				<ele>966.7435433128849</ele>
+				<time>2017-11-13T17:58:17Z</time>
+				<extensions>
+					<speed>1.8320389986038208</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01255800152949" lon="-84.21078588908891">
+				<ele>965.7420961540192</ele>
+				<time>2017-11-13T17:58:18Z</time>
+				<extensions>
+					<speed>1.7691214084625244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012531239391006" lon="-84.21078690576473">
+				<ele>964.7938106348738</ele>
+				<time>2017-11-13T17:58:19Z</time>
+				<extensions>
+					<speed>1.6776660680770874</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012525642273786" lon="-84.21079738641787">
+				<ele>964.2781609538943</ele>
+				<time>2017-11-13T17:58:20Z</time>
+				<extensions>
+					<speed>1.6125779151916504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012532543659745" lon="-84.21079647960212">
+				<ele>961.8048947043717</ele>
+				<time>2017-11-13T17:58:21Z</time>
+				<extensions>
+					<speed>1.343514084815979</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01252945159772" lon="-84.21079913309165">
+				<ele>960.2836379529908</ele>
+				<time>2017-11-13T17:58:22Z</time>
+				<extensions>
+					<speed>1.1720930337905884</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012531962459459" lon="-84.21080203345919">
+				<ele>959.6563463490456</ele>
+				<time>2017-11-13T17:58:23Z</time>
+				<extensions>
+					<speed>0.9014318585395813</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012524032596765" lon="-84.21080403288076">
+				<ele>959.4878718918189</ele>
+				<time>2017-11-13T17:58:24Z</time>
+				<extensions>
+					<speed>0.7325911521911621</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012514875201758" lon="-84.21080825375545">
+				<ele>959.633528387174</ele>
+				<time>2017-11-13T17:58:25Z</time>
+				<extensions>
+					<speed>0.7707801461219788</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012507380494664" lon="-84.2108096756623">
+				<ele>960.0981849422678</ele>
+				<time>2017-11-13T17:58:26Z</time>
+				<extensions>
+					<speed>0.7759836912155151</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012506068096819" lon="-84.21081361545941">
+				<ele>961.0871358066797</ele>
+				<time>2017-11-13T17:58:27Z</time>
+				<extensions>
+					<speed>0.8615604043006897</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012507900796612" lon="-84.21083055170554">
+				<ele>961.837523679249</ele>
+				<time>2017-11-13T17:58:28Z</time>
+				<extensions>
+					<speed>1.1854664087295532</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012505917037984" lon="-84.21084649367593">
+				<ele>962.5084034344181</ele>
+				<time>2017-11-13T17:58:29Z</time>
+				<extensions>
+					<speed>1.371578335762024</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01248202902221" lon="-84.210853299749">
+				<ele>962.4515647944063</ele>
+				<time>2017-11-13T17:58:30Z</time>
+				<extensions>
+					<speed>1.4513894319534302</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012445745886255" lon="-84.21085992149543">
+				<ele>962.335586072877</ele>
+				<time>2017-11-13T17:58:31Z</time>
+				<extensions>
+					<speed>1.7751754522323608</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012417732099978" lon="-84.21086853695044">
+				<ele>962.0685748690739</ele>
+				<time>2017-11-13T17:58:32Z</time>
+				<extensions>
+					<speed>1.947202205657959</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012392700473308" lon="-84.21087541752111">
+				<ele>961.4642268856987</ele>
+				<time>2017-11-13T17:58:33Z</time>
+				<extensions>
+					<speed>2.146636486053467</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012375303917803" lon="-84.21088820980289">
+				<ele>961.0234970776364</ele>
+				<time>2017-11-13T17:58:34Z</time>
+				<extensions>
+					<speed>2.3320162296295166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0123545270547" lon="-84.21090311293273">
+				<ele>961.0261781783774</ele>
+				<time>2017-11-13T17:58:35Z</time>
+				<extensions>
+					<speed>2.5005481243133545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012333120665149" lon="-84.21091403142715">
+				<ele>960.5985094057396</ele>
+				<time>2017-11-13T17:58:36Z</time>
+				<extensions>
+					<speed>2.456759214401245</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012323134752247" lon="-84.2109244792774">
+				<ele>960.1171922972426</ele>
+				<time>2017-11-13T17:58:37Z</time>
+				<extensions>
+					<speed>2.264354705810547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01231651554455" lon="-84.2109339196103">
+				<ele>959.527143150568</ele>
+				<time>2017-11-13T17:58:38Z</time>
+				<extensions>
+					<speed>2.190964460372925</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012310404176018" lon="-84.2109503698221">
+				<ele>959.2298119012266</ele>
+				<time>2017-11-13T17:58:39Z</time>
+				<extensions>
+					<speed>2.2189741134643555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012305425680196" lon="-84.2109691695647">
+				<ele>959.3496461147442</ele>
+				<time>2017-11-13T17:58:40Z</time>
+				<extensions>
+					<speed>2.2784602642059326</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012307059821538" lon="-84.21098668204299">
+				<ele>959.5660863956437</ele>
+				<time>2017-11-13T17:58:41Z</time>
+				<extensions>
+					<speed>2.1986942291259766</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012313100349042" lon="-84.21101396046873">
+				<ele>959.6505362689495</ele>
+				<time>2017-11-13T17:58:42Z</time>
+				<extensions>
+					<speed>2.2251052856445313</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012320347119617" lon="-84.21104568095203">
+				<ele>959.8491950342432</ele>
+				<time>2017-11-13T17:58:43Z</time>
+				<extensions>
+					<speed>2.2751753330230713</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01232545581947" lon="-84.21108657227427">
+				<ele>959.6649485500529</ele>
+				<time>2017-11-13T17:58:44Z</time>
+				<extensions>
+					<speed>2.466747760772705</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01233012804907" lon="-84.21111361713344">
+				<ele>959.5604644231498</ele>
+				<time>2017-11-13T17:58:45Z</time>
+				<extensions>
+					<speed>2.4026262760162354</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01232895815809" lon="-84.21113734533006">
+				<ele>959.586346921511</ele>
+				<time>2017-11-13T17:58:46Z</time>
+				<extensions>
+					<speed>2.2696356773376465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012330515180214" lon="-84.21115247761472">
+				<ele>960.2703125616536</ele>
+				<time>2017-11-13T17:58:47Z</time>
+				<extensions>
+					<speed>2.1280710697174072</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012327758573973" lon="-84.2111721705821">
+				<ele>960.6326107503846</ele>
+				<time>2017-11-13T17:58:48Z</time>
+				<extensions>
+					<speed>2.0316948890686035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012319446415791" lon="-84.21118698803019">
+				<ele>960.3749637212604</ele>
+				<time>2017-11-13T17:58:49Z</time>
+				<extensions>
+					<speed>2.096409320831299</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01231343068444" lon="-84.21120240837138">
+				<ele>959.9815148543566</ele>
+				<time>2017-11-13T17:58:50Z</time>
+				<extensions>
+					<speed>2.0773813724517822</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012300217885773" lon="-84.21122143106189">
+				<ele>959.9365730928257</ele>
+				<time>2017-11-13T17:58:51Z</time>
+				<extensions>
+					<speed>2.1546742916107178</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012287403638032" lon="-84.21123427758533">
+				<ele>959.8709985986352</ele>
+				<time>2017-11-13T17:58:52Z</time>
+				<extensions>
+					<speed>2.2217016220092773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01227825029627" lon="-84.2112509007396">
+				<ele>959.8843070417643</ele>
+				<time>2017-11-13T17:58:53Z</time>
+				<extensions>
+					<speed>2.2070114612579346</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012271921348159" lon="-84.21126659868726">
+				<ele>960.0960531011224</ele>
+				<time>2017-11-13T17:58:54Z</time>
+				<extensions>
+					<speed>2.1429545879364014</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012273516831781" lon="-84.21129019804073">
+				<ele>960.9066258622333</ele>
+				<time>2017-11-13T17:58:55Z</time>
+				<extensions>
+					<speed>2.0990583896636963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012278245159932" lon="-84.21131503978692">
+				<ele>961.5252337493002</ele>
+				<time>2017-11-13T17:58:56Z</time>
+				<extensions>
+					<speed>2.0564308166503906</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012277657383326" lon="-84.21134151010864">
+				<ele>961.7675855048001</ele>
+				<time>2017-11-13T17:58:57Z</time>
+				<extensions>
+					<speed>2.120586395263672</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012277085655764" lon="-84.21136371775921">
+				<ele>961.9479857692495</ele>
+				<time>2017-11-13T17:58:58Z</time>
+				<extensions>
+					<speed>2.1172165870666504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012278587671588" lon="-84.21138465549926">
+				<ele>961.6136896749958</ele>
+				<time>2017-11-13T17:58:59Z</time>
+				<extensions>
+					<speed>2.122389554977417</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012275489582619" lon="-84.21141675696168">
+				<ele>961.3580659395084</ele>
+				<time>2017-11-13T17:59:00Z</time>
+				<extensions>
+					<speed>2.2853493690490723</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012273213726585" lon="-84.21147968573646">
+				<ele>959.9981714179739</ele>
+				<time>2017-11-13T17:59:01Z</time>
+				<extensions>
+					<speed>2.94022274017334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01227113491158" lon="-84.21151752427694">
+				<ele>959.5985561460257</ele>
+				<time>2017-11-13T17:59:02Z</time>
+				<extensions>
+					<speed>3.1934893131256104</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012274013383378" lon="-84.21154738599601">
+				<ele>959.4313000980765</ele>
+				<time>2017-11-13T17:59:03Z</time>
+				<extensions>
+					<speed>3.2268640995025635</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012272793973114" lon="-84.2115770661927">
+				<ele>959.5246789306402</ele>
+				<time>2017-11-13T17:59:04Z</time>
+				<extensions>
+					<speed>3.281313896179199</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01226989880615" lon="-84.21161144664673">
+				<ele>959.4648955306038</ele>
+				<time>2017-11-13T17:59:05Z</time>
+				<extensions>
+					<speed>3.3440442085266113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012270394853438" lon="-84.21164597828682">
+				<ele>959.4919256903231</ele>
+				<time>2017-11-13T17:59:06Z</time>
+				<extensions>
+					<speed>3.4243826866149902</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012265210313911" lon="-84.2116640116613">
+				<ele>959.7636960688978</ele>
+				<time>2017-11-13T17:59:07Z</time>
+				<extensions>
+					<speed>2.9590566158294678</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012256314316943" lon="-84.21167754280802">
+				<ele>960.3813939616084</ele>
+				<time>2017-11-13T17:59:08Z</time>
+				<extensions>
+					<speed>2.416677474975586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012250968355252" lon="-84.21169529746977">
+				<ele>961.1316102938727</ele>
+				<time>2017-11-13T17:59:09Z</time>
+				<extensions>
+					<speed>1.9630966186523438</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012244089735788" lon="-84.21169904525061">
+				<ele>961.7354001253843</ele>
+				<time>2017-11-13T17:59:10Z</time>
+				<extensions>
+					<speed>1.4910483360290527</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012226962008798" lon="-84.2117012260005">
+				<ele>962.2528946157545</ele>
+				<time>2017-11-13T17:59:11Z</time>
+				<extensions>
+					<speed>1.4249581098556519</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012213086000077" lon="-84.21170311829633">
+				<ele>962.7708740038797</ele>
+				<time>2017-11-13T17:59:12Z</time>
+				<extensions>
+					<speed>1.3893482685089111</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012199104132447" lon="-84.21170401930245">
+				<ele>963.6090769516304</ele>
+				<time>2017-11-13T17:59:13Z</time>
+				<extensions>
+					<speed>1.3564190864562988</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217819077344" lon="-84.21170290093775">
+				<ele>964.1994584361091</ele>
+				<time>2017-11-13T17:59:14Z</time>
+				<extensions>
+					<speed>1.5626710653305054</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012173961739569" lon="-84.21170468270834">
+				<ele>964.7492019189522</ele>
+				<time>2017-11-13T17:59:15Z</time>
+				<extensions>
+					<speed>1.489193081855774</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012179779000048" lon="-84.21170108258718">
+				<ele>964.1686459491029</ele>
+				<time>2017-11-13T17:59:16Z</time>
+				<extensions>
+					<speed>1.1477787494659424</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012190754785562" lon="-84.21169590373361">
+				<ele>963.9687218461186</ele>
+				<time>2017-11-13T17:59:17Z</time>
+				<extensions>
+					<speed>0.7440962195396423</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012200758029119" lon="-84.2116849930945">
+				<ele>963.707820519805</ele>
+				<time>2017-11-13T17:59:18Z</time>
+				<extensions>
+					<speed>0.287250816822052</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012212118044145" lon="-84.21167369521301">
+				<ele>964.3386148456484</ele>
+				<time>2017-11-13T17:59:19Z</time>
+				<extensions>
+					<speed>0.13493499159812927</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012227492105914" lon="-84.21166901504334">
+				<ele>965.3928209524602</ele>
+				<time>2017-11-13T17:59:20Z</time>
+				<extensions>
+					<speed>0.2395145446062088</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012244869013527" lon="-84.21165681909474">
+				<ele>966.2897149752825</ele>
+				<time>2017-11-13T17:59:21Z</time>
+				<extensions>
+					<speed>0.4226415157318115</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012257513252202" lon="-84.21164727336082">
+				<ele>967.1779942009598</ele>
+				<time>2017-11-13T17:59:22Z</time>
+				<extensions>
+					<speed>0.5098300576210022</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012242533381313" lon="-84.21158552407195">
+				<ele>967.7176409289241</ele>
+				<time>2017-11-13T17:59:23Z</time>
+				<extensions>
+					<speed>1.0040438175201416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012226168086883" lon="-84.21150311417594">
+				<ele>969.0866260267794</ele>
+				<time>2017-11-13T17:59:25Z</time>
+				<extensions>
+					<speed>1.7964859008789063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012226519776664" lon="-84.21146166182656">
+				<ele>969.4562149085104</ele>
+				<time>2017-11-13T17:59:26Z</time>
+				<extensions>
+					<speed>2.134728193283081</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012228896726757" lon="-84.21143005043544">
+				<ele>969.8211304070428</ele>
+				<time>2017-11-13T17:59:27Z</time>
+				<extensions>
+					<speed>2.2323598861694336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01222589627681" lon="-84.21141071992349">
+				<ele>970.2069820361212</ele>
+				<time>2017-11-13T17:59:28Z</time>
+				<extensions>
+					<speed>1.928623080253601</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012234864546311" lon="-84.2113744678448">
+				<ele>970.2394586158916</ele>
+				<time>2017-11-13T17:59:29Z</time>
+				<extensions>
+					<speed>1.9775118827819824</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012235574611955" lon="-84.21135300122062">
+				<ele>970.6532220691442</ele>
+				<time>2017-11-13T17:59:30Z</time>
+				<extensions>
+					<speed>1.8217238187789917</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012228554350026" lon="-84.21134285277559">
+				<ele>971.0784459020942</ele>
+				<time>2017-11-13T17:59:31Z</time>
+				<extensions>
+					<speed>1.6381316184997559</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012221314234807" lon="-84.2113434745976">
+				<ele>971.5896614659578</ele>
+				<time>2017-11-13T17:59:32Z</time>
+				<extensions>
+					<speed>1.3254058361053467</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01221266834024" lon="-84.21135375665757">
+				<ele>971.6748526971787</ele>
+				<time>2017-11-13T17:59:33Z</time>
+				<extensions>
+					<speed>1.0352431535720825</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012209929117702" lon="-84.21136724617473">
+				<ele>971.4655963191763</ele>
+				<time>2017-11-13T17:59:34Z</time>
+				<extensions>
+					<speed>0.7221696972846985</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012209613758111" lon="-84.21137685815538">
+				<ele>970.8377091623843</ele>
+				<time>2017-11-13T17:59:35Z</time>
+				<extensions>
+					<speed>0.48372963070869446</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012209950126277" lon="-84.2113903190987">
+				<ele>970.4839259283617</ele>
+				<time>2017-11-13T17:59:36Z</time>
+				<extensions>
+					<speed>0.34669071435928345</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01221484113034" lon="-84.21140784566734">
+				<ele>970.2278674263507</ele>
+				<time>2017-11-13T17:59:37Z</time>
+				<extensions>
+					<speed>0.3048514425754547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012213052133394" lon="-84.2114185556242">
+				<ele>969.9376537362114</ele>
+				<time>2017-11-13T17:59:38Z</time>
+				<extensions>
+					<speed>0.21687427163124084</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0122140713367" lon="-84.21142133710751">
+				<ele>969.5206968123093</ele>
+				<time>2017-11-13T17:59:39Z</time>
+				<extensions>
+					<speed>0.24562743306159973</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012211934331773" lon="-84.21143086323426">
+				<ele>969.0998377008364</ele>
+				<time>2017-11-13T17:59:40Z</time>
+				<extensions>
+					<speed>0.3277203142642975</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012210313982013" lon="-84.21145172163462">
+				<ele>968.4233304746449</ele>
+				<time>2017-11-13T17:59:41Z</time>
+				<extensions>
+					<speed>0.48432376980781555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012209827130285" lon="-84.21146891412188">
+				<ele>967.9359514098614</ele>
+				<time>2017-11-13T17:59:42Z</time>
+				<extensions>
+					<speed>0.5984097719192505</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012212402189943" lon="-84.21148229931396">
+				<ele>967.8906458159909</ele>
+				<time>2017-11-13T17:59:43Z</time>
+				<extensions>
+					<speed>0.6766042113304138</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012215589778597" lon="-84.21149662108688">
+				<ele>968.000894731842</ele>
+				<time>2017-11-13T17:59:44Z</time>
+				<extensions>
+					<speed>0.7656809091567993</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012222137015138" lon="-84.21150977892107">
+				<ele>968.5784072522074</ele>
+				<time>2017-11-13T17:59:45Z</time>
+				<extensions>
+					<speed>0.8141844868659973</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01222506835555" lon="-84.21152220864231">
+				<ele>968.8799197319895</ele>
+				<time>2017-11-13T17:59:46Z</time>
+				<extensions>
+					<speed>0.8457946181297302</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012225220364538" lon="-84.21153095348122">
+				<ele>969.0998957753181</ele>
+				<time>2017-11-13T17:59:47Z</time>
+				<extensions>
+					<speed>0.8465568423271179</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012228473235526" lon="-84.21154148255151">
+				<ele>969.1746277604252</ele>
+				<time>2017-11-13T17:59:48Z</time>
+				<extensions>
+					<speed>0.8610591888427734</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012231892910037" lon="-84.21155610809883">
+				<ele>969.2238823901862</ele>
+				<time>2017-11-13T17:59:49Z</time>
+				<extensions>
+					<speed>0.9317908883094788</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012237528717066" lon="-84.21155734291045">
+				<ele>969.4945033099502</ele>
+				<time>2017-11-13T17:59:50Z</time>
+				<extensions>
+					<speed>0.8523604273796082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012245955142513" lon="-84.21156371213816">
+				<ele>969.4756701588631</ele>
+				<time>2017-11-13T17:59:51Z</time>
+				<extensions>
+					<speed>0.9114210605621338</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01225593383606" lon="-84.21157113427802">
+				<ele>969.3017485309392</ele>
+				<time>2017-11-13T17:59:52Z</time>
+				<extensions>
+					<speed>0.9429483413696289</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01225249067553" lon="-84.21156429851315">
+				<ele>969.8811374465004</ele>
+				<time>2017-11-13T17:59:54Z</time>
+				<extensions>
+					<speed>0.6253308057785034</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012247896097326" lon="-84.2115647857215">
+				<ele>970.125225850381</ele>
+				<time>2017-11-13T17:59:55Z</time>
+				<extensions>
+					<speed>0.5316660404205322</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012246744938105" lon="-84.21157507364032">
+				<ele>970.3542178496718</ele>
+				<time>2017-11-13T17:59:56Z</time>
+				<extensions>
+					<speed>0.5760040879249573</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01224614415003" lon="-84.21159626295926">
+				<ele>970.165327812545</ele>
+				<time>2017-11-13T17:59:57Z</time>
+				<extensions>
+					<speed>0.7195643782615662</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012243765964056" lon="-84.21161970254458">
+				<ele>969.8344889925793</ele>
+				<time>2017-11-13T17:59:58Z</time>
+				<extensions>
+					<speed>0.8575608730316162</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012235430153972" lon="-84.21164161835418">
+				<ele>969.6166678406298</ele>
+				<time>2017-11-13T17:59:59Z</time>
+				<extensions>
+					<speed>0.988660991191864</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012229265038922" lon="-84.211665586778">
+				<ele>969.342351607047</ele>
+				<time>2017-11-13T18:00:00Z</time>
+				<extensions>
+					<speed>1.0989630222320557</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012222455517678" lon="-84.21166436850744">
+				<ele>968.9520882135257</ele>
+				<time>2017-11-13T18:00:01Z</time>
+				<extensions>
+					<speed>0.9729340076446533</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01221134380228" lon="-84.21166166875265">
+				<ele>968.9720267960802</ele>
+				<time>2017-11-13T18:00:02Z</time>
+				<extensions>
+					<speed>0.9424294233322144</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012208017938697" lon="-84.2116714501327">
+				<ele>969.2777574742213</ele>
+				<time>2017-11-13T18:00:03Z</time>
+				<extensions>
+					<speed>0.9916186332702637</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01220726007944" lon="-84.21168554062275">
+				<ele>969.4694119086489</ele>
+				<time>2017-11-13T18:00:04Z</time>
+				<extensions>
+					<speed>1.0518690347671509</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012206649842813" lon="-84.21169460272075">
+				<ele>969.9514500675723</ele>
+				<time>2017-11-13T18:00:05Z</time>
+				<extensions>
+					<speed>1.0974314212799072</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012196072945283" lon="-84.21171547710678">
+				<ele>970.0632325774059</ele>
+				<time>2017-11-13T18:00:06Z</time>
+				<extensions>
+					<speed>1.301007866859436</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012185891061163" lon="-84.21173658275896">
+				<ele>970.3672322919592</ele>
+				<time>2017-11-13T18:00:07Z</time>
+				<extensions>
+					<speed>1.5260727405548096</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012156398430935" lon="-84.21178930359295">
+				<ele>970.5137126892805</ele>
+				<time>2017-11-13T18:00:08Z</time>
+				<extensions>
+					<speed>2.237764358520508</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012132747399086" lon="-84.21187048988088">
+				<ele>969.3330010063946</ele>
+				<time>2017-11-13T18:00:09Z</time>
+				<extensions>
+					<speed>3.154097557067871</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012117722760953" lon="-84.21192019138003">
+				<ele>969.077499371022</ele>
+				<time>2017-11-13T18:00:10Z</time>
+				<extensions>
+					<speed>3.748464584350586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01210479935599" lon="-84.21194049759951">
+				<ele>969.9863256877288</ele>
+				<time>2017-11-13T18:00:11Z</time>
+				<extensions>
+					<speed>3.6928844451904297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012092069290109" lon="-84.21196021509937">
+				<ele>970.8095888793468</ele>
+				<time>2017-11-13T18:00:12Z</time>
+				<extensions>
+					<speed>3.6762425899505615</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012083636194944" lon="-84.21198775431309">
+				<ele>970.9143572458997</ele>
+				<time>2017-11-13T18:00:13Z</time>
+				<extensions>
+					<speed>3.6534063816070557</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012082643233985" lon="-84.21201713192757">
+				<ele>970.9014549925923</ele>
+				<time>2017-11-13T18:00:14Z</time>
+				<extensions>
+					<speed>3.546107292175293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012087496411429" lon="-84.21204772033401">
+				<ele>970.8944318909198</ele>
+				<time>2017-11-13T18:00:15Z</time>
+				<extensions>
+					<speed>3.3882853984832764</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012087360405442" lon="-84.21207746748006">
+				<ele>970.8107497710735</ele>
+				<time>2017-11-13T18:00:16Z</time>
+				<extensions>
+					<speed>3.2694082260131836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01209456801509" lon="-84.21209498981146">
+				<ele>970.7466595722362</ele>
+				<time>2017-11-13T18:00:17Z</time>
+				<extensions>
+					<speed>3.0635018348693848</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012102130964786" lon="-84.2120979665098">
+				<ele>970.8241474097595</ele>
+				<time>2017-11-13T18:00:18Z</time>
+				<extensions>
+					<speed>2.719043493270874</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012108556335619" lon="-84.21209647218436">
+				<ele>970.9185889195651</ele>
+				<time>2017-11-13T18:00:19Z</time>
+				<extensions>
+					<speed>2.3881022930145264</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012109916764537" lon="-84.21209548817934">
+				<ele>970.7664335407317</ele>
+				<time>2017-11-13T18:00:20Z</time>
+				<extensions>
+					<speed>2.14067006111145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012103262073005" lon="-84.21208182991425">
+				<ele>970.5735853444785</ele>
+				<time>2017-11-13T18:00:21Z</time>
+				<extensions>
+					<speed>1.7433698177337646</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012102447487951" lon="-84.2120676268476">
+				<ele>970.2652331655845</ele>
+				<time>2017-11-13T18:00:22Z</time>
+				<extensions>
+					<speed>1.5011088848114014</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012100031790325" lon="-84.21204529725993">
+				<ele>969.9743897747248</ele>
+				<time>2017-11-13T18:00:23Z</time>
+				<extensions>
+					<speed>1.1708168983459473</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012096007807125" lon="-84.21200180797386">
+				<ele>969.7249380974099</ele>
+				<time>2017-11-13T18:00:24Z</time>
+				<extensions>
+					<speed>0.6822286248207092</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012087243210106" lon="-84.21196520084482">
+				<ele>969.5698793930933</ele>
+				<time>2017-11-13T18:00:25Z</time>
+				<extensions>
+					<speed>0.4001246690750122</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01209249400326" lon="-84.21194324085324">
+				<ele>969.5112228067592</ele>
+				<time>2017-11-13T18:00:26Z</time>
+				<extensions>
+					<speed>0.5598949193954468</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012100279513444" lon="-84.21192266616436">
+				<ele>969.4825442126021</ele>
+				<time>2017-11-13T18:00:27Z</time>
+				<extensions>
+					<speed>0.7696388959884644</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012104215035816" lon="-84.21189537309554">
+				<ele>969.4584218151867</ele>
+				<time>2017-11-13T18:00:28Z</time>
+				<extensions>
+					<speed>0.974563717842102</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012105824164303" lon="-84.21185219090293">
+				<ele>969.3995245825499</ele>
+				<time>2017-11-13T18:00:29Z</time>
+				<extensions>
+					<speed>1.3231717348098755</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012107596002574" lon="-84.21181503957477">
+				<ele>969.3954870114103</ele>
+				<time>2017-11-13T18:00:30Z</time>
+				<extensions>
+					<speed>1.5955233573913574</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012096461701262" lon="-84.21179124906224">
+				<ele>969.537978919223</ele>
+				<time>2017-11-13T18:00:31Z</time>
+				<extensions>
+					<speed>1.6160926818847656</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012104706401345" lon="-84.21175330684706">
+				<ele>969.3360165320337</ele>
+				<time>2017-11-13T18:00:32Z</time>
+				<extensions>
+					<speed>1.8759526014328003</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012105263352927" lon="-84.21172866541548">
+				<ele>969.30138229765</ele>
+				<time>2017-11-13T18:00:33Z</time>
+				<extensions>
+					<speed>1.9445593357086182</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012097945557315" lon="-84.21172632922475">
+				<ele>969.2789169335738</ele>
+				<time>2017-11-13T18:00:34Z</time>
+				<extensions>
+					<speed>1.6941156387329102</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01209123751531" lon="-84.21171244443454">
+				<ele>969.2791013913229</ele>
+				<time>2017-11-13T18:00:35Z</time>
+				<extensions>
+					<speed>1.683410406112671</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012097184787454" lon="-84.21169220811244">
+				<ele>969.1925992472097</ele>
+				<time>2017-11-13T18:00:36Z</time>
+				<extensions>
+					<speed>1.7907565832138062</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01210577587704" lon="-84.21165752574571">
+				<ele>969.0517021631822</ele>
+				<time>2017-11-13T18:00:37Z</time>
+				<extensions>
+					<speed>2.022672653198242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012110207096931" lon="-84.21163315606945">
+				<ele>968.9804625129327</ele>
+				<time>2017-11-13T18:00:38Z</time>
+				<extensions>
+					<speed>2.134577512741089</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012107038933856" lon="-84.21162730120243">
+				<ele>968.9834886193275</ele>
+				<time>2017-11-13T18:00:39Z</time>
+				<extensions>
+					<speed>2.0484426021575928</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012134698396713" lon="-84.2116113829927">
+				<ele>968.8052519923076</ele>
+				<time>2017-11-13T18:00:40Z</time>
+				<extensions>
+					<speed>2.096712112426758</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01215941177559" lon="-84.21159446696997">
+				<ele>968.6259513283148</ele>
+				<time>2017-11-13T18:00:41Z</time>
+				<extensions>
+					<speed>2.138451099395752</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012187643892142" lon="-84.21158405706387">
+				<ele>968.3785432046279</ele>
+				<time>2017-11-13T18:00:42Z</time>
+				<extensions>
+					<speed>2.0484161376953125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012217248244715" lon="-84.21158619943728">
+				<ele>968.1131458505988</ele>
+				<time>2017-11-13T18:00:43Z</time>
+				<extensions>
+					<speed>1.8864694833755493</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012236816793148" lon="-84.21157994841688">
+				<ele>967.9011163441464</ele>
+				<time>2017-11-13T18:00:44Z</time>
+				<extensions>
+					<speed>1.7456578016281128</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012248190812935" lon="-84.21157696085004">
+				<ele>967.567806663923</ele>
+				<time>2017-11-13T18:00:45Z</time>
+				<extensions>
+					<speed>1.4989442825317383</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01225078525225" lon="-84.21158985563758">
+				<ele>967.1040008729324</ele>
+				<time>2017-11-13T18:00:46Z</time>
+				<extensions>
+					<speed>1.1139538288116455</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012260737108512" lon="-84.21160103523893">
+				<ele>966.857523678802</ele>
+				<time>2017-11-13T18:00:47Z</time>
+				<extensions>
+					<speed>0.799774706363678</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012258168274311" lon="-84.21163475389534">
+				<ele>966.5867425603792</ele>
+				<time>2017-11-13T18:00:48Z</time>
+				<extensions>
+					<speed>0.4072197675704956</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012253107882369" lon="-84.21166220960276">
+				<ele>966.0899308780208</ele>
+				<time>2017-11-13T18:00:49Z</time>
+				<extensions>
+					<speed>0.27604740858078003</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012249635122455" lon="-84.21167801822926">
+				<ele>965.7893774211407</ele>
+				<time>2017-11-13T18:00:50Z</time>
+				<extensions>
+					<speed>0.32652270793914795</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012239018225076" lon="-84.21170121434112">
+				<ele>965.6254504350945</ele>
+				<time>2017-11-13T18:00:51Z</time>
+				<extensions>
+					<speed>0.45056959986686707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012231033534372" lon="-84.21171401527778">
+				<ele>965.6212763795629</ele>
+				<time>2017-11-13T18:00:52Z</time>
+				<extensions>
+					<speed>0.5096750855445862</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012224135867516" lon="-84.21171932894835">
+				<ele>965.5949245523661</ele>
+				<time>2017-11-13T18:00:53Z</time>
+				<extensions>
+					<speed>0.5093030333518982</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012206877578532" lon="-84.21173123631625">
+				<ele>965.2813651664183</ele>
+				<time>2017-11-13T18:00:54Z</time>
+				<extensions>
+					<speed>0.5372704863548279</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012199021705076" lon="-84.21173681158417">
+				<ele>965.3051976347342</ele>
+				<time>2017-11-13T18:00:55Z</time>
+				<extensions>
+					<speed>0.48607268929481506</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012184799343085" lon="-84.2117419936514">
+				<ele>964.9124648608267</ele>
+				<time>2017-11-13T18:00:56Z</time>
+				<extensions>
+					<speed>0.4504198729991913</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012168287187102" lon="-84.21173594980006">
+				<ele>964.6862052362412</ele>
+				<time>2017-11-13T18:00:57Z</time>
+				<extensions>
+					<speed>0.41296038031578064</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012151992532711" lon="-84.2117292234815">
+				<ele>964.6427371883765</ele>
+				<time>2017-11-13T18:00:58Z</time>
+				<extensions>
+					<speed>0.3938286602497101</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012142499544298" lon="-84.211723754432">
+				<ele>964.6604270311072</ele>
+				<time>2017-11-13T18:00:59Z</time>
+				<extensions>
+					<speed>0.3756667971611023</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012127907532744" lon="-84.21173538379877">
+				<ele>964.2701797476038</ele>
+				<time>2017-11-13T18:01:00Z</time>
+				<extensions>
+					<speed>0.3875826895236969</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012122532591352" lon="-84.21173862982397">
+				<ele>964.213769197464</ele>
+				<time>2017-11-13T18:01:01Z</time>
+				<extensions>
+					<speed>0.3421667516231537</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012114175914267" lon="-84.21174276366725">
+				<ele>964.1501512257382</ele>
+				<time>2017-11-13T18:01:02Z</time>
+				<extensions>
+					<speed>0.33451494574546814</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012109864550892" lon="-84.2117479421008">
+				<ele>964.209793433547</ele>
+				<time>2017-11-13T18:01:03Z</time>
+				<extensions>
+					<speed>0.2764689326286316</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012103390567873" lon="-84.21177053348694">
+				<ele>963.9678863575682</ele>
+				<time>2017-11-13T18:01:04Z</time>
+				<extensions>
+					<speed>0.26206308603286743</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01209303889839" lon="-84.21177949948675">
+				<ele>963.3345741257071</ele>
+				<time>2017-11-13T18:01:05Z</time>
+				<extensions>
+					<speed>0.30328601598739624</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012082613609246" lon="-84.21179974923592">
+				<ele>962.4785627732053</ele>
+				<time>2017-11-13T18:01:06Z</time>
+				<extensions>
+					<speed>0.39036181569099426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012068970689443" lon="-84.21180934773803">
+				<ele>961.960793399252</ele>
+				<time>2017-11-13T18:01:07Z</time>
+				<extensions>
+					<speed>0.4727496802806854</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012060575748695" lon="-84.21181537611075">
+				<ele>961.7077661175281</ele>
+				<time>2017-11-13T18:01:08Z</time>
+				<extensions>
+					<speed>0.5022234916687012</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012053804971877" lon="-84.21182050892529">
+				<ele>961.4927992569283</ele>
+				<time>2017-11-13T18:01:09Z</time>
+				<extensions>
+					<speed>0.4925166666507721</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012048026802832" lon="-84.21182479977509">
+				<ele>961.3140370314941</ele>
+				<time>2017-11-13T18:01:10Z</time>
+				<extensions>
+					<speed>0.4675444960594177</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012042828225441" lon="-84.21182718010546">
+				<ele>961.1544179748744</ele>
+				<time>2017-11-13T18:01:11Z</time>
+				<extensions>
+					<speed>0.438038170337677</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012039509336674" lon="-84.21183108423772">
+				<ele>961.0770222032443</ele>
+				<time>2017-11-13T18:01:12Z</time>
+				<extensions>
+					<speed>0.44085296988487244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012033155091178" lon="-84.21183174181591">
+				<ele>961.0469171479344</ele>
+				<time>2017-11-13T18:01:13Z</time>
+				<extensions>
+					<speed>0.4545927941799164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012034780200361" lon="-84.2118402659669">
+				<ele>960.994216109626</ele>
+				<time>2017-11-13T18:01:14Z</time>
+				<extensions>
+					<speed>0.4387500584125519</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012034218821382" lon="-84.21184193281894">
+				<ele>961.0284184105694</ele>
+				<time>2017-11-13T18:01:15Z</time>
+				<extensions>
+					<speed>0.42540431022644043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012035107500065" lon="-84.21183711890589">
+				<ele>960.9691451424733</ele>
+				<time>2017-11-13T18:01:16Z</time>
+				<extensions>
+					<speed>0.21479324996471405</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012043130362109" lon="-84.21182550126042">
+				<ele>961.0851174145937</ele>
+				<time>2017-11-13T18:01:17Z</time>
+				<extensions>
+					<speed>0.1320948302745819</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012045358755902" lon="-84.21181521817066">
+				<ele>961.1343412715942</ele>
+				<time>2017-11-13T18:01:18Z</time>
+				<extensions>
+					<speed>0.07379656285047531</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012045358755902" lon="-84.21181521817066">
+				<ele>961.1757009262219</ele>
+				<time>2017-11-13T18:01:19Z</time>
+				<extensions>
+					<speed>0.09924398362636566</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012045358755902" lon="-84.21181521817066">
+				<ele>961.4134276127443</ele>
+				<time>2017-11-13T18:01:20Z</time>
+				<extensions>
+					<speed>0.15290391445159912</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012045358755902" lon="-84.21181521817066">
+				<ele>961.7276588929817</ele>
+				<time>2017-11-13T18:01:21Z</time>
+				<extensions>
+					<speed>0.1919267177581787</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0120614204466" lon="-84.21176450289461">
+				<ele>962.4790839254856</ele>
+				<time>2017-11-13T18:01:22Z</time>
+				<extensions>
+					<speed>0.1885407418012619</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012067069903253" lon="-84.21176221475169">
+				<ele>963.3045803830028</ele>
+				<time>2017-11-13T18:01:23Z</time>
+				<extensions>
+					<speed>0.17487871646881104</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012074567780557" lon="-84.21176342649555">
+				<ele>964.1159986937419</ele>
+				<time>2017-11-13T18:01:24Z</time>
+				<extensions>
+					<speed>0.13074783980846405</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012083795977157" lon="-84.21177000889729">
+				<ele>965.0129598388448</ele>
+				<time>2017-11-13T18:01:25Z</time>
+				<extensions>
+					<speed>0.17011088132858276</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012103522020977" lon="-84.21177410138532">
+				<ele>966.4573014536873</ele>
+				<time>2017-11-13T18:01:26Z</time>
+				<extensions>
+					<speed>0.2648735046386719</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012124709541368" lon="-84.21178195777829">
+				<ele>967.8024668823928</ele>
+				<time>2017-11-13T18:01:27Z</time>
+				<extensions>
+					<speed>0.3652161657810211</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012136689453655" lon="-84.21179963250746">
+				<ele>968.4643032932654</ele>
+				<time>2017-11-13T18:01:28Z</time>
+				<extensions>
+					<speed>0.4436612129211426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012146869941255" lon="-84.21181354589478">
+				<ele>969.132335267961</ele>
+				<time>2017-11-13T18:01:29Z</time>
+				<extensions>
+					<speed>0.5003352165222168</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012153366366105" lon="-84.21183701842358">
+				<ele>969.5265238024294</ele>
+				<time>2017-11-13T18:01:30Z</time>
+				<extensions>
+					<speed>0.5708702206611633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012157673730377" lon="-84.21185461838881">
+				<ele>969.0244142757729</ele>
+				<time>2017-11-13T18:01:31Z</time>
+				<extensions>
+					<speed>0.6382237076759338</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012145194585463" lon="-84.2118879658189">
+				<ele>968.7131786998361</ele>
+				<time>2017-11-13T18:01:32Z</time>
+				<extensions>
+					<speed>0.8158524632453918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01213455404032" lon="-84.21190540648527">
+				<ele>968.7291595153511</ele>
+				<time>2017-11-13T18:01:33Z</time>
+				<extensions>
+					<speed>0.9485382437705994</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012116639944907" lon="-84.21191704118725">
+				<ele>968.6556714447215</ele>
+				<time>2017-11-13T18:01:34Z</time>
+				<extensions>
+					<speed>1.019092321395874</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012100638942824" lon="-84.21193025094234">
+				<ele>968.3810196658596</ele>
+				<time>2017-11-13T18:01:35Z</time>
+				<extensions>
+					<speed>1.072119951248169</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012081666367658" lon="-84.21195750964287">
+				<ele>968.1947571663186</ele>
+				<time>2017-11-13T18:01:36Z</time>
+				<extensions>
+					<speed>1.2311804294586182</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01207572786264" lon="-84.21198307735808">
+				<ele>968.4299268778414</ele>
+				<time>2017-11-13T18:01:37Z</time>
+				<extensions>
+					<speed>1.4164583683013916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012071998029093" lon="-84.21202061888475">
+				<ele>968.2267388477921</ele>
+				<time>2017-11-13T18:01:38Z</time>
+				<extensions>
+					<speed>1.6111427545547485</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012044312728673" lon="-84.21207218569553">
+				<ele>965.5905759511515</ele>
+				<time>2017-11-13T18:01:39Z</time>
+				<extensions>
+					<speed>1.834424614906311</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012028258662689" lon="-84.21209293801668">
+				<ele>966.2271431293339</ele>
+				<time>2017-11-13T18:01:40Z</time>
+				<extensions>
+					<speed>1.9390380382537842</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012021296921969" lon="-84.21213610583403">
+				<ele>968.1008110707626</ele>
+				<time>2017-11-13T18:01:41Z</time>
+				<extensions>
+					<speed>1.9093873500823975</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011959665826259" lon="-84.21219797332434">
+				<ele>953.9865339854732</ele>
+				<time>2017-11-13T18:01:42Z</time>
+				<extensions>
+					<speed>2.198273181915283</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011973888513104" lon="-84.2122426336814">
+				<ele>955.4810463171452</ele>
+				<time>2017-11-13T18:01:43Z</time>
+				<extensions>
+					<speed>2.639346122741699</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01197804118387" lon="-84.21226100512587">
+				<ele>957.6177882077172</ele>
+				<time>2017-11-13T18:01:44Z</time>
+				<extensions>
+					<speed>2.3477747440338135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011980608529523" lon="-84.21228263146173">
+				<ele>960.0295395208523</ele>
+				<time>2017-11-13T18:01:45Z</time>
+				<extensions>
+					<speed>2.181389331817627</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011979995846694" lon="-84.21230245839195">
+				<ele>962.534697894007</ele>
+				<time>2017-11-13T18:01:46Z</time>
+				<extensions>
+					<speed>2.042274236679077</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0119784061724" lon="-84.21231972647597">
+				<ele>963.6176925776526</ele>
+				<time>2017-11-13T18:01:47Z</time>
+				<extensions>
+					<speed>2.0492727756500244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011973710473658" lon="-84.21234893263701">
+				<ele>965.1801372328773</ele>
+				<time>2017-11-13T18:01:48Z</time>
+				<extensions>
+					<speed>2.1789638996124268</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011971012519966" lon="-84.21235936755174">
+				<ele>966.0208756672218</ele>
+				<time>2017-11-13T18:01:49Z</time>
+				<extensions>
+					<speed>2.065221071243286</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011972817089717" lon="-84.21236734996381">
+				<ele>966.2808149727061</ele>
+				<time>2017-11-13T18:01:50Z</time>
+				<extensions>
+					<speed>1.9157259464263916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011978285386675" lon="-84.2123703191985">
+				<ele>966.7920711962506</ele>
+				<time>2017-11-13T18:01:51Z</time>
+				<extensions>
+					<speed>1.7137315273284912</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011981938752065" lon="-84.21237146402859">
+				<ele>967.4935947787017</ele>
+				<time>2017-11-13T18:01:52Z</time>
+				<extensions>
+					<speed>1.6113173961639404</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011984810944156" lon="-84.21237898527889">
+				<ele>968.1144101973623</ele>
+				<time>2017-11-13T18:01:53Z</time>
+				<extensions>
+					<speed>1.5230191946029663</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011986409043624" lon="-84.21239066605983">
+				<ele>968.1747596124187</ele>
+				<time>2017-11-13T18:01:54Z</time>
+				<extensions>
+					<speed>1.4612103700637817</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011990107245337" lon="-84.21240233007633">
+				<ele>967.6028971327469</ele>
+				<time>2017-11-13T18:01:55Z</time>
+				<extensions>
+					<speed>1.3845449686050415</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011994616996251" lon="-84.21241838101736">
+				<ele>966.4071903992444</ele>
+				<time>2017-11-13T18:01:56Z</time>
+				<extensions>
+					<speed>1.3575515747070313</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01199725604387" lon="-84.21243228283113">
+				<ele>965.9849501708522</ele>
+				<time>2017-11-13T18:01:57Z</time>
+				<extensions>
+					<speed>1.3260151147842407</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012002794336604" lon="-84.21244591724827">
+				<ele>964.9290682021528</ele>
+				<time>2017-11-13T18:01:58Z</time>
+				<extensions>
+					<speed>1.2011243104934692</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012008621499191" lon="-84.21244474335224">
+				<ele>963.8451067972928</ele>
+				<time>2017-11-13T18:01:59Z</time>
+				<extensions>
+					<speed>1.0396473407745361</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012010088750278" lon="-84.21242180099249">
+				<ele>962.7403728952631</ele>
+				<time>2017-11-13T18:02:00Z</time>
+				<extensions>
+					<speed>0.6126527786254883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012009533309056" lon="-84.21240532057801">
+				<ele>962.2369793895632</ele>
+				<time>2017-11-13T18:02:01Z</time>
+				<extensions>
+					<speed>0.3843080997467041</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012009166105143" lon="-84.21237560291685">
+				<ele>961.3294006260112</ele>
+				<time>2017-11-13T18:02:02Z</time>
+				<extensions>
+					<speed>0.11276194453239441</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012009166105143" lon="-84.21237560291685">
+				<ele>961.3294006260112</ele>
+				<time>2017-11-13T18:02:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012009166105143" lon="-84.21237560291685">
+				<ele>961.3294006260112</ele>
+				<time>2017-11-13T18:02:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012007012408366" lon="-84.21234598157973">
+				<ele>960.7244770377874</ele>
+				<time>2017-11-13T18:02:05Z</time>
+				<extensions>
+					<speed>0.6026051640510559</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012005347833274" lon="-84.21231408133679">
+				<ele>960.1247232314199</ele>
+				<time>2017-11-13T18:02:06Z</time>
+				<extensions>
+					<speed>0.771220862865448</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012009587130338" lon="-84.21227120958599">
+				<ele>959.2749486891553</ele>
+				<time>2017-11-13T18:02:07Z</time>
+				<extensions>
+					<speed>0.9978673458099365</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0120153046346" lon="-84.2122246073305">
+				<ele>958.0797908119857</ele>
+				<time>2017-11-13T18:02:08Z</time>
+				<extensions>
+					<speed>1.409527063369751</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012028812595094" lon="-84.21219331152585">
+				<ele>956.8607459943742</ele>
+				<time>2017-11-13T18:02:09Z</time>
+				<extensions>
+					<speed>1.468803882598877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012035088663175" lon="-84.21217361850776">
+				<ele>955.9555246448144</ele>
+				<time>2017-11-13T18:02:10Z</time>
+				<extensions>
+					<speed>1.4223904609680176</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01204114273922" lon="-84.21216050049401">
+				<ele>954.670395986177</ele>
+				<time>2017-11-13T18:02:11Z</time>
+				<extensions>
+					<speed>1.3229179382324219</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012046606777655" lon="-84.21215107127064">
+				<ele>953.6908167591318</ele>
+				<time>2017-11-13T18:02:12Z</time>
+				<extensions>
+					<speed>1.2422881126403809</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012051228900408" lon="-84.21215436119628">
+				<ele>953.1282513607293</ele>
+				<time>2017-11-13T18:02:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012052790418707" lon="-84.21216337764614">
+				<ele>952.279700377956</ele>
+				<time>2017-11-13T18:02:14Z</time>
+				<extensions>
+					<speed>0.009507314302027225</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012052790418707" lon="-84.21216337764614">
+				<ele>952.279700377956</ele>
+				<time>2017-11-13T18:02:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012052790418707" lon="-84.21216337764614">
+				<ele>952.279700377956</ele>
+				<time>2017-11-13T18:02:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012052790418707" lon="-84.21216337764614">
+				<ele>952.279700377956</ele>
+				<time>2017-11-13T18:02:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012052790418707" lon="-84.21216337764614">
+				<ele>952.279700377956</ele>
+				<time>2017-11-13T18:02:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012052790418707" lon="-84.21216337764614">
+				<ele>952.279700377956</ele>
+				<time>2017-11-13T18:02:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012052790418707" lon="-84.21216337764614">
+				<ele>952.279700377956</ele>
+				<time>2017-11-13T18:02:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012052790418707" lon="-84.21216337764614">
+				<ele>952.279700377956</ele>
+				<time>2017-11-13T18:02:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012052790418707" lon="-84.21216337764614">
+				<ele>952.279700377956</ele>
+				<time>2017-11-13T18:02:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012052790418707" lon="-84.21216337764614">
+				<ele>952.279700377956</ele>
+				<time>2017-11-13T18:02:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012048134884802" lon="-84.21220359588685">
+				<ele>952.0467384541407</ele>
+				<time>2017-11-13T18:02:24Z</time>
+				<extensions>
+					<speed>0.7990471124649048</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012042922953112" lon="-84.21224031253108">
+				<ele>952.0030511543155</ele>
+				<time>2017-11-13T18:02:25Z</time>
+				<extensions>
+					<speed>0.9938822388648987</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012032040641303" lon="-84.21224864197117">
+				<ele>952.0562633685768</ele>
+				<time>2017-11-13T18:02:26Z</time>
+				<extensions>
+					<speed>0.6805286407470703</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01202418527508" lon="-84.21226384196355">
+				<ele>952.0161788845435</ele>
+				<time>2017-11-13T18:02:27Z</time>
+				<extensions>
+					<speed>0.6231409907341003</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012021536986259" lon="-84.21229260752868">
+				<ele>952.6431525293738</ele>
+				<time>2017-11-13T18:02:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012020099256969" lon="-84.21233071378217">
+				<ele>953.7395013244823</ele>
+				<time>2017-11-13T18:02:29Z</time>
+				<extensions>
+					<speed>0.4386404752731323</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012013470641598" lon="-84.21236641579569">
+				<ele>954.4617399917915</ele>
+				<time>2017-11-13T18:02:30Z</time>
+				<extensions>
+					<speed>0.7581692337989807</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012009773338521" lon="-84.21238421510395">
+				<ele>954.9775241613388</ele>
+				<time>2017-11-13T18:02:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011994376326212" lon="-84.21240324567844">
+				<ele>954.9917606944218</ele>
+				<time>2017-11-13T18:02:32Z</time>
+				<extensions>
+					<speed>0.3551938235759735</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01198323116704" lon="-84.21242035279843">
+				<ele>955.0631437813863</ele>
+				<time>2017-11-13T18:02:33Z</time>
+				<extensions>
+					<speed>0.5246982574462891</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011975824784429" lon="-84.21243620658355">
+				<ele>955.078618391417</ele>
+				<time>2017-11-13T18:02:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011975824784429" lon="-84.21243620658355">
+				<ele>955.078618391417</ele>
+				<time>2017-11-13T18:02:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011975824784429" lon="-84.21243620658355">
+				<ele>955.078618391417</ele>
+				<time>2017-11-13T18:02:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011975824784429" lon="-84.21243620658355">
+				<ele>955.078618391417</ele>
+				<time>2017-11-13T18:02:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011975824784429" lon="-84.21243620658355">
+				<ele>955.078618391417</ele>
+				<time>2017-11-13T18:02:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01196334110596" lon="-84.2124528857773">
+				<ele>955.4731706073508</ele>
+				<time>2017-11-13T18:02:39Z</time>
+				<extensions>
+					<speed>0.8280764222145081</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011957245170388" lon="-84.21245921996054">
+				<ele>955.5076967645437</ele>
+				<time>2017-11-13T18:02:40Z</time>
+				<extensions>
+					<speed>0.8692401647567749</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011955010667762" lon="-84.21246267136574">
+				<ele>955.6183744454756</ele>
+				<time>2017-11-13T18:02:41Z</time>
+				<extensions>
+					<speed>0.7958206534385681</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011957012940965" lon="-84.21246227142181">
+				<ele>955.7563029434532</ele>
+				<time>2017-11-13T18:02:42Z</time>
+				<extensions>
+					<speed>0.7585842609405518</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011955536393714" lon="-84.21247345900976">
+				<ele>956.0597377372906</ele>
+				<time>2017-11-13T18:02:43Z</time>
+				<extensions>
+					<speed>0.8728759288787842</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011950095462376" lon="-84.21248722666856">
+				<ele>956.7226065443829</ele>
+				<time>2017-11-13T18:02:44Z</time>
+				<extensions>
+					<speed>1.0006823539733887</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011949116939917" lon="-84.21250480678673">
+				<ele>956.9429415399209</ele>
+				<time>2017-11-13T18:02:45Z</time>
+				<extensions>
+					<speed>1.1496644020080566</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011944898282664" lon="-84.2125190429155">
+				<ele>957.2762516802177</ele>
+				<time>2017-11-13T18:02:46Z</time>
+				<extensions>
+					<speed>1.350454330444336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01193538234087" lon="-84.21253549407103">
+				<ele>957.7749643744901</ele>
+				<time>2017-11-13T18:02:47Z</time>
+				<extensions>
+					<speed>1.5645840167999268</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01192126649048" lon="-84.21256470198169">
+				<ele>957.993526446633</ele>
+				<time>2017-11-13T18:02:48Z</time>
+				<extensions>
+					<speed>2.064809799194336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011909261097598" lon="-84.2125944487467">
+				<ele>958.2749798316509</ele>
+				<time>2017-11-13T18:02:49Z</time>
+				<extensions>
+					<speed>2.346797227859497</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011897003160081" lon="-84.21262183957839">
+				<ele>958.6624858127907</ele>
+				<time>2017-11-13T18:02:50Z</time>
+				<extensions>
+					<speed>2.5144922733306885</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011887931129227" lon="-84.21264617481799">
+				<ele>958.9022505050525</ele>
+				<time>2017-11-13T18:02:51Z</time>
+				<extensions>
+					<speed>2.5120415687561035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011885068951289" lon="-84.21268098146703">
+				<ele>959.110648965463</ele>
+				<time>2017-11-13T18:02:52Z</time>
+				<extensions>
+					<speed>2.583519697189331</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01188263659864" lon="-84.21271000471809">
+				<ele>959.4328142721206</ele>
+				<time>2017-11-13T18:02:53Z</time>
+				<extensions>
+					<speed>2.6474435329437256</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011877696460338" lon="-84.21273581043404">
+				<ele>959.6243194416165</ele>
+				<time>2017-11-13T18:02:54Z</time>
+				<extensions>
+					<speed>2.61848521232605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011879761986823" lon="-84.21276002012819">
+				<ele>959.8787540262565</ele>
+				<time>2017-11-13T18:02:55Z</time>
+				<extensions>
+					<speed>2.6101510524749756</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011887911968925" lon="-84.21278303772638">
+				<ele>960.2272192016244</ele>
+				<time>2017-11-13T18:02:56Z</time>
+				<extensions>
+					<speed>2.6552371978759766</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011890401955778" lon="-84.21280297536407">
+				<ele>960.7026778543368</ele>
+				<time>2017-11-13T18:02:57Z</time>
+				<extensions>
+					<speed>2.649038553237915</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011887328166829" lon="-84.21281001497478">
+				<ele>960.9696641517803</ele>
+				<time>2017-11-13T18:02:58Z</time>
+				<extensions>
+					<speed>2.397181272506714</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011885265299492" lon="-84.21283426158561">
+				<ele>961.3403743552044</ele>
+				<time>2017-11-13T18:02:59Z</time>
+				<extensions>
+					<speed>2.407602071762085</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01188051009201" lon="-84.21284095128279">
+				<ele>961.950798984617</ele>
+				<time>2017-11-13T18:03:00Z</time>
+				<extensions>
+					<speed>2.1867148876190186</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01188665609317" lon="-84.21282983136214">
+				<ele>962.0142787117511</ele>
+				<time>2017-11-13T18:03:01Z</time>
+				<extensions>
+					<speed>1.7519962787628174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011897120885427" lon="-84.21282150782598">
+				<ele>962.0835564732552</ele>
+				<time>2017-11-13T18:03:02Z</time>
+				<extensions>
+					<speed>1.4714467525482178</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011906713894746" lon="-84.21281454449388">
+				<ele>962.1582546979189</ele>
+				<time>2017-11-13T18:03:03Z</time>
+				<extensions>
+					<speed>1.205532193183899</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011921938711223" lon="-84.21280379673374">
+				<ele>962.5495640998706</ele>
+				<time>2017-11-13T18:03:04Z</time>
+				<extensions>
+					<speed>0.9804428219795227</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011946906335274" lon="-84.21278816402227">
+				<ele>963.3395489612594</ele>
+				<time>2017-11-13T18:03:05Z</time>
+				<extensions>
+					<speed>0.8604527115821838</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011969606671148" lon="-84.21277037921644">
+				<ele>964.0473953047767</ele>
+				<time>2017-11-13T18:03:06Z</time>
+				<extensions>
+					<speed>0.8146247267723083</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01198895258533" lon="-84.21274923025715">
+				<ele>964.4243905423209</ele>
+				<time>2017-11-13T18:03:07Z</time>
+				<extensions>
+					<speed>0.7803135514259338</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012003270167575" lon="-84.21271419551965">
+				<ele>964.538663694635</ele>
+				<time>2017-11-13T18:03:08Z</time>
+				<extensions>
+					<speed>0.6944790482521057</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012008197714199" lon="-84.21267372017853">
+				<ele>964.6509810332209</ele>
+				<time>2017-11-13T18:03:09Z</time>
+				<extensions>
+					<speed>0.7261962890625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012026433339368" lon="-84.21262618125417">
+				<ele>965.3086190382019</ele>
+				<time>2017-11-13T18:03:10Z</time>
+				<extensions>
+					<speed>1.0434435606002808</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012029867008902" lon="-84.21258666558985">
+				<ele>965.4294698499143</ele>
+				<time>2017-11-13T18:03:11Z</time>
+				<extensions>
+					<speed>1.2644177675247192</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012047126720745" lon="-84.21255809213861">
+				<ele>966.2229947363958</ele>
+				<time>2017-11-13T18:03:12Z</time>
+				<extensions>
+					<speed>1.4574071168899536</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01205569498142" lon="-84.21252657735553">
+				<ele>966.963901440613</ele>
+				<time>2017-11-13T18:03:13Z</time>
+				<extensions>
+					<speed>1.5949914455413818</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012049798310736" lon="-84.2125244763652">
+				<ele>966.8738965308294</ele>
+				<time>2017-11-13T18:03:14Z</time>
+				<extensions>
+					<speed>1.4642701148986816</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012043728203793" lon="-84.21253947242832">
+				<ele>966.7183773024008</ele>
+				<time>2017-11-13T18:03:15Z</time>
+				<extensions>
+					<speed>1.1147990226745605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01203466897316" lon="-84.21253854203906">
+				<ele>967.050257043913</ele>
+				<time>2017-11-13T18:03:16Z</time>
+				<extensions>
+					<speed>0.9432376623153687</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012037130251088" lon="-84.212490634543">
+				<ele>967.9937679814175</ele>
+				<time>2017-11-13T18:03:17Z</time>
+				<extensions>
+					<speed>1.309312343597412</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012020063412356" lon="-84.21252203788995">
+				<ele>968.2583831986412</ele>
+				<time>2017-11-13T18:03:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012000722303112" lon="-84.2125469056851">
+				<ele>968.1413260810077</ele>
+				<time>2017-11-13T18:03:19Z</time>
+				<extensions>
+					<speed>0.3819517493247986</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011979022225509" lon="-84.21256715797514">
+				<ele>967.986499691382</ele>
+				<time>2017-11-13T18:03:20Z</time>
+				<extensions>
+					<speed>0.5343480706214905</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011959250127529" lon="-84.21257909694">
+				<ele>967.8291570749134</ele>
+				<time>2017-11-13T18:03:21Z</time>
+				<extensions>
+					<speed>0.6009829640388489</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01194351579739" lon="-84.21257996591669">
+				<ele>967.7198975402862</ele>
+				<time>2017-11-13T18:03:22Z</time>
+				<extensions>
+					<speed>0.6339136362075806</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011927652524392" lon="-84.21258702553205">
+				<ele>967.691414302215</ele>
+				<time>2017-11-13T18:03:23Z</time>
+				<extensions>
+					<speed>0.7122848629951477</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011920060044712" lon="-84.21258535680253">
+				<ele>968.0983549067751</ele>
+				<time>2017-11-13T18:03:24Z</time>
+				<extensions>
+					<speed>0.6983991265296936</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011916492100637" lon="-84.21258850580068">
+				<ele>968.2811077898368</ele>
+				<time>2017-11-13T18:03:25Z</time>
+				<extensions>
+					<speed>0.640603244304657</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0119126057277" lon="-84.21260147976297">
+				<ele>968.1066835196689</ele>
+				<time>2017-11-13T18:03:26Z</time>
+				<extensions>
+					<speed>0.6118335723876953</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011922979542277" lon="-84.21260448509423">
+				<ele>967.8491827994585</ele>
+				<time>2017-11-13T18:03:27Z</time>
+				<extensions>
+					<speed>0.38147836923599243</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01193167323558" lon="-84.21260826177705">
+				<ele>967.4901249464601</ele>
+				<time>2017-11-13T18:03:28Z</time>
+				<extensions>
+					<speed>0.21251413226127625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011939167282028" lon="-84.21260702612902">
+				<ele>966.97122459393</ele>
+				<time>2017-11-13T18:03:29Z</time>
+				<extensions>
+					<speed>0.10619333386421204</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011934160778253" lon="-84.21261747991939">
+				<ele>966.6126747038215</ele>
+				<time>2017-11-13T18:03:30Z</time>
+				<extensions>
+					<speed>0.13873319327831268</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011939792200355" lon="-84.21261997345121">
+				<ele>966.131309138611</ele>
+				<time>2017-11-13T18:03:31Z</time>
+				<extensions>
+					<speed>0.09094570577144623</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011947539534392" lon="-84.21262086957671">
+				<ele>965.7097154008225</ele>
+				<time>2017-11-13T18:03:32Z</time>
+				<extensions>
+					<speed>0.05134044587612152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011947539534392" lon="-84.21262086957671">
+				<ele>965.2106311284006</ele>
+				<time>2017-11-13T18:03:33Z</time>
+				<extensions>
+					<speed>0.24986615777015686</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011947539534392" lon="-84.21262086957671">
+				<ele>964.7186789102852</ele>
+				<time>2017-11-13T18:03:34Z</time>
+				<extensions>
+					<speed>0.3938533067703247</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011947539534392" lon="-84.21262086957671">
+				<ele>964.4075012123212</ele>
+				<time>2017-11-13T18:03:35Z</time>
+				<extensions>
+					<speed>0.5423621535301208</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011873424763232" lon="-84.21263684033991">
+				<ele>964.2546693971381</ele>
+				<time>2017-11-13T18:03:36Z</time>
+				<extensions>
+					<speed>0.6431453227996826</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011867534712676" lon="-84.21263647219008">
+				<ele>964.0053132418543</ele>
+				<time>2017-11-13T18:03:37Z</time>
+				<extensions>
+					<speed>0.6056734919548035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011867248644652" lon="-84.21263844716604">
+				<ele>963.8817979954183</ele>
+				<time>2017-11-13T18:03:38Z</time>
+				<extensions>
+					<speed>0.535990297794342</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011864694010674" lon="-84.2126442005812">
+				<ele>963.7159178927541</ele>
+				<time>2017-11-13T18:03:39Z</time>
+				<extensions>
+					<speed>0.5568833351135254</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011865376995576" lon="-84.21264661633906">
+				<ele>963.4873875668272</ele>
+				<time>2017-11-13T18:03:40Z</time>
+				<extensions>
+					<speed>0.5264878273010254</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011868756447708" lon="-84.2126441800109">
+				<ele>963.3204128583893</ele>
+				<time>2017-11-13T18:03:41Z</time>
+				<extensions>
+					<speed>0.2989412844181061</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011878897424962" lon="-84.21263167030226">
+				<ele>963.159387126565</ele>
+				<time>2017-11-13T18:03:42Z</time>
+				<extensions>
+					<speed>0.21506813168525696</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011881199121891" lon="-84.21262516766005">
+				<ele>962.9232763079926</ele>
+				<time>2017-11-13T18:03:43Z</time>
+				<extensions>
+					<speed>0.2378210723400116</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011880261580684" lon="-84.21261296866003">
+				<ele>962.7381142731756</ele>
+				<time>2017-11-13T18:03:44Z</time>
+				<extensions>
+					<speed>0.3512062132358551</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01187877618231" lon="-84.21260876080893">
+				<ele>962.6245758179575</ele>
+				<time>2017-11-13T18:03:45Z</time>
+				<extensions>
+					<speed>0.36078983545303345</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011879151863143" lon="-84.21262574516822">
+				<ele>962.4594399025664</ele>
+				<time>2017-11-13T18:03:46Z</time>
+				<extensions>
+					<speed>0.05048101022839546</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011879151863143" lon="-84.21262574516822">
+				<ele>962.4356382098049</ele>
+				<time>2017-11-13T18:03:47Z</time>
+				<extensions>
+					<speed>0.2721928358078003</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011879151863143" lon="-84.21262574516822">
+				<ele>962.5196121437475</ele>
+				<time>2017-11-13T18:03:48Z</time>
+				<extensions>
+					<speed>0.4227443039417267</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011879151863143" lon="-84.21262574516822">
+				<ele>962.5925645120442</ele>
+				<time>2017-11-13T18:03:49Z</time>
+				<extensions>
+					<speed>0.5141265988349915</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011860173154208" lon="-84.21268557611063">
+				<ele>962.6004816740751</ele>
+				<time>2017-11-13T18:03:50Z</time>
+				<extensions>
+					<speed>0.6312224864959717</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011864480993939" lon="-84.21269843579347">
+				<ele>962.4542365055531</ele>
+				<time>2017-11-13T18:03:51Z</time>
+				<extensions>
+					<speed>0.7220889925956726</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011855756223307" lon="-84.21271830558825">
+				<ele>962.0124068530276</ele>
+				<time>2017-11-13T18:03:52Z</time>
+				<extensions>
+					<speed>0.9964196085929871</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011844381456816" lon="-84.21277840336973">
+				<ele>961.3160285996273</ele>
+				<time>2017-11-13T18:03:53Z</time>
+				<extensions>
+					<speed>1.654795527458191</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011836896755412" lon="-84.21281986640334">
+				<ele>960.4053529398516</ele>
+				<time>2017-11-13T18:03:54Z</time>
+				<extensions>
+					<speed>2.5873165130615234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011800032251143" lon="-84.21291220802239">
+				<ele>959.7447087122127</ele>
+				<time>2017-11-13T18:03:55Z</time>
+				<extensions>
+					<speed>4.305325508117676</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011774051212637" lon="-84.21299084419385">
+				<ele>959.5200231103227</ele>
+				<time>2017-11-13T18:03:56Z</time>
+				<extensions>
+					<speed>5.470331192016602</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011747849916642" lon="-84.2130759133468">
+				<ele>959.3294106405228</ele>
+				<time>2017-11-13T18:03:57Z</time>
+				<extensions>
+					<speed>6.1457037925720215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011717654941261" lon="-84.21315621864618">
+				<ele>959.464806964621</ele>
+				<time>2017-11-13T18:03:58Z</time>
+				<extensions>
+					<speed>6.540775299072266</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01169975566506" lon="-84.21324870755038">
+				<ele>959.6744215162471</ele>
+				<time>2017-11-13T18:03:59Z</time>
+				<extensions>
+					<speed>6.913834095001221</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011679944819267" lon="-84.21332728793745">
+				<ele>960.0248473230749</ele>
+				<time>2017-11-13T18:04:00Z</time>
+				<extensions>
+					<speed>6.863888263702393</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011656828004801" lon="-84.21340139693876">
+				<ele>960.108552666381</ele>
+				<time>2017-11-13T18:04:01Z</time>
+				<extensions>
+					<speed>6.52857780456543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011629534479168" lon="-84.21345305566223">
+				<ele>960.500124707818</ele>
+				<time>2017-11-13T18:04:02Z</time>
+				<extensions>
+					<speed>6.001767635345459</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011602103119422" lon="-84.21349973123239">
+				<ele>960.9255293989554</ele>
+				<time>2017-11-13T18:04:03Z</time>
+				<extensions>
+					<speed>5.365551471710205</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011575542693976" lon="-84.21354774710265">
+				<ele>961.0097300698981</ele>
+				<time>2017-11-13T18:04:04Z</time>
+				<extensions>
+					<speed>5.038261890411377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011550000587862" lon="-84.21355153595434">
+				<ele>959.9962255321443</ele>
+				<time>2017-11-13T18:04:05Z</time>
+				<extensions>
+					<speed>4.331141948699951</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011528523312332" lon="-84.21358076798909">
+				<ele>960.2416519708931</ele>
+				<time>2017-11-13T18:04:06Z</time>
+				<extensions>
+					<speed>3.801352024078369</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011513754281035" lon="-84.21359955474293">
+				<ele>960.4126209011301</ele>
+				<time>2017-11-13T18:04:07Z</time>
+				<extensions>
+					<speed>3.1648221015930176</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011508345319553" lon="-84.21360227602025">
+				<ele>960.4661608748138</ele>
+				<time>2017-11-13T18:04:08Z</time>
+				<extensions>
+					<speed>2.479724407196045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011505421775759" lon="-84.21360013533499">
+				<ele>960.4760005995631</ele>
+				<time>2017-11-13T18:04:09Z</time>
+				<extensions>
+					<speed>1.9091646671295166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011524580135358" lon="-84.21356869633802">
+				<ele>960.3827224848792</ele>
+				<time>2017-11-13T18:04:10Z</time>
+				<extensions>
+					<speed>0.7787144184112549</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011541806306083" lon="-84.21353741293497">
+				<ele>960.3675592811778</ele>
+				<time>2017-11-13T18:04:11Z</time>
+				<extensions>
+					<speed>0.8130059838294983</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011541806306083" lon="-84.21353741293497">
+				<ele>960.3675592811778</ele>
+				<time>2017-11-13T18:04:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01155525144925" lon="-84.21351703151603">
+				<ele>960.6630350612104</ele>
+				<time>2017-11-13T18:04:13Z</time>
+				<extensions>
+					<speed>0.6356586217880249</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01155525144925" lon="-84.21351703151603">
+				<ele>960.6630350612104</ele>
+				<time>2017-11-13T18:04:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011566033222886" lon="-84.21350572415308">
+				<ele>960.7133004060015</ele>
+				<time>2017-11-13T18:04:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011566033222886" lon="-84.21350572415308">
+				<ele>960.7133004060015</ele>
+				<time>2017-11-13T18:04:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011566033222886" lon="-84.21350572415308">
+				<ele>960.7133004060015</ele>
+				<time>2017-11-13T18:04:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011566033222886" lon="-84.21350572415308">
+				<ele>960.7133004060015</ele>
+				<time>2017-11-13T18:04:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0115843249383" lon="-84.2134987166398">
+				<ele>960.6866388618946</ele>
+				<time>2017-11-13T18:04:19Z</time>
+				<extensions>
+					<speed>0.7080211639404297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011566033222886" lon="-84.21350572415308">
+				<ele>960.7133004060015</ele>
+				<time>2017-11-13T18:04:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011583010641827" lon="-84.2135054528335">
+				<ele>960.6188418287784</ele>
+				<time>2017-11-13T18:04:21Z</time>
+				<extensions>
+					<speed>1.1216355562210083</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011587526384984" lon="-84.21351768548635">
+				<ele>960.4939969507977</ele>
+				<time>2017-11-13T18:04:22Z</time>
+				<extensions>
+					<speed>1.3743048906326294</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011584862792816" lon="-84.2135387151823">
+				<ele>960.26665967796</ele>
+				<time>2017-11-13T18:04:23Z</time>
+				<extensions>
+					<speed>1.7800103425979614</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011582342606605" lon="-84.2135567890539">
+				<ele>959.9717412777245</ele>
+				<time>2017-11-13T18:04:24Z</time>
+				<extensions>
+					<speed>1.8337104320526123</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011577006720659" lon="-84.21357475691111">
+				<ele>959.389398522675</ele>
+				<time>2017-11-13T18:04:25Z</time>
+				<extensions>
+					<speed>1.842970848083496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011534677078078" lon="-84.21360128643367">
+				<ele>959.2183669386432</ele>
+				<time>2017-11-13T18:04:26Z</time>
+				<extensions>
+					<speed>2.35514235496521</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011488979432148" lon="-84.21363172112834">
+				<ele>959.2346312468871</ele>
+				<time>2017-11-13T18:04:27Z</time>
+				<extensions>
+					<speed>2.7117135524749756</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011377410124386" lon="-84.21367982124445">
+				<ele>959.1593435602263</ele>
+				<time>2017-11-13T18:04:28Z</time>
+				<extensions>
+					<speed>4.262429237365723</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011292410629432" lon="-84.21372125472715">
+				<ele>958.7963618477806</ele>
+				<time>2017-11-13T18:04:29Z</time>
+				<extensions>
+					<speed>5.458888053894043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01122339735673" lon="-84.2137583407422">
+				<ele>958.69944895152</ele>
+				<time>2017-11-13T18:04:30Z</time>
+				<extensions>
+					<speed>5.95126485824585</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011151010955775" lon="-84.21379815577451">
+				<ele>958.4681199807674</ele>
+				<time>2017-11-13T18:04:31Z</time>
+				<extensions>
+					<speed>6.58752965927124</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01106160780319" lon="-84.21382690511234">
+				<ele>958.3536340016872</ele>
+				<time>2017-11-13T18:04:32Z</time>
+				<extensions>
+					<speed>7.205356597900391</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010967641402821" lon="-84.21386186416208">
+				<ele>958.18077694159</ele>
+				<time>2017-11-13T18:04:33Z</time>
+				<extensions>
+					<speed>7.914495944976807</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010848032706846" lon="-84.21387863759945">
+				<ele>957.8332312572747</ele>
+				<time>2017-11-13T18:04:34Z</time>
+				<extensions>
+					<speed>8.617711067199707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010739469810002" lon="-84.2138931074666">
+				<ele>957.3736711721867</ele>
+				<time>2017-11-13T18:04:35Z</time>
+				<extensions>
+					<speed>8.99417781829834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010627052433152" lon="-84.2139182319026">
+				<ele>957.275590072386</ele>
+				<time>2017-11-13T18:04:36Z</time>
+				<extensions>
+					<speed>9.259234428405762</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010553580302382" lon="-84.213966791234">
+				<ele>957.1502872817218</ele>
+				<time>2017-11-13T18:04:37Z</time>
+				<extensions>
+					<speed>8.7474365234375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010486450641025" lon="-84.21400517341087">
+				<ele>957.0226544309407</ele>
+				<time>2017-11-13T18:04:38Z</time>
+				<extensions>
+					<speed>8.214552879333496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010424587657345" lon="-84.21403230125146">
+				<ele>956.8882417576388</ele>
+				<time>2017-11-13T18:04:39Z</time>
+				<extensions>
+					<speed>7.443637847900391</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01037101121487" lon="-84.21405335773099">
+				<ele>956.7596482178196</ele>
+				<time>2017-11-13T18:04:40Z</time>
+				<extensions>
+					<speed>7.15255069732666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010313974079478" lon="-84.21404076743634">
+				<ele>956.6156097687781</ele>
+				<time>2017-11-13T18:04:41Z</time>
+				<extensions>
+					<speed>6.8172078132629395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010267835408238" lon="-84.21400414795168">
+				<ele>956.5275382967666</ele>
+				<time>2017-11-13T18:04:42Z</time>
+				<extensions>
+					<speed>5.8969550132751465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010178315626183" lon="-84.21387606006549">
+				<ele>956.3434377377853</ele>
+				<time>2017-11-13T18:04:43Z</time>
+				<extensions>
+					<speed>5.498403549194336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010100060847174" lon="-84.21376589753274">
+				<ele>956.3696697503328</ele>
+				<time>2017-11-13T18:04:44Z</time>
+				<extensions>
+					<speed>5.576131343841553</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010146501564193" lon="-84.21295560843657">
+				<ele>956.9430828588083</ele>
+				<time>2017-11-13T18:05:10Z</time>
+				<extensions>
+					<speed>0.39442160725593567</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010149866814382" lon="-84.21292860243742">
+				<ele>959.1822152547538</ele>
+				<time>2017-11-13T18:05:11Z</time>
+				<extensions>
+					<speed>0.4335736334323883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010150393964732" lon="-84.21293341577129">
+				<ele>960.3388899033889</ele>
+				<time>2017-11-13T18:05:12Z</time>
+				<extensions>
+					<speed>0.2174174189567566</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010155383256587" lon="-84.21291759495432">
+				<ele>960.4303903523833</ele>
+				<time>2017-11-13T18:05:13Z</time>
+				<extensions>
+					<speed>0.06771687418222427</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010155383256587" lon="-84.21291759495432">
+				<ele>958.7368392376229</ele>
+				<time>2017-11-13T18:05:14Z</time>
+				<extensions>
+					<speed>0.12243809551000595</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01014103461179" lon="-84.21290163677877">
+				<ele>954.855981473811</ele>
+				<time>2017-11-13T18:05:15Z</time>
+				<extensions>
+					<speed>0.24854910373687744</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010133974792316" lon="-84.21289893617158">
+				<ele>952.1196477152407</ele>
+				<time>2017-11-13T18:05:16Z</time>
+				<extensions>
+					<speed>0.31156808137893677</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010110190914265" lon="-84.21287949640951">
+				<ele>938.4900728575885</ele>
+				<time>2017-11-13T18:05:17Z</time>
+				<extensions>
+					<speed>0.8580536842346191</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010106119783321" lon="-84.212867420348">
+				<ele>932.6573149655014</ele>
+				<time>2017-11-13T18:05:18Z</time>
+				<extensions>
+					<speed>0.8267971873283386</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010090816270694" lon="-84.21285877616435">
+				<ele>930.4420822486281</ele>
+				<time>2017-11-13T18:05:19Z</time>
+				<extensions>
+					<speed>0.917605459690094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010073198448675" lon="-84.21284571483395">
+				<ele>928.14817855414</ele>
+				<time>2017-11-13T18:05:20Z</time>
+				<extensions>
+					<speed>1.2873455286026</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01004062075549" lon="-84.2128205162109">
+				<ele>923.4165057679638</ele>
+				<time>2017-11-13T18:05:21Z</time>
+				<extensions>
+					<speed>1.7362430095672607</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010022646720259" lon="-84.2128075736914">
+				<ele>924.4415473341942</ele>
+				<time>2017-11-13T18:05:22Z</time>
+				<extensions>
+					<speed>2.186370849609375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00999231214655" lon="-84.2127829416165">
+				<ele>920.0534748705104</ele>
+				<time>2017-11-13T18:05:23Z</time>
+				<extensions>
+					<speed>2.54415225982666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009975009473512" lon="-84.21277028241926">
+				<ele>921.8728768890724</ele>
+				<time>2017-11-13T18:05:24Z</time>
+				<extensions>
+					<speed>2.9073870182037354</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009960525371016" lon="-84.21275535046621">
+				<ele>924.2175341062248</ele>
+				<time>2017-11-13T18:05:25Z</time>
+				<extensions>
+					<speed>3.292606830596924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009960525371016" lon="-84.21275535046621">
+				<ele>1018.760663731955</ele>
+				<time>2017-11-13T18:05:26Z</time>
+				<extensions>
+					<speed>1.9299412965774536</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009909932320138" lon="-84.21271288292695">
+				<ele>923.4831545045599</ele>
+				<time>2017-11-13T18:05:27Z</time>
+				<extensions>
+					<speed>3.9969985485076904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009808004900233" lon="-84.21258887819863">
+				<ele>876.5349070029333</ele>
+				<time>2017-11-13T18:05:28Z</time>
+				<extensions>
+					<speed>4.738277912139893</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009788882629678" lon="-84.21256901860927">
+				<ele>874.8174461526796</ele>
+				<time>2017-11-13T18:05:29Z</time>
+				<extensions>
+					<speed>5.064446449279785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009769891972418" lon="-84.21255723940624">
+				<ele>875.2529879547656</ele>
+				<time>2017-11-13T18:05:30Z</time>
+				<extensions>
+					<speed>5.029438495635986</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009735160114051" lon="-84.21252608321785">
+				<ele>870.7799568362534</ele>
+				<time>2017-11-13T18:05:31Z</time>
+				<extensions>
+					<speed>5.1883440017700195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009703473812648" lon="-84.21249692610934">
+				<ele>870.1425911653787</ele>
+				<time>2017-11-13T18:05:32Z</time>
+				<extensions>
+					<speed>5.454843044281006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009666086508535" lon="-84.21247296078405">
+				<ele>869.660631406121</ele>
+				<time>2017-11-13T18:05:33Z</time>
+				<extensions>
+					<speed>5.606655597686768</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009616113176056" lon="-84.21242549406446">
+				<ele>863.2225299105048</ele>
+				<time>2017-11-13T18:05:34Z</time>
+				<extensions>
+					<speed>5.852415084838867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009564035478588" lon="-84.21238308239981">
+				<ele>857.144692520611</ele>
+				<time>2017-11-13T18:05:35Z</time>
+				<extensions>
+					<speed>6.067381381988525</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009517230017863" lon="-84.21234667605293">
+				<ele>852.2237080186605</ele>
+				<time>2017-11-13T18:05:36Z</time>
+				<extensions>
+					<speed>6.142782688140869</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009475036528103" lon="-84.21231526048669">
+				<ele>848.9537597512826</ele>
+				<time>2017-11-13T18:05:37Z</time>
+				<extensions>
+					<speed>6.175904273986816</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009428349286287" lon="-84.2122835631891">
+				<ele>845.2907057320699</ele>
+				<time>2017-11-13T18:05:38Z</time>
+				<extensions>
+					<speed>6.277711868286133</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009376886388907" lon="-84.21224446827581">
+				<ele>841.0368324406445</ele>
+				<time>2017-11-13T18:05:39Z</time>
+				<extensions>
+					<speed>6.537132740020752</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009329467738807" lon="-84.2122090696825">
+				<ele>838.3773299604654</ele>
+				<time>2017-11-13T18:05:40Z</time>
+				<extensions>
+					<speed>6.5475993156433105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009284449462392" lon="-84.21217535309108">
+				<ele>835.9113441659138</ele>
+				<time>2017-11-13T18:05:41Z</time>
+				<extensions>
+					<speed>6.436756134033203</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009254392895086" lon="-84.21216031847669">
+				<ele>839.0681266095489</ele>
+				<time>2017-11-13T18:05:42Z</time>
+				<extensions>
+					<speed>6.2298784255981445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00923122908901" lon="-84.21215586387815">
+				<ele>845.2668971996754</ele>
+				<time>2017-11-13T18:05:43Z</time>
+				<extensions>
+					<speed>5.9865241050720215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009204569574" lon="-84.21214526084016">
+				<ele>851.6039870325476</ele>
+				<time>2017-11-13T18:05:44Z</time>
+				<extensions>
+					<speed>6.002023220062256</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009185587845222" lon="-84.21211188331833">
+				<ele>861.992454524152</ele>
+				<time>2017-11-13T18:05:45Z</time>
+				<extensions>
+					<speed>6.23892068862915</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009158715092065" lon="-84.2120743301172">
+				<ele>872.1359752407297</ele>
+				<time>2017-11-13T18:05:46Z</time>
+				<extensions>
+					<speed>6.6567702293396</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009111910240811" lon="-84.21202390579307">
+				<ele>876.6116302544251</ele>
+				<time>2017-11-13T18:05:47Z</time>
+				<extensions>
+					<speed>7.203999042510986</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009052490361853" lon="-84.21197972688272">
+				<ele>877.5005037207156</ele>
+				<time>2017-11-13T18:05:48Z</time>
+				<extensions>
+					<speed>7.604703903198242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008993941577968" lon="-84.21194364732332">
+				<ele>878.1706142546609</ele>
+				<time>2017-11-13T18:05:49Z</time>
+				<extensions>
+					<speed>7.724269390106201</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008933111953096" lon="-84.21189775530488">
+				<ele>879.2274778429419</ele>
+				<time>2017-11-13T18:05:50Z</time>
+				<extensions>
+					<speed>7.950325965881348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008879098907041" lon="-84.21185218064372">
+				<ele>883.4145095972344</ele>
+				<time>2017-11-13T18:05:51Z</time>
+				<extensions>
+					<speed>7.8933210372924805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00882416416312" lon="-84.2118128568991">
+				<ele>886.4636583691463</ele>
+				<time>2017-11-13T18:05:52Z</time>
+				<extensions>
+					<speed>7.940240383148193</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008774191977428" lon="-84.21175888651766">
+				<ele>891.603475167416</ele>
+				<time>2017-11-13T18:05:53Z</time>
+				<extensions>
+					<speed>8.05344295501709</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008726547963928" lon="-84.21168696086329">
+				<ele>895.6644935784861</ele>
+				<time>2017-11-13T18:05:54Z</time>
+				<extensions>
+					<speed>8.158468246459961</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008692161117557" lon="-84.21162147381459">
+				<ele>899.4291747193784</ele>
+				<time>2017-11-13T18:05:55Z</time>
+				<extensions>
+					<speed>7.999284744262695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008666267414643" lon="-84.21155299429901">
+				<ele>902.6608013659716</ele>
+				<time>2017-11-13T18:05:56Z</time>
+				<extensions>
+					<speed>7.527594566345215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008653788016616" lon="-84.21148208607879">
+				<ele>908.6301501467824</ele>
+				<time>2017-11-13T18:05:57Z</time>
+				<extensions>
+					<speed>7.759815216064453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008642500784376" lon="-84.21141240384415">
+				<ele>909.7596864113584</ele>
+				<time>2017-11-13T18:05:58Z</time>
+				<extensions>
+					<speed>7.666138648986816</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008628247016752" lon="-84.21128908623552">
+				<ele>912.9689285401255</ele>
+				<time>2017-11-13T18:05:59Z</time>
+				<extensions>
+					<speed>8.325374603271484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008608814225422" lon="-84.21116130555407">
+				<ele>911.1519205346704</ele>
+				<time>2017-11-13T18:06:00Z</time>
+				<extensions>
+					<speed>8.502127647399902</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008605632871802" lon="-84.21107688837762">
+				<ele>919.3419770700857</ele>
+				<time>2017-11-13T18:06:01Z</time>
+				<extensions>
+					<speed>8.653133392333984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00861359436764" lon="-84.21101070786078">
+				<ele>928.8023190824315</ele>
+				<time>2017-11-13T18:06:02Z</time>
+				<extensions>
+					<speed>8.673103332519531</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008616104183185" lon="-84.21088577540938">
+				<ele>941.5895232865587</ele>
+				<time>2017-11-13T18:06:03Z</time>
+				<extensions>
+					<speed>9.392757415771484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008616427419227" lon="-84.2107836210847">
+				<ele>948.0613826271147</ele>
+				<time>2017-11-13T18:06:04Z</time>
+				<extensions>
+					<speed>9.442904472351074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0086220065564" lon="-84.21068967531569">
+				<ele>951.9477607933804</ele>
+				<time>2017-11-13T18:06:05Z</time>
+				<extensions>
+					<speed>9.3237886428833</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008628187645662" lon="-84.21061292206278">
+				<ele>953.1107793655246</ele>
+				<time>2017-11-13T18:06:06Z</time>
+				<extensions>
+					<speed>9.053287506103516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008628792064915" lon="-84.21054143972589">
+				<ele>951.1099272612482</ele>
+				<time>2017-11-13T18:06:07Z</time>
+				<extensions>
+					<speed>8.616575241088867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008628041970445" lon="-84.2104853417415">
+				<ele>949.9455864708871</ele>
+				<time>2017-11-13T18:06:08Z</time>
+				<extensions>
+					<speed>7.838664531707764</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008629354784576" lon="-84.21042820199195">
+				<ele>950.2498292932287</ele>
+				<time>2017-11-13T18:06:09Z</time>
+				<extensions>
+					<speed>7.439577102661133</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008618912891924" lon="-84.21038057501409">
+				<ele>941.8645122954622</ele>
+				<time>2017-11-13T18:06:10Z</time>
+				<extensions>
+					<speed>7.016308307647705</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00860966161868" lon="-84.21035602596105">
+				<ele>936.9989061793312</ele>
+				<time>2017-11-13T18:06:11Z</time>
+				<extensions>
+					<speed>5.6939826011657715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008588006008317" lon="-84.21033332608198">
+				<ele>925.348657168448</ele>
+				<time>2017-11-13T18:06:12Z</time>
+				<extensions>
+					<speed>4.299842834472656</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008560317506456" lon="-84.21032745121671">
+				<ele>917.7477244660258</ele>
+				<time>2017-11-13T18:06:13Z</time>
+				<extensions>
+					<speed>2.2412655353546143</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008543996608864" lon="-84.21033200122712">
+				<ele>913.9261403875425</ele>
+				<time>2017-11-13T18:06:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008531696176943" lon="-84.21034226234114">
+				<ele>909.0780306383967</ele>
+				<time>2017-11-13T18:06:15Z</time>
+				<extensions>
+					<speed>0.4906408190727234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008531696176943" lon="-84.21034226234114">
+				<ele>909.0780306383967</ele>
+				<time>2017-11-13T18:06:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008523572843776" lon="-84.21032660805423">
+				<ele>905.4176844265312</ele>
+				<time>2017-11-13T18:06:17Z</time>
+				<extensions>
+					<speed>1.0015122890472412</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008515443488557" lon="-84.21030365753936">
+				<ele>901.9601368186995</ele>
+				<time>2017-11-13T18:06:18Z</time>
+				<extensions>
+					<speed>0.9189728498458862</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008515443488557" lon="-84.21030365753936">
+				<ele>901.9601368186995</ele>
+				<time>2017-11-13T18:06:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00851437748072" lon="-84.21028322469007">
+				<ele>902.8769202949479</ele>
+				<time>2017-11-13T18:06:20Z</time>
+				<extensions>
+					<speed>0.10578738152980804</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00851437748072" lon="-84.21028322469007">
+				<ele>902.8769202949479</ele>
+				<time>2017-11-13T18:06:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00851437748072" lon="-84.21028322469007">
+				<ele>902.8769202949479</ele>
+				<time>2017-11-13T18:06:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00851437748072" lon="-84.21028322469007">
+				<ele>902.8769202949479</ele>
+				<time>2017-11-13T18:06:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00851437748072" lon="-84.21028322469007">
+				<ele>902.8769202949479</ele>
+				<time>2017-11-13T18:06:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00851437748072" lon="-84.21028322469007">
+				<ele>902.8769202949479</ele>
+				<time>2017-11-13T18:06:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00850663260814" lon="-84.21028776218157">
+				<ele>902.4159083236009</ele>
+				<time>2017-11-13T18:06:26Z</time>
+				<extensions>
+					<speed>0.3962556719779968</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00850663260814" lon="-84.21028776218157">
+				<ele>902.4159083236009</ele>
+				<time>2017-11-13T18:06:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008506860237333" lon="-84.2102887022159">
+				<ele>902.5736653050408</ele>
+				<time>2017-11-13T18:06:28Z</time>
+				<extensions>
+					<speed>0.06269339472055435</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008503641772052" lon="-84.21028855950883">
+				<ele>901.6017522327602</ele>
+				<time>2017-11-13T18:06:29Z</time>
+				<extensions>
+					<speed>0.02141031250357628</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00850211716938" lon="-84.21028675840057">
+				<ele>900.6071757776663</ele>
+				<time>2017-11-13T18:06:30Z</time>
+				<extensions>
+					<speed>0.007655489724129438</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00850211716938" lon="-84.21028675840057">
+				<ele>900.6071757776663</ele>
+				<time>2017-11-13T18:06:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008499361494101" lon="-84.21028749663704">
+				<ele>899.9415242476389</ele>
+				<time>2017-11-13T18:06:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008493975848342" lon="-84.21028619227016">
+				<ele>898.720509220846</ele>
+				<time>2017-11-13T18:06:33Z</time>
+				<extensions>
+					<speed>0.22496110200881958</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008490009459283" lon="-84.21028803932529">
+				<ele>898.5284426687285</ele>
+				<time>2017-11-13T18:06:34Z</time>
+				<extensions>
+					<speed>0.2506972551345825</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008485983438321" lon="-84.21028332928066">
+				<ele>896.6204505506903</ele>
+				<time>2017-11-13T18:06:35Z</time>
+				<extensions>
+					<speed>0.25567060708999634</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008480186411063" lon="-84.21028534127842">
+				<ele>896.0895603969693</ele>
+				<time>2017-11-13T18:06:36Z</time>
+				<extensions>
+					<speed>0.3097418248653412</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008473680271985" lon="-84.21028651520876">
+				<ele>895.649406131357</ele>
+				<time>2017-11-13T18:06:37Z</time>
+				<extensions>
+					<speed>0.3619101941585541</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008469376012135" lon="-84.21028178054566">
+				<ele>894.4093011543155</ele>
+				<time>2017-11-13T18:06:38Z</time>
+				<extensions>
+					<speed>0.35550642013549805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008467177800082" lon="-84.2102724401077">
+				<ele>893.84204249084</ele>
+				<time>2017-11-13T18:06:39Z</time>
+				<extensions>
+					<speed>0.33954232931137085</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00846965409114" lon="-84.21027071918581">
+				<ele>894.1083266912028</ele>
+				<time>2017-11-13T18:06:40Z</time>
+				<extensions>
+					<speed>0.24766342341899872</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008471026215302" lon="-84.21025333140781">
+				<ele>892.9715556632727</ele>
+				<time>2017-11-13T18:06:41Z</time>
+				<extensions>
+					<speed>0.27207791805267334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008474994111873" lon="-84.2102263428384">
+				<ele>891.7574089318514</ele>
+				<time>2017-11-13T18:06:42Z</time>
+				<extensions>
+					<speed>0.46632689237594604</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008478236291834" lon="-84.21020174312403">
+				<ele>890.461379468441</ele>
+				<time>2017-11-13T18:06:43Z</time>
+				<extensions>
+					<speed>0.6208482980728149</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008481169359206" lon="-84.21016413062436">
+				<ele>888.8797997580841</ele>
+				<time>2017-11-13T18:06:44Z</time>
+				<extensions>
+					<speed>0.8607752323150635</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008485687824203" lon="-84.21012829184595">
+				<ele>887.5343860937282</ele>
+				<time>2017-11-13T18:06:45Z</time>
+				<extensions>
+					<speed>1.0526940822601318</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008495351250733" lon="-84.21007872954881">
+				<ele>886.1663881596178</ele>
+				<time>2017-11-13T18:06:46Z</time>
+				<extensions>
+					<speed>1.2877991199493408</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008504598758115" lon="-84.21006360857724">
+				<ele>885.6235415209085</ele>
+				<time>2017-11-13T18:06:47Z</time>
+				<extensions>
+					<speed>1.3069483041763306</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008511126623487" lon="-84.21006073874194">
+				<ele>885.4080540463328</ele>
+				<time>2017-11-13T18:06:48Z</time>
+				<extensions>
+					<speed>1.1984174251556396</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008517177680796" lon="-84.21005339797317">
+				<ele>885.0002041636035</ele>
+				<time>2017-11-13T18:06:49Z</time>
+				<extensions>
+					<speed>1.2324074506759644</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008516571143279" lon="-84.2100498436">
+				<ele>884.25519750081</ele>
+				<time>2017-11-13T18:06:50Z</time>
+				<extensions>
+					<speed>1.1412862539291382</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008513079721174" lon="-84.21005112313297">
+				<ele>883.3912244383246</ele>
+				<time>2017-11-13T18:06:51Z</time>
+				<extensions>
+					<speed>0.927430272102356</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008508060064832" lon="-84.21005415745807">
+				<ele>882.7173614064232</ele>
+				<time>2017-11-13T18:06:52Z</time>
+				<extensions>
+					<speed>0.682573139667511</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008495913950386" lon="-84.21005053639512">
+				<ele>881.443219576031</ele>
+				<time>2017-11-13T18:06:53Z</time>
+				<extensions>
+					<speed>0.6180376410484314</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00848872096519" lon="-84.2100525582345">
+				<ele>880.966714524664</ele>
+				<time>2017-11-13T18:06:54Z</time>
+				<extensions>
+					<speed>0.5513058304786682</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008484567571164" lon="-84.2100540744868">
+				<ele>880.7406227337196</ele>
+				<time>2017-11-13T18:06:55Z</time>
+				<extensions>
+					<speed>0.48229673504829407</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008485595483766" lon="-84.21004930322665">
+				<ele>880.9438868993893</ele>
+				<time>2017-11-13T18:06:56Z</time>
+				<extensions>
+					<speed>0.5082127451896667</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008481209006248" lon="-84.21004029817618">
+				<ele>881.1721278466284</ele>
+				<time>2017-11-13T18:06:57Z</time>
+				<extensions>
+					<speed>0.6528820395469666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008471820014645" lon="-84.21003858953542">
+				<ele>881.1828305302188</ele>
+				<time>2017-11-13T18:06:58Z</time>
+				<extensions>
+					<speed>0.7187647223472595</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008460049042032" lon="-84.21003785404508">
+				<ele>881.4937272062525</ele>
+				<time>2017-11-13T18:06:59Z</time>
+				<extensions>
+					<speed>0.7028515338897705</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008448386447855" lon="-84.2100398541235">
+				<ele>882.0942400321364</ele>
+				<time>2017-11-13T18:07:00Z</time>
+				<extensions>
+					<speed>0.5953057408332825</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008439716641199" lon="-84.21005307427117">
+				<ele>882.9032757496461</ele>
+				<time>2017-11-13T18:07:01Z</time>
+				<extensions>
+					<speed>0.3950568735599518</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008435753453243" lon="-84.21006047645226">
+				<ele>883.7258483776823</ele>
+				<time>2017-11-13T18:07:02Z</time>
+				<extensions>
+					<speed>0.24032428860664368</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008436823453257" lon="-84.2100656311084">
+				<ele>884.5511986110359</ele>
+				<time>2017-11-13T18:07:03Z</time>
+				<extensions>
+					<speed>0.08929258584976196</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008449305353679" lon="-84.21006537555198">
+				<ele>885.6103514889255</ele>
+				<time>2017-11-13T18:07:04Z</time>
+				<extensions>
+					<speed>0.17882680892944336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008453726162784" lon="-84.21006065809274">
+				<ele>887.5262743989006</ele>
+				<time>2017-11-13T18:07:05Z</time>
+				<extensions>
+					<speed>0.22153955698013306</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008458808017602" lon="-84.21005757853166">
+				<ele>888.7610708894208</ele>
+				<time>2017-11-13T18:07:06Z</time>
+				<extensions>
+					<speed>0.25343188643455505</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008464023333124" lon="-84.21005176180623">
+				<ele>890.474994388409</ele>
+				<time>2017-11-13T18:07:07Z</time>
+				<extensions>
+					<speed>0.2913512885570526</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008464953962676" lon="-84.21004375879289">
+				<ele>892.1297533661127</ele>
+				<time>2017-11-13T18:07:08Z</time>
+				<extensions>
+					<speed>0.3498196601867676</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008461417504872" lon="-84.21002397237376">
+				<ele>893.7163479356095</ele>
+				<time>2017-11-13T18:07:09Z</time>
+				<extensions>
+					<speed>0.4678138196468353</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008457393115604" lon="-84.21003878681617">
+				<ele>895.491126424633</ele>
+				<time>2017-11-13T18:07:10Z</time>
+				<extensions>
+					<speed>0.37404924631118774</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008454939167114" lon="-84.21003905894868">
+				<ele>897.6822582222521</ele>
+				<time>2017-11-13T18:07:11Z</time>
+				<extensions>
+					<speed>0.39844152331352234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00846486536027" lon="-84.21002644537401">
+				<ele>899.4073263965547</ele>
+				<time>2017-11-13T18:07:12Z</time>
+				<extensions>
+					<speed>0.5067834258079529</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008460694344286" lon="-84.20998821497622">
+				<ele>899.1879092473537</ele>
+				<time>2017-11-13T18:07:13Z</time>
+				<extensions>
+					<speed>0.7937088012695313</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008454228744162" lon="-84.20990787693664">
+				<ele>899.7035587653518</ele>
+				<time>2017-11-13T18:07:14Z</time>
+				<extensions>
+					<speed>1.4374327659606934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008448987071228" lon="-84.2098319367674">
+				<ele>900.4978893557563</ele>
+				<time>2017-11-13T18:07:15Z</time>
+				<extensions>
+					<speed>1.9924736022949219</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00845193153867" lon="-84.20974165289772">
+				<ele>902.5634379638359</ele>
+				<time>2017-11-13T18:07:16Z</time>
+				<extensions>
+					<speed>2.5713303089141846</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008446738623498" lon="-84.20967804569678">
+				<ele>901.7131332047284</ele>
+				<time>2017-11-13T18:07:17Z</time>
+				<extensions>
+					<speed>2.831839084625244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008453377230202" lon="-84.20960463335382">
+				<ele>901.9886881820858</ele>
+				<time>2017-11-13T18:07:18Z</time>
+				<extensions>
+					<speed>3.0526957511901855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008453092695245" lon="-84.20955365966358">
+				<ele>900.6440300317481</ele>
+				<time>2017-11-13T18:07:19Z</time>
+				<extensions>
+					<speed>3.243905544281006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008462005450031" lon="-84.20949076126274">
+				<ele>898.087450388819</ele>
+				<time>2017-11-13T18:07:20Z</time>
+				<extensions>
+					<speed>3.345857858657837</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008463847158414" lon="-84.20943887460663">
+				<ele>892.4414489213377</ele>
+				<time>2017-11-13T18:07:21Z</time>
+				<extensions>
+					<speed>3.188516139984131</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0084570142237" lon="-84.20939945748577">
+				<ele>887.419515511021</ele>
+				<time>2017-11-13T18:07:22Z</time>
+				<extensions>
+					<speed>3.277209758758545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008456836627651" lon="-84.2093490579759">
+				<ele>885.78167878557</ele>
+				<time>2017-11-13T18:07:23Z</time>
+				<extensions>
+					<speed>3.4515299797058105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008450968455259" lon="-84.20931186104681">
+				<ele>881.151026356034</ele>
+				<time>2017-11-13T18:07:24Z</time>
+				<extensions>
+					<speed>3.187573194503784</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008466904211529" lon="-84.20918266949097">
+				<ele>874.67859141808</ele>
+				<time>2017-11-13T18:07:25Z</time>
+				<extensions>
+					<speed>3.9626107215881348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008477286057406" lon="-84.20906763007366">
+				<ele>869.8509770911187</ele>
+				<time>2017-11-13T18:07:26Z</time>
+				<extensions>
+					<speed>4.764862060546875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008484746632204" lon="-84.2089706591682">
+				<ele>864.7756373621523</ele>
+				<time>2017-11-13T18:07:27Z</time>
+				<extensions>
+					<speed>5.454632759094238</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008488166219964" lon="-84.20888976759268">
+				<ele>860.2809906424955</ele>
+				<time>2017-11-13T18:07:28Z</time>
+				<extensions>
+					<speed>6.005695343017578</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00848693278795" lon="-84.20881260947367">
+				<ele>858.1696224324405</ele>
+				<time>2017-11-13T18:07:29Z</time>
+				<extensions>
+					<speed>6.394126892089844</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008492049416612" lon="-84.20868698513007">
+				<ele>855.0986084835604</ele>
+				<time>2017-11-13T18:07:30Z</time>
+				<extensions>
+					<speed>7.153763771057129</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00849115963924" lon="-84.20859917435656">
+				<ele>853.4672523960471</ele>
+				<time>2017-11-13T18:07:31Z</time>
+				<extensions>
+					<speed>7.279348850250244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008493124941179" lon="-84.20852411347435">
+				<ele>853.2864636266604</ele>
+				<time>2017-11-13T18:07:32Z</time>
+				<extensions>
+					<speed>7.296453475952148</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008496023078898" lon="-84.20844659828622">
+				<ele>853.8148450460285</ele>
+				<time>2017-11-13T18:07:33Z</time>
+				<extensions>
+					<speed>7.252954959869385</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00849691482041" lon="-84.20838119577945">
+				<ele>853.6932446202263</ele>
+				<time>2017-11-13T18:07:34Z</time>
+				<extensions>
+					<speed>7.06527042388916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008492760299118" lon="-84.20832784264779">
+				<ele>853.868358979933</ele>
+				<time>2017-11-13T18:07:35Z</time>
+				<extensions>
+					<speed>6.834039688110352</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008483877406697" lon="-84.20827396094755">
+				<ele>854.0389096559957</ele>
+				<time>2017-11-13T18:07:36Z</time>
+				<extensions>
+					<speed>6.645882606506348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008481795929153" lon="-84.20822201692162">
+				<ele>853.8645612858236</ele>
+				<time>2017-11-13T18:07:37Z</time>
+				<extensions>
+					<speed>6.350231647491455</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008481795929153" lon="-84.20822201692162">
+				<ele>857.1878157127649</ele>
+				<time>2017-11-13T18:07:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008464459112467" lon="-84.20835320797927">
+				<ele>857.0917565217242</ele>
+				<time>2017-11-13T18:07:39Z</time>
+				<extensions>
+					<speed>0.5817700028419495</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0084583022185" lon="-84.2083611797036">
+				<ele>855.7069543013349</ele>
+				<time>2017-11-13T18:07:40Z</time>
+				<extensions>
+					<speed>0.41636353731155396</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008460201525045" lon="-84.20840921400551">
+				<ele>860.8882045950741</ele>
+				<time>2017-11-13T18:07:41Z</time>
+				<extensions>
+					<speed>0.4470178484916687</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008460201525045" lon="-84.20840921400551">
+				<ele>860.8882045950741</ele>
+				<time>2017-11-13T18:07:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008452949981931" lon="-84.20842868377727">
+				<ele>861.5657477816567</ele>
+				<time>2017-11-13T18:07:43Z</time>
+				<extensions>
+					<speed>0.3947807252407074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008452949981931" lon="-84.20842868377727">
+				<ele>861.5657477816567</ele>
+				<time>2017-11-13T18:07:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008452949981931" lon="-84.20842868377727">
+				<ele>861.5657477816567</ele>
+				<time>2017-11-13T18:07:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008452949981931" lon="-84.20842868377727">
+				<ele>861.5657477816567</ele>
+				<time>2017-11-13T18:07:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008452949981931" lon="-84.20842868377727">
+				<ele>861.5657477816567</ele>
+				<time>2017-11-13T18:07:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008452949981931" lon="-84.20842868377727">
+				<ele>861.5657477816567</ele>
+				<time>2017-11-13T18:07:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008452949981931" lon="-84.20842868377727">
+				<ele>861.5657477816567</ele>
+				<time>2017-11-13T18:07:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008457119999576" lon="-84.20843907903617">
+				<ele>868.8623702060431</ele>
+				<time>2017-11-13T18:07:50Z</time>
+				<extensions>
+					<speed>0.7509458661079407</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008460028340092" lon="-84.2084316920616">
+				<ele>872.1640802333131</ele>
+				<time>2017-11-13T18:07:51Z</time>
+				<extensions>
+					<speed>2.1769216060638428</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008454197727866" lon="-84.20841625616295">
+				<ele>876.7408171212301</ele>
+				<time>2017-11-13T18:07:52Z</time>
+				<extensions>
+					<speed>3.582510471343994</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008439418692964" lon="-84.20840845513426">
+				<ele>870.2909718118608</ele>
+				<time>2017-11-13T18:07:53Z</time>
+				<extensions>
+					<speed>5.336338996887207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00845259417906" lon="-84.20831091775247">
+				<ele>882.3203312708065</ele>
+				<time>2017-11-13T18:07:54Z</time>
+				<extensions>
+					<speed>6.177583694458008</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008448994353387" lon="-84.20824420667712">
+				<ele>887.3570047579706</ele>
+				<time>2017-11-13T18:07:55Z</time>
+				<extensions>
+					<speed>7.514534950256348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008443959058004" lon="-84.20815623801474">
+				<ele>897.0768354535103</ele>
+				<time>2017-11-13T18:07:56Z</time>
+				<extensions>
+					<speed>9.100521087646484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008441789076935" lon="-84.20806369405992">
+				<ele>904.5435636229813</ele>
+				<time>2017-11-13T18:07:57Z</time>
+				<extensions>
+					<speed>8.77369499206543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008445613665145" lon="-84.20797790681544">
+				<ele>908.6748897451907</ele>
+				<time>2017-11-13T18:07:58Z</time>
+				<extensions>
+					<speed>8.408681869506836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008439923858932" lon="-84.20790177671051">
+				<ele>912.4702400583774</ele>
+				<time>2017-11-13T18:07:59Z</time>
+				<extensions>
+					<speed>8.100899696350098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008440372466527" lon="-84.2078332912432">
+				<ele>913.9111915407702</ele>
+				<time>2017-11-13T18:08:00Z</time>
+				<extensions>
+					<speed>7.3421311378479</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008439035406017" lon="-84.2077662386893">
+				<ele>916.9337413776666</ele>
+				<time>2017-11-13T18:08:01Z</time>
+				<extensions>
+					<speed>6.940941333770752</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008429637980786" lon="-84.20770542767448">
+				<ele>920.8196915350854</ele>
+				<time>2017-11-13T18:08:02Z</time>
+				<extensions>
+					<speed>6.435104846954346</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008424513543208" lon="-84.2076494256292">
+				<ele>922.2445994867012</ele>
+				<time>2017-11-13T18:08:03Z</time>
+				<extensions>
+					<speed>5.930662155151367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008415109025341" lon="-84.20759025500078">
+				<ele>924.1771144997329</ele>
+				<time>2017-11-13T18:08:04Z</time>
+				<extensions>
+					<speed>5.4888787269592285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008396040081013" lon="-84.20754541964274">
+				<ele>925.4640771215782</ele>
+				<time>2017-11-13T18:08:05Z</time>
+				<extensions>
+					<speed>5.266453742980957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008384149389308" lon="-84.20751936612653">
+				<ele>926.5303372219205</ele>
+				<time>2017-11-13T18:08:06Z</time>
+				<extensions>
+					<speed>4.392690181732178</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00837640658157" lon="-84.20750128140615">
+				<ele>927.1204758603126</ele>
+				<time>2017-11-13T18:08:07Z</time>
+				<extensions>
+					<speed>3.9290921688079834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008365115173156" lon="-84.2074835574439">
+				<ele>927.704006228596</ele>
+				<time>2017-11-13T18:08:08Z</time>
+				<extensions>
+					<speed>3.832228183746338</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00834838930636" lon="-84.20747746506822">
+				<ele>928.4045416200534</ele>
+				<time>2017-11-13T18:08:09Z</time>
+				<extensions>
+					<speed>3.8154187202453613</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008322832091398" lon="-84.20746709080306">
+				<ele>929.1920370226726</ele>
+				<time>2017-11-13T18:08:10Z</time>
+				<extensions>
+					<speed>3.949028253555298</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008290335366295" lon="-84.20746608596488">
+				<ele>929.6750979600474</ele>
+				<time>2017-11-13T18:08:11Z</time>
+				<extensions>
+					<speed>4.216358184814453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008248707569773" lon="-84.20745257400652">
+				<ele>930.4752000402659</ele>
+				<time>2017-11-13T18:08:12Z</time>
+				<extensions>
+					<speed>4.582973480224609</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008204476909178" lon="-84.20743644380516">
+				<ele>931.2440458908677</ele>
+				<time>2017-11-13T18:08:13Z</time>
+				<extensions>
+					<speed>4.86636209487915</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008160175024068" lon="-84.20741809700574">
+				<ele>931.9103689026088</ele>
+				<time>2017-11-13T18:08:14Z</time>
+				<extensions>
+					<speed>5.0167951583862305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008109571974574" lon="-84.2073930739369">
+				<ele>932.7351747835055</ele>
+				<time>2017-11-13T18:08:15Z</time>
+				<extensions>
+					<speed>5.273478031158447</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008058240073801" lon="-84.20737561903627">
+				<ele>933.4386661788449</ele>
+				<time>2017-11-13T18:08:16Z</time>
+				<extensions>
+					<speed>5.604991912841797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008004204865937" lon="-84.2073581615517">
+				<ele>934.1322057228535</ele>
+				<time>2017-11-13T18:08:17Z</time>
+				<extensions>
+					<speed>5.7575507164001465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007925737027502" lon="-84.20733561349829">
+				<ele>935.120582036674</ele>
+				<time>2017-11-13T18:08:18Z</time>
+				<extensions>
+					<speed>6.467658996582031</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007849673082356" lon="-84.20731413330337">
+				<ele>936.0191812757403</ele>
+				<time>2017-11-13T18:08:19Z</time>
+				<extensions>
+					<speed>6.825255870819092</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007772277044536" lon="-84.20727538315897">
+				<ele>936.9188370890915</ele>
+				<time>2017-11-13T18:08:20Z</time>
+				<extensions>
+					<speed>7.272010326385498</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007686353737743" lon="-84.20721640674695">
+				<ele>937.8684839801863</ele>
+				<time>2017-11-13T18:08:21Z</time>
+				<extensions>
+					<speed>7.551278591156006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007592985102315" lon="-84.20714374630502">
+				<ele>938.7741412250325</ele>
+				<time>2017-11-13T18:08:22Z</time>
+				<extensions>
+					<speed>7.996800899505615</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007512196304482" lon="-84.20709717452206">
+				<ele>939.6131871966645</ele>
+				<time>2017-11-13T18:08:23Z</time>
+				<extensions>
+					<speed>8.215991020202637</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007420117004644" lon="-84.2070315120391">
+				<ele>940.5035752076656</ele>
+				<time>2017-11-13T18:08:24Z</time>
+				<extensions>
+					<speed>8.577847480773926</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007337499859513" lon="-84.20698419205384">
+				<ele>941.3691796893254</ele>
+				<time>2017-11-13T18:08:25Z</time>
+				<extensions>
+					<speed>8.7056884765625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007240652961908" lon="-84.20690524684198">
+				<ele>942.4145034505054</ele>
+				<time>2017-11-13T18:08:26Z</time>
+				<extensions>
+					<speed>9.091673851013184</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007152133220183" lon="-84.20680672205818">
+				<ele>943.1155271548778</ele>
+				<time>2017-11-13T18:08:27Z</time>
+				<extensions>
+					<speed>9.409402847290039</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007049979987212" lon="-84.20668421714097">
+				<ele>943.7624556478113</ele>
+				<time>2017-11-13T18:08:28Z</time>
+				<extensions>
+					<speed>10.220690727233887</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006949768374533" lon="-84.20657940969188">
+				<ele>944.3324981555343</ele>
+				<time>2017-11-13T18:08:29Z</time>
+				<extensions>
+					<speed>10.846473693847656</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006851200876111" lon="-84.20648914128529">
+				<ele>945.0837674476206</ele>
+				<time>2017-11-13T18:08:30Z</time>
+				<extensions>
+					<speed>11.454203605651855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006752288393285" lon="-84.20641238402558">
+				<ele>945.812635303475</ele>
+				<time>2017-11-13T18:08:31Z</time>
+				<extensions>
+					<speed>11.830157279968262</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006630797518417" lon="-84.20629583165183">
+				<ele>946.5785033861175</ele>
+				<time>2017-11-13T18:08:32Z</time>
+				<extensions>
+					<speed>13.172077178955078</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006531548689466" lon="-84.2062280518975">
+				<ele>947.2678398881108</ele>
+				<time>2017-11-13T18:08:33Z</time>
+				<extensions>
+					<speed>13.344257354736328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006429763084858" lon="-84.2061517239329">
+				<ele>947.989091780968</ele>
+				<time>2017-11-13T18:08:34Z</time>
+				<extensions>
+					<speed>13.29941177368164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006345621323765" lon="-84.20610051309606">
+				<ele>948.9921055743471</ele>
+				<time>2017-11-13T18:08:35Z</time>
+				<extensions>
+					<speed>12.019722938537598</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006260261174168" lon="-84.20602754357785">
+				<ele>950.0078267958015</ele>
+				<time>2017-11-13T18:08:36Z</time>
+				<extensions>
+					<speed>11.119023323059082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00618778392655" lon="-84.20595866393553">
+				<ele>950.7800642643124</ele>
+				<time>2017-11-13T18:08:37Z</time>
+				<extensions>
+					<speed>10.681767463684082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006133387480318" lon="-84.2059089410869">
+				<ele>951.5318587580696</ele>
+				<time>2017-11-13T18:08:38Z</time>
+				<extensions>
+					<speed>8.713746070861816</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00608545689619" lon="-84.20583347760578">
+				<ele>952.2707253834233</ele>
+				<time>2017-11-13T18:08:39Z</time>
+				<extensions>
+					<speed>8.493130683898926</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006049965976661" lon="-84.20578139744575">
+				<ele>952.9146544476971</ele>
+				<time>2017-11-13T18:08:40Z</time>
+				<extensions>
+					<speed>8.065932273864746</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006034906516728" lon="-84.2057823220408">
+				<ele>953.3361716847867</ele>
+				<time>2017-11-13T18:08:41Z</time>
+				<extensions>
+					<speed>6.945248126983643</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006006184073316" lon="-84.20575483115778">
+				<ele>953.8358818236738</ele>
+				<time>2017-11-13T18:08:42Z</time>
+				<extensions>
+					<speed>6.538841724395752</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005978037304832" lon="-84.20572820012293">
+				<ele>954.3039567153901</ele>
+				<time>2017-11-13T18:08:43Z</time>
+				<extensions>
+					<speed>6.1170783042907715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005962511712237" lon="-84.20572862839015">
+				<ele>954.7844506567344</ele>
+				<time>2017-11-13T18:08:44Z</time>
+				<extensions>
+					<speed>5.394072532653809</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005940714248947" lon="-84.2057301731375">
+				<ele>955.2035271720961</ele>
+				<time>2017-11-13T18:08:45Z</time>
+				<extensions>
+					<speed>4.831803798675537</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005907069323767" lon="-84.20573308297273">
+				<ele>955.6962707443163</ele>
+				<time>2017-11-13T18:08:46Z</time>
+				<extensions>
+					<speed>4.706048011779785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005870832753427" lon="-84.20573262034515">
+				<ele>956.1881479797885</ele>
+				<time>2017-11-13T18:08:47Z</time>
+				<extensions>
+					<speed>4.723215579986572</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00582255147043" lon="-84.20573875155772">
+				<ele>956.7549069803208</ele>
+				<time>2017-11-13T18:08:48Z</time>
+				<extensions>
+					<speed>4.919374465942383</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005821197533118" lon="-84.20581698451008">
+				<ele>957.1938625639305</ele>
+				<time>2017-11-13T18:08:49Z</time>
+				<extensions>
+					<speed>3.9737586975097656</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005761192472155" lon="-84.20574925242128">
+				<ele>959.6521347304806</ele>
+				<time>2017-11-13T18:08:50Z</time>
+				<extensions>
+					<speed>3.1529958248138428</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005774927877821" lon="-84.20581577965416">
+				<ele>959.5713965669274</ele>
+				<time>2017-11-13T18:08:51Z</time>
+				<extensions>
+					<speed>1.463972568511963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00579564692458" lon="-84.20587828613121">
+				<ele>959.3572421781719</ele>
+				<time>2017-11-13T18:08:52Z</time>
+				<extensions>
+					<speed>0.04007450491189957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00579564692458" lon="-84.20587828613121">
+				<ele>959.3572421781719</ele>
+				<time>2017-11-13T18:08:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00579564692458" lon="-84.20587828613121">
+				<ele>959.3572421781719</ele>
+				<time>2017-11-13T18:08:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005799180683754" lon="-84.20586633435848">
+				<ele>959.3794489549473</ele>
+				<time>2017-11-13T18:08:55Z</time>
+				<extensions>
+					<speed>0.6604928970336914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005799180683754" lon="-84.20586633435848">
+				<ele>959.3794489549473</ele>
+				<time>2017-11-13T18:08:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005793377743577" lon="-84.20586795714965">
+				<ele>959.4156166091561</ele>
+				<time>2017-11-13T18:08:57Z</time>
+				<extensions>
+					<speed>0.17101514339447021</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005793377743577" lon="-84.20586795714965">
+				<ele>956.772065108642</ele>
+				<time>2017-11-13T18:08:58Z</time>
+				<extensions>
+					<speed>1.5552659034729004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005766494221277" lon="-84.20592346233063">
+				<ele>954.9474843917415</ele>
+				<time>2017-11-13T18:08:59Z</time>
+				<extensions>
+					<speed>3.087663412094116</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00574083922508" lon="-84.20596126765022">
+				<ele>953.4662615526468</ele>
+				<time>2017-11-13T18:09:00Z</time>
+				<extensions>
+					<speed>4.519285202026367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005711777998814" lon="-84.20599962036773">
+				<ele>953.073841447942</ele>
+				<time>2017-11-13T18:09:01Z</time>
+				<extensions>
+					<speed>5.52791690826416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005676718372715" lon="-84.20604066136335">
+				<ele>953.1817853739485</ele>
+				<time>2017-11-13T18:09:02Z</time>
+				<extensions>
+					<speed>6.113358497619629</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005638271050444" lon="-84.2060808944545">
+				<ele>953.3930421266705</ele>
+				<time>2017-11-13T18:09:03Z</time>
+				<extensions>
+					<speed>6.421392440795898</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005596750070552" lon="-84.20612705981561">
+				<ele>953.8799896789715</ele>
+				<time>2017-11-13T18:09:04Z</time>
+				<extensions>
+					<speed>6.718321323394775</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005540808547186" lon="-84.20617981904174">
+				<ele>953.9082964267582</ele>
+				<time>2017-11-13T18:09:05Z</time>
+				<extensions>
+					<speed>7.501553058624268</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005491016637768" lon="-84.20622568460752">
+				<ele>954.1762258345261</ele>
+				<time>2017-11-13T18:09:06Z</time>
+				<extensions>
+					<speed>7.580124378204346</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005433200892703" lon="-84.20627882542153">
+				<ele>954.229602121748</ele>
+				<time>2017-11-13T18:09:07Z</time>
+				<extensions>
+					<speed>8.03724193572998</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005370506181551" lon="-84.20634003982327">
+				<ele>954.1615345925093</ele>
+				<time>2017-11-13T18:09:08Z</time>
+				<extensions>
+					<speed>8.761037826538086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005309075390883" lon="-84.2063988427922">
+				<ele>954.1054080314934</ele>
+				<time>2017-11-13T18:09:09Z</time>
+				<extensions>
+					<speed>9.192728996276855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005245733824628" lon="-84.20645120683784">
+				<ele>953.9645813638344</ele>
+				<time>2017-11-13T18:09:10Z</time>
+				<extensions>
+					<speed>9.180525779724121</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005180646313976" lon="-84.20650529108974">
+				<ele>954.039135305211</ele>
+				<time>2017-11-13T18:09:11Z</time>
+				<extensions>
+					<speed>9.1344633102417</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005137257131883" lon="-84.20654991758616">
+				<ele>954.2033706409857</ele>
+				<time>2017-11-13T18:09:12Z</time>
+				<extensions>
+					<speed>8.494919776916504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005090148920212" lon="-84.20658387715677">
+				<ele>954.0125550525263</ele>
+				<time>2017-11-13T18:09:13Z</time>
+				<extensions>
+					<speed>7.6413164138793945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005056480681642" lon="-84.20661769381398">
+				<ele>953.8412168510258</ele>
+				<time>2017-11-13T18:09:14Z</time>
+				<extensions>
+					<speed>6.855718612670898</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005017096885833" lon="-84.20665327677462">
+				<ele>953.4616521103308</ele>
+				<time>2017-11-13T18:09:15Z</time>
+				<extensions>
+					<speed>6.3023881912231445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004975526053535" lon="-84.20667678954574">
+				<ele>952.9377415003255</ele>
+				<time>2017-11-13T18:09:16Z</time>
+				<extensions>
+					<speed>5.167653560638428</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004950715043464" lon="-84.20666717483141">
+				<ele>952.6350961402059</ele>
+				<time>2017-11-13T18:09:17Z</time>
+				<extensions>
+					<speed>3.6463005542755127</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00492476619893" lon="-84.20665038810739">
+				<ele>952.4639308108017</ele>
+				<time>2017-11-13T18:09:18Z</time>
+				<extensions>
+					<speed>3.2084813117980957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004892290760125" lon="-84.20663364483305">
+				<ele>952.2925236560404</ele>
+				<time>2017-11-13T18:09:19Z</time>
+				<extensions>
+					<speed>3.4737942218780518</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004865998658806" lon="-84.20660453152495">
+				<ele>952.2500341311097</ele>
+				<time>2017-11-13T18:09:20Z</time>
+				<extensions>
+					<speed>3.9201455116271973</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004831309106942" lon="-84.2065716365026">
+				<ele>952.0827310262248</ele>
+				<time>2017-11-13T18:09:21Z</time>
+				<extensions>
+					<speed>4.2632341384887695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004801190480357" lon="-84.20653695313636">
+				<ele>952.0948584033176</ele>
+				<time>2017-11-13T18:09:22Z</time>
+				<extensions>
+					<speed>4.5008158683776855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004766871686884" lon="-84.20650631450292">
+				<ele>952.05396710895</ele>
+				<time>2017-11-13T18:09:23Z</time>
+				<extensions>
+					<speed>4.6596903800964355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004727227718337" lon="-84.20647949144436">
+				<ele>952.0044044982642</ele>
+				<time>2017-11-13T18:09:24Z</time>
+				<extensions>
+					<speed>4.799752235412598</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004686204397522" lon="-84.20645770926535">
+				<ele>952.0320968423039</ele>
+				<time>2017-11-13T18:09:25Z</time>
+				<extensions>
+					<speed>4.947901725769043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004627531919592" lon="-84.20640563221704">
+				<ele>951.6320317490026</ele>
+				<time>2017-11-13T18:09:26Z</time>
+				<extensions>
+					<speed>6.050538063049316</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004586226612904" lon="-84.20638366075362">
+				<ele>951.4014378432184</ele>
+				<time>2017-11-13T18:09:27Z</time>
+				<extensions>
+					<speed>6.024885177612305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004538883540551" lon="-84.20635493210708">
+				<ele>951.1547236749902</ele>
+				<time>2017-11-13T18:09:28Z</time>
+				<extensions>
+					<speed>6.126251697540283</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004489630975298" lon="-84.20632739661555">
+				<ele>950.9268168676645</ele>
+				<time>2017-11-13T18:09:29Z</time>
+				<extensions>
+					<speed>6.051218032836914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004399953373401" lon="-84.20631148882507">
+				<ele>950.7785691739991</ele>
+				<time>2017-11-13T18:09:30Z</time>
+				<extensions>
+					<speed>5.609408855438232</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004365094832021" lon="-84.20630225942996">
+				<ele>950.6255662925541</ele>
+				<time>2017-11-13T18:09:31Z</time>
+				<extensions>
+					<speed>4.544490814208984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00436351141676" lon="-84.20629705756674">
+				<ele>950.545847736299</ele>
+				<time>2017-11-13T18:09:32Z</time>
+				<extensions>
+					<speed>3.635970115661621</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004375398141537" lon="-84.20626669111027">
+				<ele>950.2749803252518</ele>
+				<time>2017-11-13T18:09:33Z</time>
+				<extensions>
+					<speed>4.53119421005249</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00440440750015" lon="-84.20623898414803">
+				<ele>949.9511227970943</ele>
+				<time>2017-11-13T18:09:34Z</time>
+				<extensions>
+					<speed>5.08405065536499</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00444942511039" lon="-84.20620160786478">
+				<ele>949.6481936788186</ele>
+				<time>2017-11-13T18:09:35Z</time>
+				<extensions>
+					<speed>5.650840759277344</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004498972693554" lon="-84.20615459108033">
+				<ele>949.5544226178899</ele>
+				<time>2017-11-13T18:09:36Z</time>
+				<extensions>
+					<speed>6.597332000732422</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004544535929488" lon="-84.20609284714625">
+				<ele>949.4201663406566</ele>
+				<time>2017-11-13T18:09:37Z</time>
+				<extensions>
+					<speed>6.924729347229004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004586366594818" lon="-84.20603183583425">
+				<ele>949.0254731429741</ele>
+				<time>2017-11-13T18:09:38Z</time>
+				<extensions>
+					<speed>6.912513256072998</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00463145489264" lon="-84.20597219263773">
+				<ele>948.6512798657641</ele>
+				<time>2017-11-13T18:09:39Z</time>
+				<extensions>
+					<speed>7.049720287322998</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004680983561673" lon="-84.20591752807734">
+				<ele>948.4350419258699</ele>
+				<time>2017-11-13T18:09:40Z</time>
+				<extensions>
+					<speed>7.220620155334473</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004729123468865" lon="-84.20586173853317">
+				<ele>947.8644409840927</ele>
+				<time>2017-11-13T18:09:41Z</time>
+				<extensions>
+					<speed>7.355294227600098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004781552596489" lon="-84.20580215707285">
+				<ele>947.5865758536384</ele>
+				<time>2017-11-13T18:09:42Z</time>
+				<extensions>
+					<speed>7.576025009155273</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004834802418532" lon="-84.20575343820066">
+				<ele>947.3854750692844</ele>
+				<time>2017-11-13T18:09:43Z</time>
+				<extensions>
+					<speed>7.629427433013916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004889385365699" lon="-84.20570080965454">
+				<ele>947.2221385119483</ele>
+				<time>2017-11-13T18:09:44Z</time>
+				<extensions>
+					<speed>7.702608108520508</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004945709358703" lon="-84.20565504275604">
+				<ele>946.9134178450331</ele>
+				<time>2017-11-13T18:09:45Z</time>
+				<extensions>
+					<speed>7.725485324859619</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004993075375586" lon="-84.20562294760403">
+				<ele>946.371392856352</ele>
+				<time>2017-11-13T18:09:46Z</time>
+				<extensions>
+					<speed>7.541568279266357</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00502938725485" lon="-84.20558007470802">
+				<ele>945.7908964408562</ele>
+				<time>2017-11-13T18:09:47Z</time>
+				<extensions>
+					<speed>7.281661510467529</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005061214539456" lon="-84.20553720560939">
+				<ele>945.5986740114167</ele>
+				<time>2017-11-13T18:09:48Z</time>
+				<extensions>
+					<speed>7.097675323486328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005085565827299" lon="-84.20549829649717">
+				<ele>945.3919377978891</ele>
+				<time>2017-11-13T18:09:49Z</time>
+				<extensions>
+					<speed>6.8917646408081055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005106444323882" lon="-84.20544918677247">
+				<ele>945.3514933213592</ele>
+				<time>2017-11-13T18:09:50Z</time>
+				<extensions>
+					<speed>6.644283294677734</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005130061827872" lon="-84.20540157543903">
+				<ele>945.2503392305225</ele>
+				<time>2017-11-13T18:09:51Z</time>
+				<extensions>
+					<speed>6.604723930358887</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005149797833772" lon="-84.20535227086354">
+				<ele>945.1806411109865</ele>
+				<time>2017-11-13T18:09:52Z</time>
+				<extensions>
+					<speed>6.606443881988525</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00516418352339" lon="-84.20530097637295">
+				<ele>945.1812825016677</ele>
+				<time>2017-11-13T18:09:53Z</time>
+				<extensions>
+					<speed>6.554163455963135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005183520369561" lon="-84.20524779714596">
+				<ele>945.2132169594988</ele>
+				<time>2017-11-13T18:09:54Z</time>
+				<extensions>
+					<speed>6.241147041320801</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005204587218602" lon="-84.20520241253931">
+				<ele>945.2363950703293</ele>
+				<time>2017-11-13T18:09:55Z</time>
+				<extensions>
+					<speed>5.7714409828186035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005224568190235" lon="-84.20516410034153">
+				<ele>945.186464461498</ele>
+				<time>2017-11-13T18:09:56Z</time>
+				<extensions>
+					<speed>5.202157974243164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00523496050134" lon="-84.2051354583633">
+				<ele>945.1476696887985</ele>
+				<time>2017-11-13T18:09:57Z</time>
+				<extensions>
+					<speed>4.468267440795898</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00524955266279" lon="-84.20510302154706">
+				<ele>945.1184995640069</ele>
+				<time>2017-11-13T18:09:58Z</time>
+				<extensions>
+					<speed>4.146681308746338</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005261177875852" lon="-84.20507324911743">
+				<ele>945.1593419490382</ele>
+				<time>2017-11-13T18:09:59Z</time>
+				<extensions>
+					<speed>3.905520439147949</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005272157184084" lon="-84.20505023963149">
+				<ele>945.169111289084</ele>
+				<time>2017-11-13T18:10:00Z</time>
+				<extensions>
+					<speed>3.5874202251434326</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005287924497033" lon="-84.20502309814648">
+				<ele>945.1957517052069</ele>
+				<time>2017-11-13T18:10:01Z</time>
+				<extensions>
+					<speed>3.5309314727783203</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297511753785" lon="-84.20500494300505">
+				<ele>944.9685126636177</ele>
+				<time>2017-11-13T18:10:02Z</time>
+				<extensions>
+					<speed>3.356104850769043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005295333542898" lon="-84.20499929008807">
+				<ele>944.5587547821924</ele>
+				<time>2017-11-13T18:10:03Z</time>
+				<extensions>
+					<speed>2.9604811668395996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005293522608275" lon="-84.20499060735278">
+				<ele>944.289073205553</ele>
+				<time>2017-11-13T18:10:04Z</time>
+				<extensions>
+					<speed>2.7284979820251465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00528833642532" lon="-84.20500334230891">
+				<ele>943.8279782123864</ele>
+				<time>2017-11-13T18:10:05Z</time>
+				<extensions>
+					<speed>2.1339080333709717</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005292219283788" lon="-84.20500110784533">
+				<ele>943.4353802287951</ele>
+				<time>2017-11-13T18:10:06Z</time>
+				<extensions>
+					<speed>1.969422698020935</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005299416358058" lon="-84.20498701655954">
+				<ele>943.2493800548837</ele>
+				<time>2017-11-13T18:10:07Z</time>
+				<extensions>
+					<speed>1.9907699823379517</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005302882815293" lon="-84.20497360892433">
+				<ele>942.9636041196063</ele>
+				<time>2017-11-13T18:10:08Z</time>
+				<extensions>
+					<speed>1.9865267276763916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00530749811355" lon="-84.20496259340007">
+				<ele>942.8137224409729</ele>
+				<time>2017-11-13T18:10:09Z</time>
+				<extensions>
+					<speed>1.9064545631408691</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005317308561409" lon="-84.2049476579188">
+				<ele>942.4999450091273</ele>
+				<time>2017-11-13T18:10:10Z</time>
+				<extensions>
+					<speed>1.8845216035842896</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005332048483297" lon="-84.2049311869803">
+				<ele>941.6592190833762</ele>
+				<time>2017-11-13T18:10:11Z</time>
+				<extensions>
+					<speed>1.9746456146240234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00535481870684" lon="-84.20489863791147">
+				<ele>941.3167540868744</ele>
+				<time>2017-11-13T18:10:12Z</time>
+				<extensions>
+					<speed>2.293003559112549</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005383383208232" lon="-84.20485268088694">
+				<ele>940.9513078611344</ele>
+				<time>2017-11-13T18:10:13Z</time>
+				<extensions>
+					<speed>2.9194819927215576</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00542877995732" lon="-84.20481609588869">
+				<ele>940.6895999815315</ele>
+				<time>2017-11-13T18:10:15Z</time>
+				<extensions>
+					<speed>3.0157361030578613</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00544197851305" lon="-84.2048019532731">
+				<ele>939.7078481251374</ele>
+				<time>2017-11-13T18:10:16Z</time>
+				<extensions>
+					<speed>2.9723994731903076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005465897214192" lon="-84.20479534740677">
+				<ele>938.122322037816</ele>
+				<time>2017-11-13T18:10:17Z</time>
+				<extensions>
+					<speed>3.0829052925109863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005479659065053" lon="-84.20479774243663">
+				<ele>936.4253840306774</ele>
+				<time>2017-11-13T18:10:18Z</time>
+				<extensions>
+					<speed>3.3987314701080322</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005489924588282" lon="-84.20479583290071">
+				<ele>935.9039865639061</ele>
+				<time>2017-11-13T18:10:19Z</time>
+				<extensions>
+					<speed>3.1398346424102783</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005495860255547" lon="-84.2047957776699">
+				<ele>935.3044562637806</ele>
+				<time>2017-11-13T18:10:20Z</time>
+				<extensions>
+					<speed>3.076575994491577</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005506289861957" lon="-84.20479435526873">
+				<ele>934.87978384085</ele>
+				<time>2017-11-13T18:10:21Z</time>
+				<extensions>
+					<speed>3.1506898403167725</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005521543533918" lon="-84.20478238456772">
+				<ele>934.2879917928949</ele>
+				<time>2017-11-13T18:10:22Z</time>
+				<extensions>
+					<speed>3.0280182361602783</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00553766501599" lon="-84.20477204361839">
+				<ele>930.9862912902609</ele>
+				<time>2017-11-13T18:10:23Z</time>
+				<extensions>
+					<speed>3.0219106674194336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005558099618337" lon="-84.20473729938621">
+				<ele>930.4571758974344</ele>
+				<time>2017-11-13T18:10:24Z</time>
+				<extensions>
+					<speed>3.2585091590881348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005583390674838" lon="-84.20470599729101">
+				<ele>929.8752793110907</ele>
+				<time>2017-11-13T18:10:25Z</time>
+				<extensions>
+					<speed>3.590503215789795</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005611250056722" lon="-84.20468048981793">
+				<ele>929.3482730546966</ele>
+				<time>2017-11-13T18:10:26Z</time>
+				<extensions>
+					<speed>3.8026790618896484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005631675102" lon="-84.20465131962422">
+				<ele>928.8802262693644</ele>
+				<time>2017-11-13T18:10:27Z</time>
+				<extensions>
+					<speed>3.810533285140991</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005656921378392" lon="-84.2046180587289">
+				<ele>928.6861498299986</ele>
+				<time>2017-11-13T18:10:28Z</time>
+				<extensions>
+					<speed>4.058575630187988</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005679560627023" lon="-84.20457976535143">
+				<ele>928.1724784206599</ele>
+				<time>2017-11-13T18:10:29Z</time>
+				<extensions>
+					<speed>4.36068868637085</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005706117970776" lon="-84.20454692740273">
+				<ele>927.9454298904166</ele>
+				<time>2017-11-13T18:10:30Z</time>
+				<extensions>
+					<speed>4.458064556121826</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005731688194091" lon="-84.20451626535964">
+				<ele>927.7626018030569</ele>
+				<time>2017-11-13T18:10:31Z</time>
+				<extensions>
+					<speed>4.496907711029053</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00575564351092" lon="-84.20448436841568">
+				<ele>927.4077953035012</ele>
+				<time>2017-11-13T18:10:32Z</time>
+				<extensions>
+					<speed>4.493901252746582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005778204211682" lon="-84.20445046977211">
+				<ele>927.2999212574214</ele>
+				<time>2017-11-13T18:10:33Z</time>
+				<extensions>
+					<speed>4.822153091430664</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005799070939888" lon="-84.20442434458144">
+				<ele>927.2196346428245</ele>
+				<time>2017-11-13T18:10:34Z</time>
+				<extensions>
+					<speed>5.059030055999756</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005827751706455" lon="-84.20439069799825">
+				<ele>927.359317669645</ele>
+				<time>2017-11-13T18:10:35Z</time>
+				<extensions>
+					<speed>5.342686176300049</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005853934139681" lon="-84.20435754386983">
+				<ele>927.4014887707308</ele>
+				<time>2017-11-13T18:10:36Z</time>
+				<extensions>
+					<speed>5.309148788452148</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005878990469453" lon="-84.20432752025903">
+				<ele>927.5869180792943</ele>
+				<time>2017-11-13T18:10:37Z</time>
+				<extensions>
+					<speed>4.877956867218018</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005905931865922" lon="-84.20429634289174">
+				<ele>927.382162780501</ele>
+				<time>2017-11-13T18:10:38Z</time>
+				<extensions>
+					<speed>4.2943196296691895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005929992768182" lon="-84.20426853847418">
+				<ele>927.2187665523961</ele>
+				<time>2017-11-13T18:10:39Z</time>
+				<extensions>
+					<speed>4.02000617980957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005953232144991" lon="-84.20424199470531">
+				<ele>926.9499795446172</ele>
+				<time>2017-11-13T18:10:40Z</time>
+				<extensions>
+					<speed>3.829491376876831</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005969676630295" lon="-84.20422393122915">
+				<ele>926.5835969727486</ele>
+				<time>2017-11-13T18:10:41Z</time>
+				<extensions>
+					<speed>3.140068769454956</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005985885788313" lon="-84.20420585586596">
+				<ele>926.4089930104092</ele>
+				<time>2017-11-13T18:10:42Z</time>
+				<extensions>
+					<speed>2.8581745624542236</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00599976934749" lon="-84.20419279804082">
+				<ele>926.1077684499323</ele>
+				<time>2017-11-13T18:10:43Z</time>
+				<extensions>
+					<speed>2.6198909282684326</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00599916979412" lon="-84.20418674953606">
+				<ele>925.672490471974</ele>
+				<time>2017-11-13T18:10:44Z</time>
+				<extensions>
+					<speed>2.02260684967041</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005991840903423" lon="-84.2041925936996">
+				<ele>925.0383438076824</ele>
+				<time>2017-11-13T18:10:45Z</time>
+				<extensions>
+					<speed>1.3132762908935547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00598151027985" lon="-84.2042023647107">
+				<ele>924.5281039150432</ele>
+				<time>2017-11-13T18:10:46Z</time>
+				<extensions>
+					<speed>0.6906390190124512</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005977583320293" lon="-84.20421360992344">
+				<ele>924.2086825566366</ele>
+				<time>2017-11-13T18:10:47Z</time>
+				<extensions>
+					<speed>0.7296600937843323</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005973069307204" lon="-84.20422291769783">
+				<ele>923.8779194951057</ele>
+				<time>2017-11-13T18:10:48Z</time>
+				<extensions>
+					<speed>0.5745505690574646</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005968531778617" lon="-84.20422705800975">
+				<ele>923.5653644939885</ele>
+				<time>2017-11-13T18:10:49Z</time>
+				<extensions>
+					<speed>0.515558660030365</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005964790934847" lon="-84.20423582294981">
+				<ele>922.9711900744587</ele>
+				<time>2017-11-13T18:10:50Z</time>
+				<extensions>
+					<speed>0.5442137718200684</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005964605836951" lon="-84.20423672840192">
+				<ele>922.6418470963836</ele>
+				<time>2017-11-13T18:10:51Z</time>
+				<extensions>
+					<speed>0.35440170764923096</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005966732608968" lon="-84.20423424253941">
+				<ele>922.3193067722023</ele>
+				<time>2017-11-13T18:10:52Z</time>
+				<extensions>
+					<speed>0.09238004684448242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005964054446482" lon="-84.20423886204738">
+				<ele>921.8164264792576</ele>
+				<time>2017-11-13T18:10:53Z</time>
+				<extensions>
+					<speed>0.10607904940843582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005966115945148" lon="-84.20423695838818">
+				<ele>921.4297338817269</ele>
+				<time>2017-11-13T18:10:54Z</time>
+				<extensions>
+					<speed>0.11926326900720596</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005962958796756" lon="-84.20423335436506">
+				<ele>920.983051257208</ele>
+				<time>2017-11-13T18:10:55Z</time>
+				<extensions>
+					<speed>0.023952022194862366</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005962958796756" lon="-84.20423335436506">
+				<ele>920.3231411771849</ele>
+				<time>2017-11-13T18:10:56Z</time>
+				<extensions>
+					<speed>0.12224864214658737</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005962958796756" lon="-84.20423335436506">
+				<ele>919.9744294052944</ele>
+				<time>2017-11-13T18:10:57Z</time>
+				<extensions>
+					<speed>0.1621302217245102</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005962958796756" lon="-84.20423335436506">
+				<ele>919.5784440310672</ele>
+				<time>2017-11-13T18:10:58Z</time>
+				<extensions>
+					<speed>0.19821366667747498</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005895466563048" lon="-84.20427000556003">
+				<ele>923.4712451100349</ele>
+				<time>2017-11-13T18:10:59Z</time>
+				<extensions>
+					<speed>0.4499674439430237</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005891978032443" lon="-84.20427146047767">
+				<ele>923.3298579081893</ele>
+				<time>2017-11-13T18:11:00Z</time>
+				<extensions>
+					<speed>0.3588835597038269</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005901815397886" lon="-84.20425953571113">
+				<ele>923.0651639932767</ele>
+				<time>2017-11-13T18:11:01Z</time>
+				<extensions>
+					<speed>0.05566781386733055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005901573812828" lon="-84.2042595263206">
+				<ele>922.4120108978823</ele>
+				<time>2017-11-13T18:11:02Z</time>
+				<extensions>
+					<speed>0.48780736327171326</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005902770212264" lon="-84.20425565197425">
+				<ele>921.4065646780655</ele>
+				<time>2017-11-13T18:11:03Z</time>
+				<extensions>
+					<speed>0.6471741199493408</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005907777455745" lon="-84.20424685170408">
+				<ele>920.4330152096227</ele>
+				<time>2017-11-13T18:11:04Z</time>
+				<extensions>
+					<speed>0.8153019547462463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005908861356321" lon="-84.20424195460173">
+				<ele>919.3780913949013</ele>
+				<time>2017-11-13T18:11:05Z</time>
+				<extensions>
+					<speed>0.7132238149642944</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005905445492608" lon="-84.2042417114883">
+				<ele>918.696220561862</ele>
+				<time>2017-11-13T18:11:06Z</time>
+				<extensions>
+					<speed>0.7523345351219177</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005907611873988" lon="-84.20424045378036">
+				<ele>918.9727641381323</ele>
+				<time>2017-11-13T18:11:07Z</time>
+				<extensions>
+					<speed>0.8394795060157776</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005905291780723" lon="-84.20424209021826">
+				<ele>917.8678126586601</ele>
+				<time>2017-11-13T18:11:08Z</time>
+				<extensions>
+					<speed>0.7745002508163452</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005904949954274" lon="-84.20423825517835">
+				<ele>916.9442692883313</ele>
+				<time>2017-11-13T18:11:09Z</time>
+				<extensions>
+					<speed>0.612736701965332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005910336741566" lon="-84.20423078418438">
+				<ele>916.2510684868321</ele>
+				<time>2017-11-13T18:11:10Z</time>
+				<extensions>
+					<speed>0.774516224861145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005919986125283" lon="-84.20422351537789">
+				<ele>914.5178280407563</ele>
+				<time>2017-11-13T18:11:11Z</time>
+				<extensions>
+					<speed>1.3811554908752441</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00593562829315" lon="-84.20421002920762">
+				<ele>913.3703731987625</ele>
+				<time>2017-11-13T18:11:12Z</time>
+				<extensions>
+					<speed>2.009080410003662</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005959886244948" lon="-84.20419237550351">
+				<ele>913.0021532792598</ele>
+				<time>2017-11-13T18:11:13Z</time>
+				<extensions>
+					<speed>2.8938791751861572</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0059894963462" lon="-84.20416614183124">
+				<ele>912.3104505315423</ele>
+				<time>2017-11-13T18:11:14Z</time>
+				<extensions>
+					<speed>3.7790892124176025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00602072217751" lon="-84.20413309313876">
+				<ele>910.6158090531826</ele>
+				<time>2017-11-13T18:11:15Z</time>
+				<extensions>
+					<speed>4.854640007019043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006052721710141" lon="-84.20409871644385">
+				<ele>909.8101190617308</ele>
+				<time>2017-11-13T18:11:16Z</time>
+				<extensions>
+					<speed>5.023238182067871</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00608210982564" lon="-84.2040615999704">
+				<ele>908.3905817642808</ele>
+				<time>2017-11-13T18:11:17Z</time>
+				<extensions>
+					<speed>5.089588642120361</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006107255254198" lon="-84.2040269888123">
+				<ele>907.7138512460515</ele>
+				<time>2017-11-13T18:11:18Z</time>
+				<extensions>
+					<speed>4.7851176261901855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006115099117062" lon="-84.20400470985">
+				<ele>907.2694883197546</ele>
+				<time>2017-11-13T18:11:19Z</time>
+				<extensions>
+					<speed>3.6993250846862793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00611728090669" lon="-84.20398283840152">
+				<ele>906.6369817443192</ele>
+				<time>2017-11-13T18:11:20Z</time>
+				<extensions>
+					<speed>2.1053836345672607</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00611932314837" lon="-84.20396951478807">
+				<ele>906.5826134355739</ele>
+				<time>2017-11-13T18:11:21Z</time>
+				<extensions>
+					<speed>1.0804955959320068</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00612562360468" lon="-84.2039684372183">
+				<ele>905.9841245319694</ele>
+				<time>2017-11-13T18:11:22Z</time>
+				<extensions>
+					<speed>0.7962506413459778</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00612562360468" lon="-84.2039684372183">
+				<ele>905.9841245319694</ele>
+				<time>2017-11-13T18:11:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006143128141867" lon="-84.20396470034069">
+				<ele>905.8652625698596</ele>
+				<time>2017-11-13T18:11:24Z</time>
+				<extensions>
+					<speed>1.1796061992645264</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006169200586811" lon="-84.20396285456391">
+				<ele>905.9535127021372</ele>
+				<time>2017-11-13T18:11:25Z</time>
+				<extensions>
+					<speed>2.044745683670044</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006204955682865" lon="-84.20396623341752">
+				<ele>906.0551065076143</ele>
+				<time>2017-11-13T18:11:26Z</time>
+				<extensions>
+					<speed>3.252997636795044</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006242740821365" lon="-84.20399260911451">
+				<ele>905.6965959621593</ele>
+				<time>2017-11-13T18:11:27Z</time>
+				<extensions>
+					<speed>4.4145355224609375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006287687684567" lon="-84.20402710595216">
+				<ele>905.2765261819586</ele>
+				<time>2017-11-13T18:11:28Z</time>
+				<extensions>
+					<speed>5.235660552978516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006345451357982" lon="-84.20406690417971">
+				<ele>905.6423537861556</ele>
+				<time>2017-11-13T18:11:29Z</time>
+				<extensions>
+					<speed>5.972455978393555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0064050854375" lon="-84.20411675088982">
+				<ele>905.9161036517471</ele>
+				<time>2017-11-13T18:11:30Z</time>
+				<extensions>
+					<speed>6.633078575134277</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006472594472884" lon="-84.2041688908397">
+				<ele>906.1500105448067</ele>
+				<time>2017-11-13T18:11:31Z</time>
+				<extensions>
+					<speed>7.272068023681641</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006539522219123" lon="-84.2042281165162">
+				<ele>906.0463041309267</ele>
+				<time>2017-11-13T18:11:32Z</time>
+				<extensions>
+					<speed>7.807611465454102</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006605619622858" lon="-84.20427997059758">
+				<ele>906.0541667211801</ele>
+				<time>2017-11-13T18:11:33Z</time>
+				<extensions>
+					<speed>7.947964668273926</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006658753240451" lon="-84.20433203056825">
+				<ele>906.0149683570489</ele>
+				<time>2017-11-13T18:11:34Z</time>
+				<extensions>
+					<speed>7.748003959655762</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00670965782702" lon="-84.20437255160392">
+				<ele>905.9424404231831</ele>
+				<time>2017-11-13T18:11:35Z</time>
+				<extensions>
+					<speed>7.3042144775390625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006744662403545" lon="-84.2043948690525">
+				<ele>905.8189753834158</ele>
+				<time>2017-11-13T18:11:36Z</time>
+				<extensions>
+					<speed>6.312169075012207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006779880804048" lon="-84.20443076930607">
+				<ele>905.6959693962708</ele>
+				<time>2017-11-13T18:11:37Z</time>
+				<extensions>
+					<speed>5.949356555938721</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006802032875378" lon="-84.204444009689">
+				<ele>905.8765766853467</ele>
+				<time>2017-11-13T18:11:38Z</time>
+				<extensions>
+					<speed>4.825845718383789</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006809841968531" lon="-84.20444333393888">
+				<ele>905.3379747867584</ele>
+				<time>2017-11-13T18:11:39Z</time>
+				<extensions>
+					<speed>3.7920682430267334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006808048361343" lon="-84.20442241203018">
+				<ele>905.3227850925177</ele>
+				<time>2017-11-13T18:11:40Z</time>
+				<extensions>
+					<speed>2.0172507762908936</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006815775450097" lon="-84.20442613503663">
+				<ele>905.6465886402875</ele>
+				<time>2017-11-13T18:11:41Z</time>
+				<extensions>
+					<speed>1.586391806602478</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006808573932139" lon="-84.20439598245525">
+				<ele>906.1695148767903</ele>
+				<time>2017-11-13T18:11:42Z</time>
+				<extensions>
+					<speed>0.2568247318267822</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006800742006751" lon="-84.20438407247435">
+				<ele>906.1231666784734</ele>
+				<time>2017-11-13T18:11:43Z</time>
+				<extensions>
+					<speed>0.5642646551132202</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006785027272977" lon="-84.2043723470328">
+				<ele>905.5628317240626</ele>
+				<time>2017-11-13T18:11:44Z</time>
+				<extensions>
+					<speed>1.0691003799438477</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006779781882386" lon="-84.20436931020596">
+				<ele>904.9902681475505</ele>
+				<time>2017-11-13T18:11:45Z</time>
+				<extensions>
+					<speed>1.0720998048782349</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006782946573264" lon="-84.20437299580615">
+				<ele>905.0143456347287</ele>
+				<time>2017-11-13T18:11:46Z</time>
+				<extensions>
+					<speed>0.618426501750946</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006786808674073" lon="-84.20437716105047">
+				<ele>905.0423999903724</ele>
+				<time>2017-11-13T18:11:47Z</time>
+				<extensions>
+					<speed>0.09787680208683014</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006792345009051" lon="-84.20437900168734">
+				<ele>905.2431393703446</ele>
+				<time>2017-11-13T18:11:48Z</time>
+				<extensions>
+					<speed>0.09397236257791519</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006799027557395" lon="-84.20437265516586">
+				<ele>905.1212089685723</ele>
+				<time>2017-11-13T18:11:49Z</time>
+				<extensions>
+					<speed>0.2517145276069641</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006805593435098" lon="-84.20436750405436">
+				<ele>905.0629308754578</ele>
+				<time>2017-11-13T18:11:50Z</time>
+				<extensions>
+					<speed>0.2888394892215729</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006812796302942" lon="-84.20436579425282">
+				<ele>905.6563736703247</ele>
+				<time>2017-11-13T18:11:51Z</time>
+				<extensions>
+					<speed>0.3642808198928833</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006830354717557" lon="-84.20438911638455">
+				<ele>906.5571305165067</ele>
+				<time>2017-11-13T18:11:52Z</time>
+				<extensions>
+					<speed>0.817411482334137</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006845298307626" lon="-84.20440823381401">
+				<ele>907.8827804820612</ele>
+				<time>2017-11-13T18:11:53Z</time>
+				<extensions>
+					<speed>1.1318038702011108</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006869019910368" lon="-84.20443726123528">
+				<ele>908.6730602476746</ele>
+				<time>2017-11-13T18:11:54Z</time>
+				<extensions>
+					<speed>2.129425048828125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00689255267222" lon="-84.20446356730861">
+				<ele>909.0155065385625</ele>
+				<time>2017-11-13T18:11:55Z</time>
+				<extensions>
+					<speed>2.8210699558258057</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006916334166833" lon="-84.20448775124217">
+				<ele>909.4480510763824</ele>
+				<time>2017-11-13T18:11:56Z</time>
+				<extensions>
+					<speed>3.208862066268921</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00694114433014" lon="-84.20450303996265">
+				<ele>909.9681482454762</ele>
+				<time>2017-11-13T18:11:57Z</time>
+				<extensions>
+					<speed>3.3132870197296143</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006971435102779" lon="-84.20452738502415">
+				<ele>910.3172801807523</ele>
+				<time>2017-11-13T18:11:58Z</time>
+				<extensions>
+					<speed>3.8792266845703125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006998471836987" lon="-84.20454499523663">
+				<ele>910.5704065049067</ele>
+				<time>2017-11-13T18:11:59Z</time>
+				<extensions>
+					<speed>3.8510658740997314</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007029359287296" lon="-84.20457479063273">
+				<ele>910.9474285766482</ele>
+				<time>2017-11-13T18:12:00Z</time>
+				<extensions>
+					<speed>4.122939109802246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007057103600658" lon="-84.20460022472433">
+				<ele>911.1788947265595</ele>
+				<time>2017-11-13T18:12:01Z</time>
+				<extensions>
+					<speed>4.081764221191406</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007085707394172" lon="-84.20463315307178">
+				<ele>911.2165251830593</ele>
+				<time>2017-11-13T18:12:02Z</time>
+				<extensions>
+					<speed>4.244714736938477</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007113743113438" lon="-84.20467101782715">
+				<ele>911.5203559491783</ele>
+				<time>2017-11-13T18:12:03Z</time>
+				<extensions>
+					<speed>4.372182846069336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007135864249802" lon="-84.20469941080982">
+				<ele>912.409216134809</ele>
+				<time>2017-11-13T18:12:04Z</time>
+				<extensions>
+					<speed>3.900385618209839</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00715338530377" lon="-84.20472530709003">
+				<ele>912.6900314763188</ele>
+				<time>2017-11-13T18:12:05Z</time>
+				<extensions>
+					<speed>3.594496726989746</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00715985826845" lon="-84.20472549510603">
+				<ele>913.0880737537518</ele>
+				<time>2017-11-13T18:12:06Z</time>
+				<extensions>
+					<speed>2.8545777797698975</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0071631741661" lon="-84.20471689844304">
+				<ele>913.670948590152</ele>
+				<time>2017-11-13T18:12:07Z</time>
+				<extensions>
+					<speed>2.0723941326141357</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007167118335145" lon="-84.20471365596532">
+				<ele>913.968287056312</ele>
+				<time>2017-11-13T18:12:08Z</time>
+				<extensions>
+					<speed>1.525352120399475</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007171982659486" lon="-84.20471298402286">
+				<ele>914.153344062157</ele>
+				<time>2017-11-13T18:12:09Z</time>
+				<extensions>
+					<speed>1.3043889999389648</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007173298184323" lon="-84.20471166543624">
+				<ele>914.3690529437736</ele>
+				<time>2017-11-13T18:12:10Z</time>
+				<extensions>
+					<speed>1.0958750247955322</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007178553959095" lon="-84.20469947857919">
+				<ele>914.688893721439</ele>
+				<time>2017-11-13T18:12:11Z</time>
+				<extensions>
+					<speed>1.136384129524231</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007178135343949" lon="-84.2046550473687">
+				<ele>915.7975549222901</ele>
+				<time>2017-11-13T18:12:12Z</time>
+				<extensions>
+					<speed>1.3358759880065918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007196122617348" lon="-84.20462368099378">
+				<ele>917.1793005112559</ele>
+				<time>2017-11-13T18:12:13Z</time>
+				<extensions>
+					<speed>2.363008499145508</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007221209972126" lon="-84.20461230139234">
+				<ele>917.5560885816813</ele>
+				<time>2017-11-13T18:12:14Z</time>
+				<extensions>
+					<speed>2.991901159286499</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007243229123107" lon="-84.20458849316068">
+				<ele>918.1277016233653</ele>
+				<time>2017-11-13T18:12:15Z</time>
+				<extensions>
+					<speed>3.060279369354248</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007278877967671" lon="-84.20458023411614">
+				<ele>918.6518861837685</ele>
+				<time>2017-11-13T18:12:16Z</time>
+				<extensions>
+					<speed>3.2440834045410156</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007310339789578" lon="-84.2045582893568">
+				<ele>918.9835911877453</ele>
+				<time>2017-11-13T18:12:17Z</time>
+				<extensions>
+					<speed>3.3633861541748047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007340601909538" lon="-84.20453891412485">
+				<ele>919.1221568314359</ele>
+				<time>2017-11-13T18:12:18Z</time>
+				<extensions>
+					<speed>3.3753371238708496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007360583994897" lon="-84.20452297027317">
+				<ele>919.1782437441871</ele>
+				<time>2017-11-13T18:12:19Z</time>
+				<extensions>
+					<speed>3.096818208694458</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007369104020446" lon="-84.20453359375581">
+				<ele>919.2274930551648</ele>
+				<time>2017-11-13T18:12:20Z</time>
+				<extensions>
+					<speed>2.1864941120147705</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00737474947112" lon="-84.20453733090348">
+				<ele>919.3691905895248</ele>
+				<time>2017-11-13T18:12:21Z</time>
+				<extensions>
+					<speed>1.384657382965088</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007364722717254" lon="-84.20452478400826">
+				<ele>919.3909951336682</ele>
+				<time>2017-11-13T18:12:22Z</time>
+				<extensions>
+					<speed>0.3353305459022522</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007347482295629" lon="-84.20452266284059">
+				<ele>919.3709998289123</ele>
+				<time>2017-11-13T18:12:23Z</time>
+				<extensions>
+					<speed>1.1092095375061035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007344784414235" lon="-84.20453529552861">
+				<ele>919.87590529304</ele>
+				<time>2017-11-13T18:12:24Z</time>
+				<extensions>
+					<speed>0.9830939173698425</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007349829271686" lon="-84.2045548038431">
+				<ele>920.4440366048366</ele>
+				<time>2017-11-13T18:12:25Z</time>
+				<extensions>
+					<speed>1.0155434608459473</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00735216637578" lon="-84.20456317964548">
+				<ele>921.0952195450664</ele>
+				<time>2017-11-13T18:12:26Z</time>
+				<extensions>
+					<speed>0.8312743902206421</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007355052361488" lon="-84.20457067277795">
+				<ele>921.4417013786733</ele>
+				<time>2017-11-13T18:12:27Z</time>
+				<extensions>
+					<speed>0.5790349245071411</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007368476456358" lon="-84.20456414372325">
+				<ele>921.8294662320986</ele>
+				<time>2017-11-13T18:12:28Z</time>
+				<extensions>
+					<speed>0.4367784857749939</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007373690051992" lon="-84.20456404226243">
+				<ele>922.5188683168963</ele>
+				<time>2017-11-13T18:12:29Z</time>
+				<extensions>
+					<speed>0.21864326298236847</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007381687184784" lon="-84.20456247990043">
+				<ele>923.4241602923721</ele>
+				<time>2017-11-13T18:12:30Z</time>
+				<extensions>
+					<speed>0.4717465341091156</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007387858450366" lon="-84.20455718299284">
+				<ele>924.0999172395095</ele>
+				<time>2017-11-13T18:12:31Z</time>
+				<extensions>
+					<speed>0.6271154284477234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007394442844134" lon="-84.20454177002811">
+				<ele>924.7276192298159</ele>
+				<time>2017-11-13T18:12:32Z</time>
+				<extensions>
+					<speed>1.2701537609100342</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007409746517304" lon="-84.20451491452386">
+				<ele>925.4722646167502</ele>
+				<time>2017-11-13T18:12:33Z</time>
+				<extensions>
+					<speed>2.5075912475585938</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007428270641396" lon="-84.2044586526857">
+				<ele>926.6398699041456</ele>
+				<time>2017-11-13T18:12:34Z</time>
+				<extensions>
+					<speed>4.485528945922852</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00746121535452" lon="-84.20441175249127">
+				<ele>927.4923908533528</ele>
+				<time>2017-11-13T18:12:35Z</time>
+				<extensions>
+					<speed>5.381500244140625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007499184008228" lon="-84.20436575367394">
+				<ele>928.1806714404374</ele>
+				<time>2017-11-13T18:12:36Z</time>
+				<extensions>
+					<speed>6.0522141456604</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00753949993267" lon="-84.20431371418066">
+				<ele>928.7496895622462</ele>
+				<time>2017-11-13T18:12:37Z</time>
+				<extensions>
+					<speed>6.292476177215576</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007583364159848" lon="-84.20427034547312">
+				<ele>928.9820874566212</ele>
+				<time>2017-11-13T18:12:38Z</time>
+				<extensions>
+					<speed>6.47215461730957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007625393398097" lon="-84.2042277741704">
+				<ele>929.4010332813486</ele>
+				<time>2017-11-13T18:12:39Z</time>
+				<extensions>
+					<speed>6.51640510559082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007678704966152" lon="-84.20418528993639">
+				<ele>929.2250728001818</ele>
+				<time>2017-11-13T18:12:40Z</time>
+				<extensions>
+					<speed>7.080495834350586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007730273352845" lon="-84.20414161238565">
+				<ele>929.1874271817505</ele>
+				<time>2017-11-13T18:12:41Z</time>
+				<extensions>
+					<speed>7.373062610626221</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007779781700986" lon="-84.2040986840125">
+				<ele>928.9603948947042</ele>
+				<time>2017-11-13T18:12:42Z</time>
+				<extensions>
+					<speed>7.502683639526367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007827360626813" lon="-84.20404932214302">
+				<ele>929.098653819412</ele>
+				<time>2017-11-13T18:12:43Z</time>
+				<extensions>
+					<speed>7.507607460021973</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007876697955789" lon="-84.20400181188964">
+				<ele>929.1352134272456</ele>
+				<time>2017-11-13T18:12:44Z</time>
+				<extensions>
+					<speed>7.70283842086792</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007924562146625" lon="-84.2039567949532">
+				<ele>929.0993226533756</ele>
+				<time>2017-11-13T18:12:45Z</time>
+				<extensions>
+					<speed>7.60511589050293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007975540912723" lon="-84.20391614518466">
+				<ele>928.9302395340055</ele>
+				<time>2017-11-13T18:12:46Z</time>
+				<extensions>
+					<speed>7.499759197235107</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008028579010233" lon="-84.20387687966064">
+				<ele>928.7574774092063</ele>
+				<time>2017-11-13T18:12:47Z</time>
+				<extensions>
+					<speed>7.617152690887451</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008089437251304" lon="-84.20383445831474">
+				<ele>928.726400770247</ele>
+				<time>2017-11-13T18:12:48Z</time>
+				<extensions>
+					<speed>7.712922096252441</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008141667571175" lon="-84.20378240801148">
+				<ele>928.7430975874886</ele>
+				<time>2017-11-13T18:12:49Z</time>
+				<extensions>
+					<speed>7.815715789794922</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008189581782707" lon="-84.20373895753048">
+				<ele>928.6617144886404</ele>
+				<time>2017-11-13T18:12:50Z</time>
+				<extensions>
+					<speed>7.576044082641602</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00823484408143" lon="-84.20369673342117">
+				<ele>928.4589164629579</ele>
+				<time>2017-11-13T18:12:51Z</time>
+				<extensions>
+					<speed>7.337299346923828</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008277634939853" lon="-84.20366024314248">
+				<ele>928.2500069299713</ele>
+				<time>2017-11-13T18:12:52Z</time>
+				<extensions>
+					<speed>7.005742073059082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008317844827776" lon="-84.20362501077778">
+				<ele>928.2083119647577</ele>
+				<time>2017-11-13T18:12:53Z</time>
+				<extensions>
+					<speed>6.6691575050354</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008358466804767" lon="-84.20359136730337">
+				<ele>928.3486003829166</ele>
+				<time>2017-11-13T18:12:54Z</time>
+				<extensions>
+					<speed>6.304075241088867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00838862816015" lon="-84.20356811841641">
+				<ele>928.9504697956145</ele>
+				<time>2017-11-13T18:12:55Z</time>
+				<extensions>
+					<speed>5.323948860168457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008419829064698" lon="-84.20354529957761">
+				<ele>929.4755929159</ele>
+				<time>2017-11-13T18:12:56Z</time>
+				<extensions>
+					<speed>4.763241291046143</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008441170873047" lon="-84.20352583671374">
+				<ele>929.9387118546292</ele>
+				<time>2017-11-13T18:12:57Z</time>
+				<extensions>
+					<speed>4.1600022315979</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008445393470057" lon="-84.20352437452901">
+				<ele>930.2283585444093</ele>
+				<time>2017-11-13T18:12:58Z</time>
+				<extensions>
+					<speed>2.7552037239074707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008455585307535" lon="-84.20352125929159">
+				<ele>930.6367904758081</ele>
+				<time>2017-11-13T18:12:59Z</time>
+				<extensions>
+					<speed>1.9844145774841309</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008461580091948" lon="-84.20351381016195">
+				<ele>930.9677297966555</ele>
+				<time>2017-11-13T18:13:00Z</time>
+				<extensions>
+					<speed>1.9231548309326172</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008467985874896" lon="-84.20348797202891">
+				<ele>931.732368263416</ele>
+				<time>2017-11-13T18:13:01Z</time>
+				<extensions>
+					<speed>2.3562119007110596</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008497771623572" lon="-84.20346740286918">
+				<ele>932.6852612504736</ele>
+				<time>2017-11-13T18:13:02Z</time>
+				<extensions>
+					<speed>3.1593968868255615</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008526615263532" lon="-84.20344274970718">
+				<ele>933.3564255377278</ele>
+				<time>2017-11-13T18:13:03Z</time>
+				<extensions>
+					<speed>3.4703755378723145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008565859040896" lon="-84.20341613416721">
+				<ele>933.7308181449771</ele>
+				<time>2017-11-13T18:13:04Z</time>
+				<extensions>
+					<speed>4.101296901702881</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008604613877155" lon="-84.20339022205205">
+				<ele>934.1257967213169</ele>
+				<time>2017-11-13T18:13:05Z</time>
+				<extensions>
+					<speed>4.602499961853027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008637434026697" lon="-84.20335018721535">
+				<ele>934.6285771168768</ele>
+				<time>2017-11-13T18:13:06Z</time>
+				<extensions>
+					<speed>4.9366655349731445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008682513237913" lon="-84.20330411475287">
+				<ele>934.9040103349835</ele>
+				<time>2017-11-13T18:13:07Z</time>
+				<extensions>
+					<speed>5.434574127197266</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008721271911355" lon="-84.20325858443675">
+				<ele>935.0635483898222</ele>
+				<time>2017-11-13T18:13:08Z</time>
+				<extensions>
+					<speed>5.6306047439575195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008754550157436" lon="-84.20321395638115">
+				<ele>935.154617164284</ele>
+				<time>2017-11-13T18:13:09Z</time>
+				<extensions>
+					<speed>5.617583751678467</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008779158915367" lon="-84.20317318822912">
+				<ele>935.3268997482955</ele>
+				<time>2017-11-13T18:13:10Z</time>
+				<extensions>
+					<speed>5.313973903656006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008818012127351" lon="-84.20313031797998">
+				<ele>935.2839201558381</ele>
+				<time>2017-11-13T18:13:11Z</time>
+				<extensions>
+					<speed>5.372391223907471</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008852284575783" lon="-84.2030980680016">
+				<ele>934.9288620408624</ele>
+				<time>2017-11-13T18:13:12Z</time>
+				<extensions>
+					<speed>5.220181465148926</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008814565173406" lon="-84.20312895321456">
+				<ele>935.0268536107615</ele>
+				<time>2017-11-13T18:13:13Z</time>
+				<extensions>
+					<speed>3.4158198833465576</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008765742380728" lon="-84.20317894978969">
+				<ele>935.4633795302361</ele>
+				<time>2017-11-13T18:13:14Z</time>
+				<extensions>
+					<speed>1.3743704557418823</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008744287580122" lon="-84.20320181877725">
+				<ele>935.6200621332973</ele>
+				<time>2017-11-13T18:13:15Z</time>
+				<extensions>
+					<speed>1.0115898847579956</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008740539664403" lon="-84.20321675251164">
+				<ele>935.4317847136408</ele>
+				<time>2017-11-13T18:13:16Z</time>
+				<extensions>
+					<speed>0.6329695582389832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008766532059756" lon="-84.20320548210991">
+				<ele>934.0903016906232</ele>
+				<time>2017-11-13T18:13:17Z</time>
+				<extensions>
+					<speed>0.3173331916332245</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008779599077348" lon="-84.20320162875355">
+				<ele>933.0233617611229</ele>
+				<time>2017-11-13T18:13:18Z</time>
+				<extensions>
+					<speed>0.32709288597106934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008783355269395" lon="-84.20319912471977">
+				<ele>932.393872750923</ele>
+				<time>2017-11-13T18:13:19Z</time>
+				<extensions>
+					<speed>0.32028013467788696</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008787116452469" lon="-84.20319182317651">
+				<ele>932.2773084295914</ele>
+				<time>2017-11-13T18:13:20Z</time>
+				<extensions>
+					<speed>0.3939354419708252</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008787843213534" lon="-84.20317964440004">
+				<ele>932.3698884090409</ele>
+				<time>2017-11-13T18:13:21Z</time>
+				<extensions>
+					<speed>0.3309890925884247</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00878980716576" lon="-84.2031675585366">
+				<ele>932.54471140448</ele>
+				<time>2017-11-13T18:13:22Z</time>
+				<extensions>
+					<speed>0.3572038412094116</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008791311071592" lon="-84.20314683153042">
+				<ele>932.8275114893913</ele>
+				<time>2017-11-13T18:13:23Z</time>
+				<extensions>
+					<speed>0.4460189938545227</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008797949736474" lon="-84.203132910976">
+				<ele>933.0080527579412</ele>
+				<time>2017-11-13T18:13:24Z</time>
+				<extensions>
+					<speed>0.5566452145576477</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008808106604189" lon="-84.20312425216942">
+				<ele>932.9471417022869</ele>
+				<time>2017-11-13T18:13:25Z</time>
+				<extensions>
+					<speed>0.6547209620475769</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008818936321294" lon="-84.20311559540707">
+				<ele>932.9789824485779</ele>
+				<time>2017-11-13T18:13:26Z</time>
+				<extensions>
+					<speed>0.7252867817878723</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008824442279419" lon="-84.20310094595288">
+				<ele>933.1174709275365</ele>
+				<time>2017-11-13T18:13:27Z</time>
+				<extensions>
+					<speed>0.7711374163627625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008830629458984" lon="-84.20308884989116">
+				<ele>933.3647993989289</ele>
+				<time>2017-11-13T18:13:28Z</time>
+				<extensions>
+					<speed>0.8076557517051697</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008860040388184" lon="-84.20308409110476">
+				<ele>933.3493907265365</ele>
+				<time>2017-11-13T18:13:29Z</time>
+				<extensions>
+					<speed>1.0462286472320557</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008884567975366" lon="-84.20308014229502">
+				<ele>933.2848587734625</ele>
+				<time>2017-11-13T18:13:30Z</time>
+				<extensions>
+					<speed>1.2064024209976196</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008911656194744" lon="-84.2030772679115">
+				<ele>932.9646451268345</ele>
+				<time>2017-11-13T18:13:31Z</time>
+				<extensions>
+					<speed>1.3344777822494507</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008921578902433" lon="-84.20308230758727">
+				<ele>932.8001771718264</ele>
+				<time>2017-11-13T18:13:32Z</time>
+				<extensions>
+					<speed>1.1544872522354126</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008915211428967" lon="-84.203101758415">
+				<ele>932.7512605460361</ele>
+				<time>2017-11-13T18:13:33Z</time>
+				<extensions>
+					<speed>0.8778910040855408</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00889183491276" lon="-84.2030989411655">
+				<ele>931.385569119826</ele>
+				<time>2017-11-13T18:13:34Z</time>
+				<extensions>
+					<speed>0.3977779448032379</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008868896776342" lon="-84.20310667533982">
+				<ele>929.8759625051171</ele>
+				<time>2017-11-13T18:13:35Z</time>
+				<extensions>
+					<speed>0.5070075988769531</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00887025652933" lon="-84.20311149173328">
+				<ele>930.1262721624225</ele>
+				<time>2017-11-13T18:13:36Z</time>
+				<extensions>
+					<speed>0.7267935276031494</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008886562692831" lon="-84.20310856414335">
+				<ele>930.5320983631536</ele>
+				<time>2017-11-13T18:13:37Z</time>
+				<extensions>
+					<speed>1.4641200304031372</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008905788508098" lon="-84.20309624128566">
+				<ele>930.4195485245436</ele>
+				<time>2017-11-13T18:13:38Z</time>
+				<extensions>
+					<speed>2.3570635318756104</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008935031226626" lon="-84.20308040962085">
+				<ele>929.9003115911037</ele>
+				<time>2017-11-13T18:13:39Z</time>
+				<extensions>
+					<speed>3.644306182861328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008968183304932" lon="-84.2030653204766">
+				<ele>930.231813329272</ele>
+				<time>2017-11-13T18:13:40Z</time>
+				<extensions>
+					<speed>4.252112865447998</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009008572356837" lon="-84.20303158860936">
+				<ele>930.7077180426568</ele>
+				<time>2017-11-13T18:13:41Z</time>
+				<extensions>
+					<speed>5.58543586730957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009045462192264" lon="-84.2030014095257">
+				<ele>930.4847308276221</ele>
+				<time>2017-11-13T18:13:42Z</time>
+				<extensions>
+					<speed>6.361383438110352</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009081225285245" lon="-84.20297207437237">
+				<ele>930.5091502275318</ele>
+				<time>2017-11-13T18:13:43Z</time>
+				<extensions>
+					<speed>5.922063827514648</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009099950802002" lon="-84.2029540947661">
+				<ele>930.1907287314534</ele>
+				<time>2017-11-13T18:13:44Z</time>
+				<extensions>
+					<speed>4.78564453125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0091166673238" lon="-84.20293540973155">
+				<ele>930.0148312849924</ele>
+				<time>2017-11-13T18:13:45Z</time>
+				<extensions>
+					<speed>3.4875800609588623</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009126258250285" lon="-84.20292097361316">
+				<ele>929.6127414572984</ele>
+				<time>2017-11-13T18:13:46Z</time>
+				<extensions>
+					<speed>2.537385940551758</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009133031368096" lon="-84.20290970025808">
+				<ele>929.4941264567897</ele>
+				<time>2017-11-13T18:13:47Z</time>
+				<extensions>
+					<speed>2.1328978538513184</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009145799188754" lon="-84.20289961727512">
+				<ele>928.9422121364623</ele>
+				<time>2017-11-13T18:13:48Z</time>
+				<extensions>
+					<speed>2.5858154296875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009174471837868" lon="-84.20289127379326">
+				<ele>928.57474806346</ele>
+				<time>2017-11-13T18:13:49Z</time>
+				<extensions>
+					<speed>2.973491907119751</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00920361433073" lon="-84.2028800865815">
+				<ele>928.4561841078103</ele>
+				<time>2017-11-13T18:13:50Z</time>
+				<extensions>
+					<speed>3.1602330207824707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009228966006" lon="-84.20286778027092">
+				<ele>928.3860016576946</ele>
+				<time>2017-11-13T18:13:51Z</time>
+				<extensions>
+					<speed>3.21734619140625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009255822656538" lon="-84.20285295855271">
+				<ele>927.9291106183082</ele>
+				<time>2017-11-13T18:13:52Z</time>
+				<extensions>
+					<speed>3.4126322269439697</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00928559555105" lon="-84.20283203966412">
+				<ele>927.7524691587314</ele>
+				<time>2017-11-13T18:13:53Z</time>
+				<extensions>
+					<speed>3.725090742111206</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009317154092523" lon="-84.20280552675555">
+				<ele>927.5072788773105</ele>
+				<time>2017-11-13T18:13:54Z</time>
+				<extensions>
+					<speed>4.028500080108643</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00935391613296" lon="-84.20277650395707">
+				<ele>927.2015375457704</ele>
+				<time>2017-11-13T18:13:55Z</time>
+				<extensions>
+					<speed>4.418100833892822</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009395479276614" lon="-84.2027415388017">
+				<ele>926.9697209168226</ele>
+				<time>2017-11-13T18:13:56Z</time>
+				<extensions>
+					<speed>4.797538757324219</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00945590779108" lon="-84.20269148210409">
+				<ele>926.7949027353898</ele>
+				<time>2017-11-13T18:13:57Z</time>
+				<extensions>
+					<speed>5.815443992614746</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009521046264352" lon="-84.20263083386331">
+				<ele>926.4715691581368</ele>
+				<time>2017-11-13T18:13:58Z</time>
+				<extensions>
+					<speed>6.875406265258789</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009578721099897" lon="-84.2025747973941">
+				<ele>926.0242786593735</ele>
+				<time>2017-11-13T18:13:59Z</time>
+				<extensions>
+					<speed>7.108698844909668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009636264618953" lon="-84.20250255822366">
+				<ele>925.6460948456079</ele>
+				<time>2017-11-13T18:14:00Z</time>
+				<extensions>
+					<speed>7.389317512512207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009676193961642" lon="-84.20244193815718">
+				<ele>925.7351482557133</ele>
+				<time>2017-11-13T18:14:01Z</time>
+				<extensions>
+					<speed>7.253288269042969</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009723997360858" lon="-84.20238882469694">
+				<ele>925.3977216556668</ele>
+				<time>2017-11-13T18:14:02Z</time>
+				<extensions>
+					<speed>7.349053382873535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009778931475923" lon="-84.20232675098154">
+				<ele>924.9297729413956</ele>
+				<time>2017-11-13T18:14:03Z</time>
+				<extensions>
+					<speed>7.545803070068359</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009838782816885" lon="-84.20225846067925">
+				<ele>924.3751365169883</ele>
+				<time>2017-11-13T18:14:04Z</time>
+				<extensions>
+					<speed>7.661168575286865</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00989460151931" lon="-84.20219995563934">
+				<ele>923.8992203185335</ele>
+				<time>2017-11-13T18:14:05Z</time>
+				<extensions>
+					<speed>7.630110263824463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009944685201294" lon="-84.20214629491106">
+				<ele>923.2009277120233</ele>
+				<time>2017-11-13T18:14:06Z</time>
+				<extensions>
+					<speed>7.485875129699707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009995307050156" lon="-84.20209440195829">
+				<ele>922.7096148934215</ele>
+				<time>2017-11-13T18:14:07Z</time>
+				<extensions>
+					<speed>7.274412631988525</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01003172924812" lon="-84.20205832479716">
+				<ele>922.1847051940858</ele>
+				<time>2017-11-13T18:14:08Z</time>
+				<extensions>
+					<speed>6.481845855712891</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010063545673832" lon="-84.20202331942849">
+				<ele>921.6030736174434</ele>
+				<time>2017-11-13T18:14:09Z</time>
+				<extensions>
+					<speed>5.206678867340088</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010074533739322" lon="-84.20200161433796">
+				<ele>918.919147930108</ele>
+				<time>2017-11-13T18:14:10Z</time>
+				<extensions>
+					<speed>3.3854236602783203</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010075792649594" lon="-84.2019816251046">
+				<ele>916.4559231698513</ele>
+				<time>2017-11-13T18:14:11Z</time>
+				<extensions>
+					<speed>1.9606218338012695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01006727113458" lon="-84.20196795846775">
+				<ele>916.9825350288302</ele>
+				<time>2017-11-13T18:14:12Z</time>
+				<extensions>
+					<speed>0.8864150047302246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010052797703064" lon="-84.20195202405915">
+				<ele>918.0849512992427</ele>
+				<time>2017-11-13T18:14:13Z</time>
+				<extensions>
+					<speed>1.6741433143615723</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010043574379363" lon="-84.2020222197969">
+				<ele>883.8382450286299</ele>
+				<time>2017-11-13T18:14:14Z</time>
+				<extensions>
+					<speed>1.5639572143554688</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010041344864243" lon="-84.20201933874256">
+				<ele>891.5156525131315</ele>
+				<time>2017-11-13T18:14:15Z</time>
+				<extensions>
+					<speed>1.379063606262207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010021917518864" lon="-84.20202995334871">
+				<ele>890.7664730232209</ele>
+				<time>2017-11-13T18:14:16Z</time>
+				<extensions>
+					<speed>1.6280055046081543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01002616903174" lon="-84.20203626921156">
+				<ele>893.7834077710286</ele>
+				<time>2017-11-13T18:14:17Z</time>
+				<extensions>
+					<speed>0.8627679347991943</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01002310349228" lon="-84.20204312029797">
+				<ele>893.8567815991119</ele>
+				<time>2017-11-13T18:14:18Z</time>
+				<extensions>
+					<speed>0.7035067081451416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01002310349228" lon="-84.20204312029797">
+				<ele>893.8567815991119</ele>
+				<time>2017-11-13T18:14:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010024277002126" lon="-84.2020394776491">
+				<ele>894.6077302619815</ele>
+				<time>2017-11-13T18:14:20Z</time>
+				<extensions>
+					<speed>0.5884732007980347</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010024277002126" lon="-84.2020394776491">
+				<ele>894.6077302619815</ele>
+				<time>2017-11-13T18:14:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010031006828925" lon="-84.20204897477684">
+				<ele>895.7741803480312</ele>
+				<time>2017-11-13T18:14:22Z</time>
+				<extensions>
+					<speed>0.389658123254776</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010031006828925" lon="-84.20204897477684">
+				<ele>895.7741803480312</ele>
+				<time>2017-11-13T18:14:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010067938502168" lon="-84.2020567338874">
+				<ele>900.8029746580869</ele>
+				<time>2017-11-13T18:14:24Z</time>
+				<extensions>
+					<speed>1.4800620079040527</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010105432790503" lon="-84.20205135699973">
+				<ele>902.6441786717623</ele>
+				<time>2017-11-13T18:14:25Z</time>
+				<extensions>
+					<speed>2.2940077781677246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010143271581695" lon="-84.20204054687544">
+				<ele>904.6541895559058</ele>
+				<time>2017-11-13T18:14:26Z</time>
+				<extensions>
+					<speed>3.2561919689178467</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0101944203895" lon="-84.20202230577887">
+				<ele>906.2970786588266</ele>
+				<time>2017-11-13T18:14:27Z</time>
+				<extensions>
+					<speed>4.236626625061035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010272559129845" lon="-84.20200306431546">
+				<ele>908.0074245063588</ele>
+				<time>2017-11-13T18:14:28Z</time>
+				<extensions>
+					<speed>5.376083850860596</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010337671424503" lon="-84.20197591394472">
+				<ele>909.4228642219678</ele>
+				<time>2017-11-13T18:14:29Z</time>
+				<extensions>
+					<speed>6.234158039093018</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010391031625314" lon="-84.2019328673619">
+				<ele>913.2824957305565</ele>
+				<time>2017-11-13T18:14:30Z</time>
+				<extensions>
+					<speed>6.407588481903076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010450746322837" lon="-84.20190055936142">
+				<ele>915.9520815312862</ele>
+				<time>2017-11-13T18:14:31Z</time>
+				<extensions>
+					<speed>6.498808860778809</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010503190684567" lon="-84.20185241799922">
+				<ele>918.9392229821533</ele>
+				<time>2017-11-13T18:14:32Z</time>
+				<extensions>
+					<speed>6.708205699920654</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010558066154589" lon="-84.20181391602853">
+				<ele>920.4316151114181</ele>
+				<time>2017-11-13T18:14:33Z</time>
+				<extensions>
+					<speed>6.857614517211914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01060955967076" lon="-84.20176412892151">
+				<ele>922.099715070799</ele>
+				<time>2017-11-13T18:14:34Z</time>
+				<extensions>
+					<speed>6.8731689453125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01066566638153" lon="-84.20172428210361">
+				<ele>922.8622507080436</ele>
+				<time>2017-11-13T18:14:35Z</time>
+				<extensions>
+					<speed>6.819233417510986</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01072273299395" lon="-84.20168314806924">
+				<ele>924.2179200593382</ele>
+				<time>2017-11-13T18:14:36Z</time>
+				<extensions>
+					<speed>6.931813716888428</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010775664160983" lon="-84.20164159032859">
+				<ele>924.9052301552147</ele>
+				<time>2017-11-13T18:14:37Z</time>
+				<extensions>
+					<speed>6.9774169921875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01082949751015" lon="-84.20160473067128">
+				<ele>925.4954960457981</ele>
+				<time>2017-11-13T18:14:38Z</time>
+				<extensions>
+					<speed>6.961458206176758</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010877888196019" lon="-84.20156468490362">
+				<ele>926.2679590927437</ele>
+				<time>2017-11-13T18:14:39Z</time>
+				<extensions>
+					<speed>6.832186698913574</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01092648450456" lon="-84.20154033907822">
+				<ele>927.4768734751269</ele>
+				<time>2017-11-13T18:14:40Z</time>
+				<extensions>
+					<speed>6.590886116027832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01096746512159" lon="-84.20151758538499">
+				<ele>928.1349834101275</ele>
+				<time>2017-11-13T18:14:41Z</time>
+				<extensions>
+					<speed>6.368423938751221</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01101524410301" lon="-84.2014942759733">
+				<ele>928.5681600030512</ele>
+				<time>2017-11-13T18:14:42Z</time>
+				<extensions>
+					<speed>6.270198345184326</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011053254418004" lon="-84.20147887863891">
+				<ele>929.0106334444135</ele>
+				<time>2017-11-13T18:14:43Z</time>
+				<extensions>
+					<speed>5.925285339355469</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011090345738495" lon="-84.20145944011487">
+				<ele>929.4335082173347</ele>
+				<time>2017-11-13T18:14:44Z</time>
+				<extensions>
+					<speed>5.690951347351074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01113291103959" lon="-84.2014418389694">
+				<ele>929.7798596173525</ele>
+				<time>2017-11-13T18:14:45Z</time>
+				<extensions>
+					<speed>5.583662033081055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011166598020095" lon="-84.20143727326656">
+				<ele>930.2924976060167</ele>
+				<time>2017-11-13T18:14:46Z</time>
+				<extensions>
+					<speed>5.281103610992432</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011169169050378" lon="-84.20143647577905">
+				<ele>930.6785375894979</ele>
+				<time>2017-11-13T18:14:47Z</time>
+				<extensions>
+					<speed>4.393643379211426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011198773414772" lon="-84.20143448579542">
+				<ele>931.0221449313685</ele>
+				<time>2017-11-13T18:14:48Z</time>
+				<extensions>
+					<speed>4.17935848236084</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011231645803033" lon="-84.20143206341882">
+				<ele>931.2845225902274</ele>
+				<time>2017-11-13T18:14:49Z</time>
+				<extensions>
+					<speed>4.094045639038086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011261095285612" lon="-84.20143854157824">
+				<ele>931.5409369496629</ele>
+				<time>2017-11-13T18:14:50Z</time>
+				<extensions>
+					<speed>3.950274705886841</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011311462056351" lon="-84.20144177732641">
+				<ele>931.7483995733783</ele>
+				<time>2017-11-13T18:14:51Z</time>
+				<extensions>
+					<speed>4.151576995849609</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011346748456036" lon="-84.20143485872016">
+				<ele>931.9659224906936</ele>
+				<time>2017-11-13T18:14:52Z</time>
+				<extensions>
+					<speed>4.104223728179932</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011384421871089" lon="-84.20142720316271">
+				<ele>932.1608247021213</ele>
+				<time>2017-11-13T18:14:53Z</time>
+				<extensions>
+					<speed>4.202779769897461</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011422036462116" lon="-84.2014139344963">
+				<ele>932.3274440150708</ele>
+				<time>2017-11-13T18:14:54Z</time>
+				<extensions>
+					<speed>4.341484069824219</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011452678197234" lon="-84.20138765896755">
+				<ele>932.482125482522</ele>
+				<time>2017-11-13T18:14:55Z</time>
+				<extensions>
+					<speed>4.202117919921875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011483346033136" lon="-84.20136721027019">
+				<ele>932.577823124826</ele>
+				<time>2017-11-13T18:14:56Z</time>
+				<extensions>
+					<speed>4.0593671798706055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011505508253826" lon="-84.20136065448474">
+				<ele>932.5822177408263</ele>
+				<time>2017-11-13T18:14:57Z</time>
+				<extensions>
+					<speed>3.707667350769043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011510551608687" lon="-84.20137504131745">
+				<ele>932.4546852791682</ele>
+				<time>2017-11-13T18:14:58Z</time>
+				<extensions>
+					<speed>2.95623517036438</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011513078084835" lon="-84.20139281428362">
+				<ele>932.0383936269209</ele>
+				<time>2017-11-13T18:14:59Z</time>
+				<extensions>
+					<speed>2.1389272212982178</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011501210039768" lon="-84.201383819018">
+				<ele>932.0946735739708</ele>
+				<time>2017-11-13T18:15:00Z</time>
+				<extensions>
+					<speed>1.355994701385498</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011465062872734" lon="-84.20138033896247">
+				<ele>932.4542251629755</ele>
+				<time>2017-11-13T18:15:01Z</time>
+				<extensions>
+					<speed>0.6749981641769409</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011439809473153" lon="-84.20138487844366">
+				<ele>931.4112945245579</ele>
+				<time>2017-11-13T18:15:02Z</time>
+				<extensions>
+					<speed>0.6309272050857544</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011439809473153" lon="-84.20138487844366">
+				<ele>931.4112945245579</ele>
+				<time>2017-11-13T18:15:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011438296951587" lon="-84.20138145355794">
+				<ele>931.2165326429531</ele>
+				<time>2017-11-13T18:15:04Z</time>
+				<extensions>
+					<speed>0.5084323883056641</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011438296951587" lon="-84.20138145355794">
+				<ele>931.2165326429531</ele>
+				<time>2017-11-13T18:15:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011436253227224" lon="-84.20145940921273">
+				<ele>921.6046167630702</ele>
+				<time>2017-11-13T18:15:06Z</time>
+				<extensions>
+					<speed>0.10032663494348526</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011436253227224" lon="-84.20145940921273">
+				<ele>921.6046167630702</ele>
+				<time>2017-11-13T18:15:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011436253227224" lon="-84.20145940921273">
+				<ele>921.6046167630702</ele>
+				<time>2017-11-13T18:15:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011436253227224" lon="-84.20145940921273">
+				<ele>921.6046167630702</ele>
+				<time>2017-11-13T18:15:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011436253227224" lon="-84.20145940921273">
+				<ele>921.6046167630702</ele>
+				<time>2017-11-13T18:15:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011436253227224" lon="-84.20145940921273">
+				<ele>921.6046167630702</ele>
+				<time>2017-11-13T18:15:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011436253227224" lon="-84.20145940921273">
+				<ele>921.6046167630702</ele>
+				<time>2017-11-13T18:15:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011436253227224" lon="-84.20145940921273">
+				<ele>921.6046167630702</ele>
+				<time>2017-11-13T18:15:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011436253227224" lon="-84.20145940921273">
+				<ele>921.6046167630702</ele>
+				<time>2017-11-13T18:15:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011436253227224" lon="-84.20145940921273">
+				<ele>921.6046167630702</ele>
+				<time>2017-11-13T18:15:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011436253227224" lon="-84.20145940921273">
+				<ele>921.6046167630702</ele>
+				<time>2017-11-13T18:15:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011436253227224" lon="-84.20145940921273">
+				<ele>921.6046167630702</ele>
+				<time>2017-11-13T18:15:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011436253227224" lon="-84.20145940921273">
+				<ele>921.6046167630702</ele>
+				<time>2017-11-13T18:15:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011436253227224" lon="-84.20145940921273">
+				<ele>921.6046167630702</ele>
+				<time>2017-11-13T18:15:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011436253227224" lon="-84.20145940921273">
+				<ele>921.6046167630702</ele>
+				<time>2017-11-13T18:15:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011436253227224" lon="-84.20145940921273">
+				<ele>921.6046167630702</ele>
+				<time>2017-11-13T18:15:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011436253227224" lon="-84.20145940921273">
+				<ele>921.6046167630702</ele>
+				<time>2017-11-13T18:15:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011436253227224" lon="-84.20145940921273">
+				<ele>921.6046167630702</ele>
+				<time>2017-11-13T18:15:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011436253227224" lon="-84.20145940921273">
+				<ele>921.6046167630702</ele>
+				<time>2017-11-13T18:15:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011443656617617" lon="-84.20144727160901">
+				<ele>922.1367386439815</ele>
+				<time>2017-11-13T18:15:25Z</time>
+				<extensions>
+					<speed>0.6945050954818726</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011436253227224" lon="-84.20145940921273">
+				<ele>921.6046167630702</ele>
+				<time>2017-11-13T18:15:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011444623051437" lon="-84.20145313856312">
+				<ele>922.0843105344102</ele>
+				<time>2017-11-13T18:15:27Z</time>
+				<extensions>
+					<speed>1.176648497581482</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011453942028737" lon="-84.20143966103743">
+				<ele>922.4238163335249</ele>
+				<time>2017-11-13T18:15:28Z</time>
+				<extensions>
+					<speed>1.387876272201538</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011467220408168" lon="-84.20141584763763">
+				<ele>922.825826883316</ele>
+				<time>2017-11-13T18:15:29Z</time>
+				<extensions>
+					<speed>1.5320569276809692</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011487777396159" lon="-84.20138958265375">
+				<ele>923.164548526518</ele>
+				<time>2017-11-13T18:15:30Z</time>
+				<extensions>
+					<speed>1.6777079105377197</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01150977597864" lon="-84.20137286745853">
+				<ele>923.0700020957738</ele>
+				<time>2017-11-13T18:15:31Z</time>
+				<extensions>
+					<speed>2.0930745601654053</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011539385655771" lon="-84.20135556332117">
+				<ele>922.8413867698982</ele>
+				<time>2017-11-13T18:15:32Z</time>
+				<extensions>
+					<speed>2.601142644882202</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01157407997233" lon="-84.20134322995571">
+				<ele>922.9320426667109</ele>
+				<time>2017-11-13T18:15:33Z</time>
+				<extensions>
+					<speed>3.2131595611572266</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011622648006217" lon="-84.20132199313785">
+				<ele>923.2369170971215</ele>
+				<time>2017-11-13T18:15:34Z</time>
+				<extensions>
+					<speed>4.1187591552734375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011673904726365" lon="-84.20127656890755">
+				<ele>925.390405125916</ele>
+				<time>2017-11-13T18:15:35Z</time>
+				<extensions>
+					<speed>4.994615077972412</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011717431480406" lon="-84.2012490190218">
+				<ele>926.5282843820751</ele>
+				<time>2017-11-13T18:15:36Z</time>
+				<extensions>
+					<speed>5.169484615325928</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011761949575988" lon="-84.20123053986906">
+				<ele>927.4489437583834</ele>
+				<time>2017-11-13T18:15:37Z</time>
+				<extensions>
+					<speed>5.129508972167969</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011805442205144" lon="-84.20121176178812">
+				<ele>928.0570406969637</ele>
+				<time>2017-11-13T18:15:38Z</time>
+				<extensions>
+					<speed>5.067150115966797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011848628451165" lon="-84.20119127348264">
+				<ele>928.5074385814369</ele>
+				<time>2017-11-13T18:15:39Z</time>
+				<extensions>
+					<speed>5.148031234741211</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011889830768638" lon="-84.20116805323066">
+				<ele>928.7347588222474</ele>
+				<time>2017-11-13T18:15:40Z</time>
+				<extensions>
+					<speed>5.118735313415527</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926009525368" lon="-84.20114775148922">
+				<ele>928.9402552591637</ele>
+				<time>2017-11-13T18:15:41Z</time>
+				<extensions>
+					<speed>5.031187057495117</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011957877043134" lon="-84.20112829341431">
+				<ele>929.076091112569</ele>
+				<time>2017-11-13T18:15:42Z</time>
+				<extensions>
+					<speed>4.919230937957764</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011985059882992" lon="-84.20111322352658">
+				<ele>929.3921850426123</ele>
+				<time>2017-11-13T18:15:43Z</time>
+				<extensions>
+					<speed>4.7655181884765625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012015243366555" lon="-84.20110027706778">
+				<ele>929.6413345290348</ele>
+				<time>2017-11-13T18:15:44Z</time>
+				<extensions>
+					<speed>4.572676658630371</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012044638844557" lon="-84.20108795233912">
+				<ele>929.8437741417438</ele>
+				<time>2017-11-13T18:15:45Z</time>
+				<extensions>
+					<speed>4.534049987792969</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012080862197704" lon="-84.20107073678572">
+				<ele>929.9270514873788</ele>
+				<time>2017-11-13T18:15:46Z</time>
+				<extensions>
+					<speed>4.6050238609313965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012116027191944" lon="-84.20105481041162">
+				<ele>929.9361129105091</ele>
+				<time>2017-11-13T18:15:47Z</time>
+				<extensions>
+					<speed>4.43014669418335</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01214551233834" lon="-84.20104347518136">
+				<ele>930.116726692766</ele>
+				<time>2017-11-13T18:15:48Z</time>
+				<extensions>
+					<speed>3.945695400238037</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01217026104932" lon="-84.20102596548605">
+				<ele>930.0340642044321</ele>
+				<time>2017-11-13T18:15:49Z</time>
+				<extensions>
+					<speed>3.249774217605591</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012196170677635" lon="-84.20100644364301">
+				<ele>929.7727957861498</ele>
+				<time>2017-11-13T18:15:50Z</time>
+				<extensions>
+					<speed>2.9256019592285156</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01222625386712" lon="-84.20098495631439">
+				<ele>929.7920500338078</ele>
+				<time>2017-11-13T18:15:51Z</time>
+				<extensions>
+					<speed>3.055457592010498</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012257774629186" lon="-84.20096515765603">
+				<ele>930.0442953351885</ele>
+				<time>2017-11-13T18:15:52Z</time>
+				<extensions>
+					<speed>3.414506435394287</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012304737175265" lon="-84.20093804842598">
+				<ele>930.2008175309747</ele>
+				<time>2017-11-13T18:15:53Z</time>
+				<extensions>
+					<speed>4.253291606903076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012356964757398" lon="-84.20091088346774">
+				<ele>930.2576336823404</ele>
+				<time>2017-11-13T18:15:54Z</time>
+				<extensions>
+					<speed>4.904160022735596</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0124087899377" lon="-84.20087970191817">
+				<ele>930.3986763851717</ele>
+				<time>2017-11-13T18:15:55Z</time>
+				<extensions>
+					<speed>5.490337371826172</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01245559866027" lon="-84.20085423108107">
+				<ele>930.6039449926466</ele>
+				<time>2017-11-13T18:15:56Z</time>
+				<extensions>
+					<speed>5.868644714355469</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012507296768552" lon="-84.20082890415624">
+				<ele>930.94954105746</ele>
+				<time>2017-11-13T18:15:57Z</time>
+				<extensions>
+					<speed>6.112508773803711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012563642088699" lon="-84.20079769772074">
+				<ele>930.621172809042</ele>
+				<time>2017-11-13T18:15:58Z</time>
+				<extensions>
+					<speed>6.626749515533447</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01263088187735" lon="-84.2007623603395">
+				<ele>930.8098124386743</ele>
+				<time>2017-11-13T18:15:59Z</time>
+				<extensions>
+					<speed>7.6171770095825195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012699575840871" lon="-84.20072765411922">
+				<ele>930.4533713832498</ele>
+				<time>2017-11-13T18:16:00Z</time>
+				<extensions>
+					<speed>8.064620971679688</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012761744087257" lon="-84.20069312210065">
+				<ele>930.1589383715764</ele>
+				<time>2017-11-13T18:16:01Z</time>
+				<extensions>
+					<speed>7.495242595672607</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012816497262504" lon="-84.20066204607244">
+				<ele>929.9636059943587</ele>
+				<time>2017-11-13T18:16:02Z</time>
+				<extensions>
+					<speed>6.572443008422852</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012857146506851" lon="-84.20063952627096">
+				<ele>929.7676181932911</ele>
+				<time>2017-11-13T18:16:03Z</time>
+				<extensions>
+					<speed>4.981801509857178</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012882118838712" lon="-84.20062749345372">
+				<ele>930.0138162737712</ele>
+				<time>2017-11-13T18:16:04Z</time>
+				<extensions>
+					<speed>2.8345401287078857</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012895049168936" lon="-84.20062258578102">
+				<ele>930.2251429827884</ele>
+				<time>2017-11-13T18:16:05Z</time>
+				<extensions>
+					<speed>1.375770926475525</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012895841800573" lon="-84.20062352588643">
+				<ele>930.4176099644974</ele>
+				<time>2017-11-13T18:16:06Z</time>
+				<extensions>
+					<speed>0.022587651386857033</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012895841800573" lon="-84.20062352588643">
+				<ele>930.4176099644974</ele>
+				<time>2017-11-13T18:16:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012887509606651" lon="-84.2006319205134">
+				<ele>930.651876334101</ele>
+				<time>2017-11-13T18:16:08Z</time>
+				<extensions>
+					<speed>0.6385741829872131</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012895841800573" lon="-84.20062352588643">
+				<ele>930.4176099644974</ele>
+				<time>2017-11-13T18:16:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012895841800573" lon="-84.20062352588643">
+				<ele>930.4176099644974</ele>
+				<time>2017-11-13T18:16:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012910338913992" lon="-84.20061247573844">
+				<ele>930.1978578800336</ele>
+				<time>2017-11-13T18:16:11Z</time>
+				<extensions>
+					<speed>1.6101598739624023</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012918856359462" lon="-84.20062863117211">
+				<ele>931.2034887280315</ele>
+				<time>2017-11-13T18:16:12Z</time>
+				<extensions>
+					<speed>3.081885814666748</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01294545202943" lon="-84.20064395921024">
+				<ele>931.6890951571986</ele>
+				<time>2017-11-13T18:16:13Z</time>
+				<extensions>
+					<speed>3.9925854206085205</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01296631251473" lon="-84.20067574951344">
+				<ele>932.2916026301682</ele>
+				<time>2017-11-13T18:16:14Z</time>
+				<extensions>
+					<speed>4.301455020904541</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012998969804656" lon="-84.20071174170886">
+				<ele>932.7371562859043</ele>
+				<time>2017-11-13T18:16:15Z</time>
+				<extensions>
+					<speed>4.691786766052246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0130314873768" lon="-84.20074888830486">
+				<ele>932.9449102859944</ele>
+				<time>2017-11-13T18:16:16Z</time>
+				<extensions>
+					<speed>4.946516513824463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013044653724698" lon="-84.20081949710355">
+				<ele>935.4203418307006</ele>
+				<time>2017-11-13T18:16:17Z</time>
+				<extensions>
+					<speed>5.617977142333984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013071253465103" lon="-84.20087548420572">
+				<ele>936.397810514085</ele>
+				<time>2017-11-13T18:16:18Z</time>
+				<extensions>
+					<speed>6.167660236358643</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013102423744167" lon="-84.20093286188285">
+				<ele>936.7873102519661</ele>
+				<time>2017-11-13T18:16:19Z</time>
+				<extensions>
+					<speed>6.582027912139893</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013134276622628" lon="-84.200989836681">
+				<ele>937.0937121920288</ele>
+				<time>2017-11-13T18:16:20Z</time>
+				<extensions>
+					<speed>6.761907577514648</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0131611242346" lon="-84.20104273629568">
+				<ele>937.6203217152506</ele>
+				<time>2017-11-13T18:16:21Z</time>
+				<extensions>
+					<speed>6.253741264343262</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013190409134756" lon="-84.20109602330378">
+				<ele>938.0881209634244</ele>
+				<time>2017-11-13T18:16:22Z</time>
+				<extensions>
+					<speed>6.2208943367004395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013225852737417" lon="-84.20114624941895">
+				<ele>938.3226132811978</ele>
+				<time>2017-11-13T18:16:23Z</time>
+				<extensions>
+					<speed>6.128790855407715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013258205249304" lon="-84.2011926338889">
+				<ele>938.7113599525765</ele>
+				<time>2017-11-13T18:16:24Z</time>
+				<extensions>
+					<speed>6.113784313201904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013293289778245" lon="-84.20122671034258">
+				<ele>939.0905429208651</ele>
+				<time>2017-11-13T18:16:25Z</time>
+				<extensions>
+					<speed>5.527171611785889</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013323799822631" lon="-84.20126236899806">
+				<ele>939.0297983372584</ele>
+				<time>2017-11-13T18:16:26Z</time>
+				<extensions>
+					<speed>5.273565769195557</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013355094144096" lon="-84.20129104143784">
+				<ele>939.0001760292798</ele>
+				<time>2017-11-13T18:16:27Z</time>
+				<extensions>
+					<speed>5.14840841293335</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01338991066648" lon="-84.20131807235686">
+				<ele>938.9739507129416</ele>
+				<time>2017-11-13T18:16:28Z</time>
+				<extensions>
+					<speed>4.869300842285156</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01342190657285" lon="-84.20133984579172">
+				<ele>939.281451783143</ele>
+				<time>2017-11-13T18:16:29Z</time>
+				<extensions>
+					<speed>4.110033988952637</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013450591749816" lon="-84.20135048940419">
+				<ele>940.1545825581998</ele>
+				<time>2017-11-13T18:16:30Z</time>
+				<extensions>
+					<speed>2.9383316040039063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013465504593935" lon="-84.20135679243296">
+				<ele>940.8932279441506</ele>
+				<time>2017-11-13T18:16:31Z</time>
+				<extensions>
+					<speed>1.1817256212234497</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013469828075921" lon="-84.20135627669227">
+				<ele>941.4875538963825</ele>
+				<time>2017-11-13T18:16:32Z</time>
+				<extensions>
+					<speed>0.257785826921463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013469828075921" lon="-84.20135627669227">
+				<ele>941.4875538963825</ele>
+				<time>2017-11-13T18:16:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013464109316294" lon="-84.20134748716093">
+				<ele>941.5591248888522</ele>
+				<time>2017-11-13T18:16:34Z</time>
+				<extensions>
+					<speed>0.8461467623710632</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013464109316294" lon="-84.20134748716093">
+				<ele>941.5591248888522</ele>
+				<time>2017-11-13T18:16:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013460652519319" lon="-84.20134250775101">
+				<ele>942.5551574286073</ele>
+				<time>2017-11-13T18:16:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013460652519319" lon="-84.20134250775101">
+				<ele>942.5551574286073</ele>
+				<time>2017-11-13T18:16:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013460652519319" lon="-84.20134250775101">
+				<ele>942.5551574286073</ele>
+				<time>2017-11-13T18:16:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013460652519319" lon="-84.20134250775101">
+				<ele>942.5551574286073</ele>
+				<time>2017-11-13T18:16:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013460652519319" lon="-84.20134250775101">
+				<ele>942.5551574286073</ele>
+				<time>2017-11-13T18:16:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013460652519319" lon="-84.20134250775101">
+				<ele>942.5551574286073</ele>
+				<time>2017-11-13T18:16:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013460652519319" lon="-84.20134250775101">
+				<ele>942.5551574286073</ele>
+				<time>2017-11-13T18:16:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013460652519319" lon="-84.20134250775101">
+				<ele>942.5551574286073</ele>
+				<time>2017-11-13T18:16:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013460652519319" lon="-84.20134250775101">
+				<ele>942.5551574286073</ele>
+				<time>2017-11-13T18:16:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013460652519319" lon="-84.20134250775101">
+				<ele>942.5551574286073</ele>
+				<time>2017-11-13T18:16:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013469544461914" lon="-84.20133652488569">
+				<ele>943.0609305510297</ele>
+				<time>2017-11-13T18:16:46Z</time>
+				<extensions>
+					<speed>0.6081547737121582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013479257873172" lon="-84.20133600364004">
+				<ele>943.1723477356136</ele>
+				<time>2017-11-13T18:16:47Z</time>
+				<extensions>
+					<speed>1.1726765632629395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013493415009954" lon="-84.20134181912867">
+				<ele>943.2706175027415</ele>
+				<time>2017-11-13T18:16:48Z</time>
+				<extensions>
+					<speed>1.8814177513122559</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01351548440432" lon="-84.20136482682011">
+				<ele>942.9025154095143</ele>
+				<time>2017-11-13T18:16:49Z</time>
+				<extensions>
+					<speed>3.307957172393799</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013542122326635" lon="-84.20139276126231">
+				<ele>942.654218332842</ele>
+				<time>2017-11-13T18:16:50Z</time>
+				<extensions>
+					<speed>4.492053508758545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013577256661574" lon="-84.20143186794027">
+				<ele>942.920008437708</ele>
+				<time>2017-11-13T18:16:51Z</time>
+				<extensions>
+					<speed>5.405117988586426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013621604275984" lon="-84.20148447654825">
+				<ele>943.4111994002014</ele>
+				<time>2017-11-13T18:16:52Z</time>
+				<extensions>
+					<speed>6.726929187774658</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013666450650021" lon="-84.20154031163418">
+				<ele>943.2815116671845</ele>
+				<time>2017-11-13T18:16:53Z</time>
+				<extensions>
+					<speed>7.418920040130615</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013711275345287" lon="-84.20160139456083">
+				<ele>943.1914961049333</ele>
+				<time>2017-11-13T18:16:54Z</time>
+				<extensions>
+					<speed>7.728343486785889</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013754505320165" lon="-84.20166315506407">
+				<ele>942.8285492286086</ele>
+				<time>2017-11-13T18:16:55Z</time>
+				<extensions>
+					<speed>7.906677722930908</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013801796599132" lon="-84.20172877702846">
+				<ele>942.4360331082717</ele>
+				<time>2017-11-13T18:16:56Z</time>
+				<extensions>
+					<speed>7.794977188110352</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013843591098938" lon="-84.20179151646688">
+				<ele>942.3004723833874</ele>
+				<time>2017-11-13T18:16:57Z</time>
+				<extensions>
+					<speed>7.367458343505859</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013880243068266" lon="-84.20184266023958">
+				<ele>941.9154849527404</ele>
+				<time>2017-11-13T18:16:58Z</time>
+				<extensions>
+					<speed>6.726661205291748</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013913591914813" lon="-84.20189554064463">
+				<ele>941.0157071985304</ele>
+				<time>2017-11-13T18:16:59Z</time>
+				<extensions>
+					<speed>6.709141731262207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013946265630976" lon="-84.20195486779855">
+				<ele>940.6648806966841</ele>
+				<time>2017-11-13T18:17:00Z</time>
+				<extensions>
+					<speed>6.897503852844238</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013981593799906" lon="-84.20202334747441">
+				<ele>940.3921288680285</ele>
+				<time>2017-11-13T18:17:01Z</time>
+				<extensions>
+					<speed>7.140452861785889</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014007562995479" lon="-84.20208140056576">
+				<ele>940.0530943432823</ele>
+				<time>2017-11-13T18:17:02Z</time>
+				<extensions>
+					<speed>6.712593078613281</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01402769522921" lon="-84.20212601493715">
+				<ele>939.5439954875037</ele>
+				<time>2017-11-13T18:17:03Z</time>
+				<extensions>
+					<speed>5.73204231262207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014043525919858" lon="-84.20216815345178">
+				<ele>938.9121419340372</ele>
+				<time>2017-11-13T18:17:04Z</time>
+				<extensions>
+					<speed>5.046977996826172</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014061317275267" lon="-84.2022062095007">
+				<ele>938.8847165564075</ele>
+				<time>2017-11-13T18:17:05Z</time>
+				<extensions>
+					<speed>4.821985721588135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014080498156257" lon="-84.20224202876659">
+				<ele>938.5197386015207</ele>
+				<time>2017-11-13T18:17:06Z</time>
+				<extensions>
+					<speed>4.615116596221924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014093970996186" lon="-84.20227173358973">
+				<ele>938.2831273591146</ele>
+				<time>2017-11-13T18:17:07Z</time>
+				<extensions>
+					<speed>3.982592821121216</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01410278715071" lon="-84.20229142904657">
+				<ele>938.1556039247662</ele>
+				<time>2017-11-13T18:17:08Z</time>
+				<extensions>
+					<speed>2.302460193634033</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014102083224506" lon="-84.20230143878757">
+				<ele>937.8690224988386</ele>
+				<time>2017-11-13T18:17:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014099599340216" lon="-84.20229951364847">
+				<ele>937.581302575767</ele>
+				<time>2017-11-13T18:17:10Z</time>
+				<extensions>
+					<speed>0.4772595763206482</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014099599340216" lon="-84.20229951364847">
+				<ele>937.581302575767</ele>
+				<time>2017-11-13T18:17:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01409642405295" lon="-84.20229347021575">
+				<ele>937.1329465573654</ele>
+				<time>2017-11-13T18:17:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01409642405295" lon="-84.20229347021575">
+				<ele>937.1329465573654</ele>
+				<time>2017-11-13T18:17:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01409642405295" lon="-84.20229347021575">
+				<ele>937.1329465573654</ele>
+				<time>2017-11-13T18:17:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01409642405295" lon="-84.20229347021575">
+				<ele>937.1329465573654</ele>
+				<time>2017-11-13T18:17:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01409642405295" lon="-84.20229347021575">
+				<ele>937.1329465573654</ele>
+				<time>2017-11-13T18:17:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014104307828541" lon="-84.20230324086457">
+				<ele>937.1054259585217</ele>
+				<time>2017-11-13T18:17:17Z</time>
+				<extensions>
+					<speed>0.9971346855163574</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014115700708931" lon="-84.20232879801875">
+				<ele>937.0776944234967</ele>
+				<time>2017-11-13T18:17:18Z</time>
+				<extensions>
+					<speed>2.485107898712158</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014131359317622" lon="-84.20235335607522">
+				<ele>937.5088794808835</ele>
+				<time>2017-11-13T18:17:19Z</time>
+				<extensions>
+					<speed>2.9899728298187256</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014148391400868" lon="-84.20238810892899">
+				<ele>937.891364140436</ele>
+				<time>2017-11-13T18:17:20Z</time>
+				<extensions>
+					<speed>3.7899374961853027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014167742671123" lon="-84.20243469366977">
+				<ele>937.7741707805544</ele>
+				<time>2017-11-13T18:17:21Z</time>
+				<extensions>
+					<speed>4.800668716430664</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014187173168494" lon="-84.20247361600158">
+				<ele>936.9372815070674</ele>
+				<time>2017-11-13T18:17:22Z</time>
+				<extensions>
+					<speed>4.584332466125488</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014209448102624" lon="-84.20250625104302">
+				<ele>936.8547132574022</ele>
+				<time>2017-11-13T18:17:23Z</time>
+				<extensions>
+					<speed>4.498164653778076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014239835245064" lon="-84.20252501611192">
+				<ele>936.9655170859769</ele>
+				<time>2017-11-13T18:17:24Z</time>
+				<extensions>
+					<speed>4.270349025726318</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014277472444881" lon="-84.20251835104496">
+				<ele>936.3664278136566</ele>
+				<time>2017-11-13T18:17:25Z</time>
+				<extensions>
+					<speed>4.735024452209473</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014321510815455" lon="-84.2024982141904">
+				<ele>936.032645046711</ele>
+				<time>2017-11-13T18:17:26Z</time>
+				<extensions>
+					<speed>5.761038303375244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014378463085091" lon="-84.20246571100213">
+				<ele>935.8373367479071</ele>
+				<time>2017-11-13T18:17:27Z</time>
+				<extensions>
+					<speed>7.3679704666137695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01444021183063" lon="-84.2024157160624">
+				<ele>936.0462684324011</ele>
+				<time>2017-11-13T18:17:28Z</time>
+				<extensions>
+					<speed>8.405057907104492</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014502583349994" lon="-84.20236356086475">
+				<ele>936.0375117138028</ele>
+				<time>2017-11-13T18:17:29Z</time>
+				<extensions>
+					<speed>8.689988136291504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01456637150798" lon="-84.20232019500578">
+				<ele>936.0075556784868</ele>
+				<time>2017-11-13T18:17:30Z</time>
+				<extensions>
+					<speed>8.60083293914795</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014633772787462" lon="-84.20227894984576">
+				<ele>935.882669958286</ele>
+				<time>2017-11-13T18:17:31Z</time>
+				<extensions>
+					<speed>8.78134536743164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01470530136575" lon="-84.20223692247959">
+				<ele>935.5391664868221</ele>
+				<time>2017-11-13T18:17:32Z</time>
+				<extensions>
+					<speed>8.97795581817627</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014774441529445" lon="-84.20219277576278">
+				<ele>935.4309770129621</ele>
+				<time>2017-11-13T18:17:33Z</time>
+				<extensions>
+					<speed>8.9523286819458</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014846112999413" lon="-84.20215019674673">
+				<ele>935.3269612910226</ele>
+				<time>2017-11-13T18:17:34Z</time>
+				<extensions>
+					<speed>9.229546546936035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01492551163469" lon="-84.20211182123337">
+				<ele>934.917603851296</ele>
+				<time>2017-11-13T18:17:35Z</time>
+				<extensions>
+					<speed>9.493703842163086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014998594303847" lon="-84.20207793674712">
+				<ele>934.6170048685744</ele>
+				<time>2017-11-13T18:17:36Z</time>
+				<extensions>
+					<speed>9.01696491241455</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015065047834714" lon="-84.20204183476314">
+				<ele>934.5112358266488</ele>
+				<time>2017-11-13T18:17:37Z</time>
+				<extensions>
+					<speed>8.37213134765625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01512470549169" lon="-84.20200895346503">
+				<ele>934.6091505475342</ele>
+				<time>2017-11-13T18:17:38Z</time>
+				<extensions>
+					<speed>7.342188835144043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015164945184102" lon="-84.20198449108803">
+				<ele>934.4720564242452</ele>
+				<time>2017-11-13T18:17:39Z</time>
+				<extensions>
+					<speed>4.902645111083984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015186348191156" lon="-84.20196907906987">
+				<ele>934.1007950082421</ele>
+				<time>2017-11-13T18:17:40Z</time>
+				<extensions>
+					<speed>2.041473627090454</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191494813168" lon="-84.20196439549689">
+				<ele>933.8347520977259</ele>
+				<time>2017-11-13T18:17:41Z</time>
+				<extensions>
+					<speed>0.5160176753997803</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0151874345378" lon="-84.2019658504105">
+				<ele>933.5731251295656</ele>
+				<time>2017-11-13T18:17:42Z</time>
+				<extensions>
+					<speed>0.8466086387634277</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015175938485282" lon="-84.20197256849818">
+				<ele>933.4953390117735</ele>
+				<time>2017-11-13T18:17:43Z</time>
+				<extensions>
+					<speed>1.17778480052948</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015167791598822" lon="-84.20198504802684">
+				<ele>933.9831893723458</ele>
+				<time>2017-11-13T18:17:44Z</time>
+				<extensions>
+					<speed>1.317945957183838</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01515974344472" lon="-84.20199647988824">
+				<ele>934.3176728729159</ele>
+				<time>2017-11-13T18:17:45Z</time>
+				<extensions>
+					<speed>1.42757248878479</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015160447937717" lon="-84.20201539499566">
+				<ele>935.6595479529351</ele>
+				<time>2017-11-13T18:17:46Z</time>
+				<extensions>
+					<speed>1.3863024711608887</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015163040496104" lon="-84.20204698039545">
+				<ele>936.5876415902749</ele>
+				<time>2017-11-13T18:17:47Z</time>
+				<extensions>
+					<speed>1.6770414113998413</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015160315909686" lon="-84.20206828806441">
+				<ele>936.6555873388425</ele>
+				<time>2017-11-13T18:17:48Z</time>
+				<extensions>
+					<speed>1.7476626634597778</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015159941967656" lon="-84.20209015485597">
+				<ele>936.6990002254024</ele>
+				<time>2017-11-13T18:17:49Z</time>
+				<extensions>
+					<speed>1.8053693771362305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015160274826222" lon="-84.20210515329343">
+				<ele>936.4750882862136</ele>
+				<time>2017-11-13T18:17:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015163711166966" lon="-84.20211481835956">
+				<ele>936.5053521804512</ele>
+				<time>2017-11-13T18:17:51Z</time>
+				<extensions>
+					<speed>0.4474503993988037</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015163711166966" lon="-84.20211481835956">
+				<ele>936.5053521804512</ele>
+				<time>2017-11-13T18:17:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015169217393147" lon="-84.20212091413173">
+				<ele>935.9306789431721</ele>
+				<time>2017-11-13T18:17:53Z</time>
+				<extensions>
+					<speed>0.612223207950592</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015169217393147" lon="-84.20212091413173">
+				<ele>935.9306789431721</ele>
+				<time>2017-11-13T18:17:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015182419911975" lon="-84.2021055926452">
+				<ele>935.6155773233622</ele>
+				<time>2017-11-13T18:17:55Z</time>
+				<extensions>
+					<speed>0.7193244099617004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015197205828247" lon="-84.20206568449139">
+				<ele>934.7351040225476</ele>
+				<time>2017-11-13T18:17:56Z</time>
+				<extensions>
+					<speed>2.1067631244659424</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015220977854183" lon="-84.20202490848796">
+				<ele>934.0929503953084</ele>
+				<time>2017-11-13T18:17:57Z</time>
+				<extensions>
+					<speed>3.8418502807617188</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015252639611182" lon="-84.2019726814272">
+				<ele>933.7169778458774</ele>
+				<time>2017-11-13T18:17:58Z</time>
+				<extensions>
+					<speed>5.108316421508789</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01529328607665" lon="-84.20191843327343">
+				<ele>933.2740691518411</ele>
+				<time>2017-11-13T18:17:59Z</time>
+				<extensions>
+					<speed>6.110739231109619</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015335457292593" lon="-84.2018649175654">
+				<ele>932.7104412838817</ele>
+				<time>2017-11-13T18:18:00Z</time>
+				<extensions>
+					<speed>6.398285388946533</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015374015531894" lon="-84.20180969222305">
+				<ele>931.8129452057183</ele>
+				<time>2017-11-13T18:18:01Z</time>
+				<extensions>
+					<speed>5.8571648597717285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015402747059134" lon="-84.2017662749416">
+				<ele>931.4224584726617</ele>
+				<time>2017-11-13T18:18:02Z</time>
+				<extensions>
+					<speed>3.9563727378845215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01541472417187" lon="-84.20174164813284">
+				<ele>931.7901735147461</ele>
+				<time>2017-11-13T18:18:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015406828650908" lon="-84.20173408735647">
+				<ele>932.1003979854286</ele>
+				<time>2017-11-13T18:18:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015406828650908" lon="-84.20173408735647">
+				<ele>932.1003979854286</ele>
+				<time>2017-11-13T18:18:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01539377861645" lon="-84.20174028117823">
+				<ele>933.1781846145168</ele>
+				<time>2017-11-13T18:18:06Z</time>
+				<extensions>
+					<speed>1.1618551015853882</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015378725136186" lon="-84.20174847384806">
+				<ele>933.8627359047532</ele>
+				<time>2017-11-13T18:18:07Z</time>
+				<extensions>
+					<speed>1.099409580230713</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015370556498649" lon="-84.2017554627307">
+				<ele>935.4574274010956</ele>
+				<time>2017-11-13T18:18:08Z</time>
+				<extensions>
+					<speed>0.7186394929885864</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015370556498649" lon="-84.2017554627307">
+				<ele>935.4574274010956</ele>
+				<time>2017-11-13T18:18:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01536673807145" lon="-84.20176179226">
+				<ele>935.6611202452332</ele>
+				<time>2017-11-13T18:18:10Z</time>
+				<extensions>
+					<speed>0.43109309673309326</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01536673807145" lon="-84.20176179226">
+				<ele>935.6611202452332</ele>
+				<time>2017-11-13T18:18:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01537335521907" lon="-84.20176432827488">
+				<ele>938.2979549551383</ele>
+				<time>2017-11-13T18:18:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01537335521907" lon="-84.20176432827488">
+				<ele>938.2979549551383</ele>
+				<time>2017-11-13T18:18:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01537335521907" lon="-84.20176432827488">
+				<ele>938.2979549551383</ele>
+				<time>2017-11-13T18:18:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01537335521907" lon="-84.20176432827488">
+				<ele>938.2979549551383</ele>
+				<time>2017-11-13T18:18:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01537335521907" lon="-84.20176432827488">
+				<ele>938.2979549551383</ele>
+				<time>2017-11-13T18:18:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01537335521907" lon="-84.20176432827488">
+				<ele>938.2979549551383</ele>
+				<time>2017-11-13T18:18:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015369275445805" lon="-84.20175925810508">
+				<ele>939.0175919057801</ele>
+				<time>2017-11-13T18:18:18Z</time>
+				<extensions>
+					<speed>0.3571626543998718</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015369275445805" lon="-84.20175925810508">
+				<ele>939.0175919057801</ele>
+				<time>2017-11-13T18:18:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01536156744648" lon="-84.20175519853119">
+				<ele>939.8283083159477</ele>
+				<time>2017-11-13T18:18:20Z</time>
+				<extensions>
+					<speed>0.699730396270752</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01534948265356" lon="-84.20175285927532">
+				<ele>939.5787487085909</ele>
+				<time>2017-11-13T18:18:21Z</time>
+				<extensions>
+					<speed>1.001987099647522</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015335763922096" lon="-84.20175218441145">
+				<ele>939.9002545075491</ele>
+				<time>2017-11-13T18:18:22Z</time>
+				<extensions>
+					<speed>1.265964388847351</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015321844578539" lon="-84.20174649072133">
+				<ele>940.3911537174135</ele>
+				<time>2017-11-13T18:18:23Z</time>
+				<extensions>
+					<speed>1.248090147972107</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015309641341817" lon="-84.20174678706924">
+				<ele>940.3866411373019</ele>
+				<time>2017-11-13T18:18:24Z</time>
+				<extensions>
+					<speed>1.2799580097198486</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015303954764212" lon="-84.20173640093601">
+				<ele>940.2976594464853</ele>
+				<time>2017-11-13T18:18:25Z</time>
+				<extensions>
+					<speed>0.9853020906448364</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015303954764212" lon="-84.20173640093601">
+				<ele>940.2976594464853</ele>
+				<time>2017-11-13T18:18:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015304596800569" lon="-84.20173223086488">
+				<ele>941.0699567999691</ele>
+				<time>2017-11-13T18:18:27Z</time>
+				<extensions>
+					<speed>0.5773603916168213</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015304596800569" lon="-84.20173223086488">
+				<ele>941.0699567999691</ele>
+				<time>2017-11-13T18:18:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015300558481798" lon="-84.20173357624925">
+				<ele>940.937122143805</ele>
+				<time>2017-11-13T18:18:29Z</time>
+				<extensions>
+					<speed>0.6067443490028381</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015300558481798" lon="-84.20173357624925">
+				<ele>940.937122143805</ele>
+				<time>2017-11-13T18:18:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01529922338515" lon="-84.20173846443974">
+				<ele>940.5505577661097</ele>
+				<time>2017-11-13T18:18:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01529922338515" lon="-84.20173846443974">
+				<ele>940.5505577661097</ele>
+				<time>2017-11-13T18:18:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015295941189988" lon="-84.20173215519637">
+				<ele>941.2993502179161</ele>
+				<time>2017-11-13T18:18:33Z</time>
+				<extensions>
+					<speed>0.9738627076148987</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015292366509133" lon="-84.20173566551017">
+				<ele>943.9271108917892</ele>
+				<time>2017-11-13T18:18:34Z</time>
+				<extensions>
+					<speed>0.5710678696632385</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01529301763429" lon="-84.2017424888194">
+				<ele>947.5132760647684</ele>
+				<time>2017-11-13T18:18:35Z</time>
+				<extensions>
+					<speed>0.41614437103271484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01529301763429" lon="-84.2017424888194">
+				<ele>947.5132760647684</ele>
+				<time>2017-11-13T18:18:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015297122533612" lon="-84.20175263467257">
+				<ele>948.0792859699577</ele>
+				<time>2017-11-13T18:18:37Z</time>
+				<extensions>
+					<speed>0.5184481739997864</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015301212571824" lon="-84.20176382380086">
+				<ele>948.4109581839293</ele>
+				<time>2017-11-13T18:18:38Z</time>
+				<extensions>
+					<speed>0.8839436173439026</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015311412420715" lon="-84.20178168619368">
+				<ele>948.7670455817133</ele>
+				<time>2017-11-13T18:18:39Z</time>
+				<extensions>
+					<speed>1.4025245904922485</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015321150468138" lon="-84.20179698336499">
+				<ele>948.5647009648383</ele>
+				<time>2017-11-13T18:18:40Z</time>
+				<extensions>
+					<speed>1.3392822742462158</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015329716359235" lon="-84.20180618425532">
+				<ele>948.5293661225587</ele>
+				<time>2017-11-13T18:18:41Z</time>
+				<extensions>
+					<speed>1.0791386365890503</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015333975200587" lon="-84.2018144946029">
+				<ele>948.6354821976274</ele>
+				<time>2017-11-13T18:18:42Z</time>
+				<extensions>
+					<speed>0.5808259844779968</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015333226746758" lon="-84.20182057653533">
+				<ele>947.979178971611</ele>
+				<time>2017-11-13T18:18:43Z</time>
+				<extensions>
+					<speed>0.45068275928497314</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332799825833" lon="-84.201833759431">
+				<ele>946.9187737004831</ele>
+				<time>2017-11-13T18:18:44Z</time>
+				<extensions>
+					<speed>1.1810215711593628</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01533288744688" lon="-84.2018482526357">
+				<ele>946.4372682087123</ele>
+				<time>2017-11-13T18:18:45Z</time>
+				<extensions>
+					<speed>1.9627447128295898</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01532939240454" lon="-84.2018693062652">
+				<ele>946.0938697252423</ele>
+				<time>2017-11-13T18:18:46Z</time>
+				<extensions>
+					<speed>3.281526803970337</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0153189211408" lon="-84.20190295006331">
+				<ele>946.7576986700296</ele>
+				<time>2017-11-13T18:18:47Z</time>
+				<extensions>
+					<speed>5.169652462005615</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015291822792614" lon="-84.20194353801381">
+				<ele>947.5406816257164</ele>
+				<time>2017-11-13T18:18:48Z</time>
+				<extensions>
+					<speed>6.070800304412842</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015249269900988" lon="-84.20198559758663">
+				<ele>947.9144160673022</ele>
+				<time>2017-11-13T18:18:49Z</time>
+				<extensions>
+					<speed>7.235479831695557</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015183952620754" lon="-84.20202005394333">
+				<ele>948.0113487374038</ele>
+				<time>2017-11-13T18:18:50Z</time>
+				<extensions>
+					<speed>8.998282432556152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015102271467601" lon="-84.20206216214426">
+				<ele>948.1434538196772</ele>
+				<time>2017-11-13T18:18:51Z</time>
+				<extensions>
+					<speed>11.109396934509277</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015008391992762" lon="-84.20211534805799">
+				<ele>948.1362209534273</ele>
+				<time>2017-11-13T18:18:52Z</time>
+				<extensions>
+					<speed>12.249654769897461</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014907899226934" lon="-84.20217084502809">
+				<ele>948.0424485998228</ele>
+				<time>2017-11-13T18:18:53Z</time>
+				<extensions>
+					<speed>12.988224983215332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014798308307803" lon="-84.20222895219648">
+				<ele>948.1913019921631</ele>
+				<time>2017-11-13T18:18:54Z</time>
+				<extensions>
+					<speed>13.974745750427246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014685213142727" lon="-84.20228798983065">
+				<ele>948.5038493415341</ele>
+				<time>2017-11-13T18:18:55Z</time>
+				<extensions>
+					<speed>14.15913200378418</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01457424582003" lon="-84.20234118986417">
+				<ele>948.6497839065269</ele>
+				<time>2017-11-13T18:18:56Z</time>
+				<extensions>
+					<speed>13.177326202392578</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014474511381911" lon="-84.20238935858454">
+				<ele>948.5283182933927</ele>
+				<time>2017-11-13T18:18:57Z</time>
+				<extensions>
+					<speed>11.359209060668945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014390234457574" lon="-84.2024318761652">
+				<ele>948.3978106863797</ele>
+				<time>2017-11-13T18:18:58Z</time>
+				<extensions>
+					<speed>9.175091743469238</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432962849334" lon="-84.20246530391164">
+				<ele>948.0823045987636</ele>
+				<time>2017-11-13T18:18:59Z</time>
+				<extensions>
+					<speed>6.200698375701904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014293457806943" lon="-84.20248780147963">
+				<ele>947.8941469443962</ele>
+				<time>2017-11-13T18:19:00Z</time>
+				<extensions>
+					<speed>3.279607057571411</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281963556474" lon="-84.2024989496434">
+				<ele>947.8851304985583</ele>
+				<time>2017-11-13T18:19:01Z</time>
+				<extensions>
+					<speed>0.6116620302200317</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01428706510746" lon="-84.20249989797256">
+				<ele>947.9637136738747</ele>
+				<time>2017-11-13T18:19:02Z</time>
+				<extensions>
+					<speed>0.6243813037872314</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01428706510746" lon="-84.20249989797256">
+				<ele>947.9637136738747</ele>
+				<time>2017-11-13T18:19:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014281869774678" lon="-84.20250072506035">
+				<ele>947.8890402493998</ele>
+				<time>2017-11-13T18:19:04Z</time>
+				<extensions>
+					<speed>0.8279659748077393</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014267411580667" lon="-84.20249794796209">
+				<ele>947.7915678666905</ele>
+				<time>2017-11-13T18:19:05Z</time>
+				<extensions>
+					<speed>1.5378096103668213</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014245331910915" lon="-84.20248896795775">
+				<ele>947.6708866022527</ele>
+				<time>2017-11-13T18:19:06Z</time>
+				<extensions>
+					<speed>2.1820995807647705</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014221086743568" lon="-84.2024730199469">
+				<ele>947.5149845751002</ele>
+				<time>2017-11-13T18:19:07Z</time>
+				<extensions>
+					<speed>2.581576347351074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01420315312623" lon="-84.2024329154911">
+				<ele>946.5248117381707</ele>
+				<time>2017-11-13T18:19:08Z</time>
+				<extensions>
+					<speed>2.7826788425445557</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014180063619797" lon="-84.20241005870027">
+				<ele>946.4573384188116</ele>
+				<time>2017-11-13T18:19:09Z</time>
+				<extensions>
+					<speed>2.8780357837677</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01416620908778" lon="-84.20239142991042">
+				<ele>946.3944689705968</ele>
+				<time>2017-11-13T18:19:10Z</time>
+				<extensions>
+					<speed>2.261866807937622</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014160160464494" lon="-84.2023813326864">
+				<ele>946.3020987613127</ele>
+				<time>2017-11-13T18:19:11Z</time>
+				<extensions>
+					<speed>1.3036413192749023</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014159458579517" lon="-84.20237132856415">
+				<ele>946.2234164625406</ele>
+				<time>2017-11-13T18:19:12Z</time>
+				<extensions>
+					<speed>0.5482972264289856</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014159458579517" lon="-84.20237132856415">
+				<ele>946.2234164625406</ele>
+				<time>2017-11-13T18:19:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014161604204281" lon="-84.20236698264823">
+				<ele>946.1965331351385</ele>
+				<time>2017-11-13T18:19:14Z</time>
+				<extensions>
+					<speed>0.23415744304656982</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014161604204281" lon="-84.20236698264823">
+				<ele>946.1965331351385</ele>
+				<time>2017-11-13T18:19:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014161604204281" lon="-84.20236698264823">
+				<ele>946.1965331351385</ele>
+				<time>2017-11-13T18:19:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014161604204281" lon="-84.20236698264823">
+				<ele>946.1965331351385</ele>
+				<time>2017-11-13T18:19:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01415971392628" lon="-84.20237771898319">
+				<ele>946.4395456342027</ele>
+				<time>2017-11-13T18:19:18Z</time>
+				<extensions>
+					<speed>1.0171743631362915</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014158948285562" lon="-84.20238962886768">
+				<ele>946.6651298347861</ele>
+				<time>2017-11-13T18:19:19Z</time>
+				<extensions>
+					<speed>1.0357717275619507</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01416532861836" lon="-84.20239923851192">
+				<ele>947.0415078913793</ele>
+				<time>2017-11-13T18:19:20Z</time>
+				<extensions>
+					<speed>1.1318981647491455</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014167245351876" lon="-84.20240405270705">
+				<ele>947.2467205831781</ele>
+				<time>2017-11-13T18:19:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014167245351876" lon="-84.20240405270705">
+				<ele>947.2467205831781</ele>
+				<time>2017-11-13T18:19:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014167245351876" lon="-84.20240405270705">
+				<ele>947.2467205831781</ele>
+				<time>2017-11-13T18:19:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014167245351876" lon="-84.20240405270705">
+				<ele>947.2467205831781</ele>
+				<time>2017-11-13T18:19:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014167245351876" lon="-84.20240405270705">
+				<ele>947.2467205831781</ele>
+				<time>2017-11-13T18:19:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014167245351876" lon="-84.20240405270705">
+				<ele>947.2467205831781</ele>
+				<time>2017-11-13T18:19:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014167245351876" lon="-84.20240405270705">
+				<ele>947.2467205831781</ele>
+				<time>2017-11-13T18:19:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014167245351876" lon="-84.20240405270705">
+				<ele>947.2467205831781</ele>
+				<time>2017-11-13T18:19:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014158028002512" lon="-84.20238357271086">
+				<ele>947.1952358614653</ele>
+				<time>2017-11-13T18:19:29Z</time>
+				<extensions>
+					<speed>0.6926645636558533</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014167245351876" lon="-84.20240405270705">
+				<ele>947.2467205831781</ele>
+				<time>2017-11-13T18:19:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01415926922516" lon="-84.20239092676337">
+				<ele>947.0298718987033</ele>
+				<time>2017-11-13T18:19:31Z</time>
+				<extensions>
+					<speed>0.954943835735321</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014144438487339" lon="-84.20236579085906">
+				<ele>946.6375118969008</ele>
+				<time>2017-11-13T18:19:32Z</time>
+				<extensions>
+					<speed>1.8871877193450928</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01412047784077" lon="-84.2023224798651">
+				<ele>946.4602325884625</ele>
+				<time>2017-11-13T18:19:33Z</time>
+				<extensions>
+					<speed>3.771265745162964</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014093911104048" lon="-84.2022658797888">
+				<ele>946.2764522526413</ele>
+				<time>2017-11-13T18:19:34Z</time>
+				<extensions>
+					<speed>6.1759352684021</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014061626277886" lon="-84.20220207243881">
+				<ele>946.1846377337351</ele>
+				<time>2017-11-13T18:19:35Z</time>
+				<extensions>
+					<speed>7.135117053985596</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01403002823521" lon="-84.20213545458721">
+				<ele>945.7476317863911</ele>
+				<time>2017-11-13T18:19:36Z</time>
+				<extensions>
+					<speed>7.091594219207764</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013995811397741" lon="-84.20207279949906">
+				<ele>945.5344947027043</ele>
+				<time>2017-11-13T18:19:37Z</time>
+				<extensions>
+					<speed>7.182158946990967</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013958262358635" lon="-84.20200907205633">
+				<ele>945.7758894274011</ele>
+				<time>2017-11-13T18:19:38Z</time>
+				<extensions>
+					<speed>7.489879608154297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01392511222816" lon="-84.20195051140601">
+				<ele>945.9156678980216</ele>
+				<time>2017-11-13T18:19:39Z</time>
+				<extensions>
+					<speed>7.386849880218506</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013897781201793" lon="-84.20189216842303">
+				<ele>946.0198125010356</ele>
+				<time>2017-11-13T18:19:40Z</time>
+				<extensions>
+					<speed>7.156762599945068</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013878201180832" lon="-84.20184579689187">
+				<ele>946.0943581871688</ele>
+				<time>2017-11-13T18:19:41Z</time>
+				<extensions>
+					<speed>6.033325672149658</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013860350619339" lon="-84.20180492653456">
+				<ele>946.2306764246896</ele>
+				<time>2017-11-13T18:19:42Z</time>
+				<extensions>
+					<speed>4.633455276489258</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013844609814914" lon="-84.20176946952263">
+				<ele>946.129560447298</ele>
+				<time>2017-11-13T18:19:43Z</time>
+				<extensions>
+					<speed>3.4461216926574707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013835555690408" lon="-84.2017560832174">
+				<ele>946.1914466777816</ele>
+				<time>2017-11-13T18:19:44Z</time>
+				<extensions>
+					<speed>1.9374161958694458</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013827124910495" lon="-84.2017447195969">
+				<ele>946.208033349365</ele>
+				<time>2017-11-13T18:19:45Z</time>
+				<extensions>
+					<speed>1.4020328521728516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013818644390104" lon="-84.20173105052662">
+				<ele>946.2435861593112</ele>
+				<time>2017-11-13T18:19:46Z</time>
+				<extensions>
+					<speed>1.5636062622070313</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01380771501895" lon="-84.201715475696">
+				<ele>946.1684889681637</ele>
+				<time>2017-11-13T18:19:47Z</time>
+				<extensions>
+					<speed>1.8517125844955444</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013788334529325" lon="-84.20169450450229">
+				<ele>946.2676660865545</ele>
+				<time>2017-11-13T18:19:48Z</time>
+				<extensions>
+					<speed>2.4909911155700684</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013758767260128" lon="-84.20166257648444">
+				<ele>946.2096837349236</ele>
+				<time>2017-11-13T18:19:49Z</time>
+				<extensions>
+					<speed>3.702116012573242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013720360238967" lon="-84.20162478854157">
+				<ele>946.4182112514973</ele>
+				<time>2017-11-13T18:19:50Z</time>
+				<extensions>
+					<speed>5.409925937652588</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013678926697521" lon="-84.20158239490657">
+				<ele>946.5013726362959</ele>
+				<time>2017-11-13T18:19:51Z</time>
+				<extensions>
+					<speed>6.266515731811523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013638291530855" lon="-84.20154271385896">
+				<ele>946.8097344301641</ele>
+				<time>2017-11-13T18:19:52Z</time>
+				<extensions>
+					<speed>6.33689546585083</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013601359415802" lon="-84.20151143449534">
+				<ele>947.0785481026396</ele>
+				<time>2017-11-13T18:19:53Z</time>
+				<extensions>
+					<speed>6.061587810516357</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01357337506801" lon="-84.20148581255334">
+				<ele>947.3725127549842</ele>
+				<time>2017-11-13T18:19:54Z</time>
+				<extensions>
+					<speed>5.16403341293335</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0135527819852" lon="-84.20146573552972">
+				<ele>947.5767963975668</ele>
+				<time>2017-11-13T18:19:55Z</time>
+				<extensions>
+					<speed>3.733182907104492</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013546025860258" lon="-84.20145291700892">
+				<ele>947.7272303607315</ele>
+				<time>2017-11-13T18:19:56Z</time>
+				<extensions>
+					<speed>1.645996332168579</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013549191955294" lon="-84.20144673158543">
+				<ele>947.7587237693369</ele>
+				<time>2017-11-13T18:19:57Z</time>
+				<extensions>
+					<speed>0.27355706691741943</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01355446301407" lon="-84.20144589384093">
+				<ele>947.7402813704684</ele>
+				<time>2017-11-13T18:19:58Z</time>
+				<extensions>
+					<speed>0.5377349853515625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013562597859359" lon="-84.20144886557881">
+				<ele>947.7167781116441</ele>
+				<time>2017-11-13T18:19:59Z</time>
+				<extensions>
+					<speed>0.667374312877655</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013570368012372" lon="-84.20145025289094">
+				<ele>946.6330044362694</ele>
+				<time>2017-11-13T18:20:00Z</time>
+				<extensions>
+					<speed>0.7157894968986511</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013570368012372" lon="-84.20145025289094">
+				<ele>946.6330044362694</ele>
+				<time>2017-11-13T18:20:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013579279058773" lon="-84.20145476759964">
+				<ele>949.3931469945237</ele>
+				<time>2017-11-13T18:20:02Z</time>
+				<extensions>
+					<speed>0.6775765419006348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013579279058773" lon="-84.20145476759964">
+				<ele>949.3931469945237</ele>
+				<time>2017-11-13T18:20:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013578736952109" lon="-84.20145567329361">
+				<ele>949.2350916750729</ele>
+				<time>2017-11-13T18:20:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013578736952109" lon="-84.20145567329361">
+				<ele>949.2350916750729</ele>
+				<time>2017-11-13T18:20:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013578736952109" lon="-84.20145567329361">
+				<ele>949.2350916750729</ele>
+				<time>2017-11-13T18:20:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013567161608698" lon="-84.20144573297699">
+				<ele>949.6242433572188</ele>
+				<time>2017-11-13T18:20:07Z</time>
+				<extensions>
+					<speed>1.299107313156128</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013546146888146" lon="-84.20142599584842">
+				<ele>949.8507646545768</ele>
+				<time>2017-11-13T18:20:08Z</time>
+				<extensions>
+					<speed>2.230706214904785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013509526259059" lon="-84.20139526812982">
+				<ele>950.0643394449726</ele>
+				<time>2017-11-13T18:20:09Z</time>
+				<extensions>
+					<speed>3.6365835666656494</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01347518893437" lon="-84.2013608658727">
+				<ele>950.5233435835689</ele>
+				<time>2017-11-13T18:20:10Z</time>
+				<extensions>
+					<speed>4.628640651702881</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013439367837595" lon="-84.20131970100347">
+				<ele>950.9413919253275</ele>
+				<time>2017-11-13T18:20:11Z</time>
+				<extensions>
+					<speed>5.364178657531738</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013404272874297" lon="-84.20127194133154">
+				<ele>951.5424974607304</ele>
+				<time>2017-11-13T18:20:12Z</time>
+				<extensions>
+					<speed>5.859013557434082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01336744548885" lon="-84.20121739171039">
+				<ele>952.1401038318872</ele>
+				<time>2017-11-13T18:20:13Z</time>
+				<extensions>
+					<speed>6.320658206939697</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013326625937703" lon="-84.20116068233101">
+				<ele>952.6946277692914</ele>
+				<time>2017-11-13T18:20:14Z</time>
+				<extensions>
+					<speed>6.509763717651367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013286085873604" lon="-84.20110236562678">
+				<ele>953.0739184450358</ele>
+				<time>2017-11-13T18:20:15Z</time>
+				<extensions>
+					<speed>6.560964107513428</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013250897626378" lon="-84.20104609743271">
+				<ele>953.2657342711464</ele>
+				<time>2017-11-13T18:20:16Z</time>
+				<extensions>
+					<speed>6.6146559715271</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013217137923736" lon="-84.2009899316288">
+				<ele>953.4552429290488</ele>
+				<time>2017-11-13T18:20:17Z</time>
+				<extensions>
+					<speed>6.7047343254089355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0131841191239" lon="-84.20093661452093">
+				<ele>953.8689674735069</ele>
+				<time>2017-11-13T18:20:18Z</time>
+				<extensions>
+					<speed>6.655884265899658</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01315140158081" lon="-84.20088755076144">
+				<ele>954.0873970584944</ele>
+				<time>2017-11-13T18:20:19Z</time>
+				<extensions>
+					<speed>6.567707538604736</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013118738109027" lon="-84.20084052872325">
+				<ele>954.3429047614336</ele>
+				<time>2017-11-13T18:20:20Z</time>
+				<extensions>
+					<speed>6.486564636230469</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013088259717033" lon="-84.20080136220163">
+				<ele>954.6485628383234</ele>
+				<time>2017-11-13T18:20:21Z</time>
+				<extensions>
+					<speed>6.105398178100586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013062754769686" lon="-84.20076602587326">
+				<ele>954.7590024340898</ele>
+				<time>2017-11-13T18:20:22Z</time>
+				<extensions>
+					<speed>5.567276954650879</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013050367042547" lon="-84.20076154914136">
+				<ele>954.7418944463134</ele>
+				<time>2017-11-13T18:20:23Z</time>
+				<extensions>
+					<speed>3.9750406742095947</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013040524214817" lon="-84.20074770938108">
+				<ele>955.3523763399571</ele>
+				<time>2017-11-13T18:20:24Z</time>
+				<extensions>
+					<speed>2.649442195892334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013031309089133" lon="-84.20073949072761">
+				<ele>955.5813145535067</ele>
+				<time>2017-11-13T18:20:25Z</time>
+				<extensions>
+					<speed>2.1249849796295166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013022628673495" lon="-84.20072680822156">
+				<ele>955.9886789014563</ele>
+				<time>2017-11-13T18:20:26Z</time>
+				<extensions>
+					<speed>2.090643882751465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013014907688783" lon="-84.20071070793813">
+				<ele>956.3496471829712</ele>
+				<time>2017-11-13T18:20:27Z</time>
+				<extensions>
+					<speed>2.344062089920044</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01301197187995" lon="-84.20068693158261">
+				<ele>956.4617301747203</ele>
+				<time>2017-11-13T18:20:28Z</time>
+				<extensions>
+					<speed>2.9920525550842285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013022319835178" lon="-84.20065761869812">
+				<ele>955.6466367198154</ele>
+				<time>2017-11-13T18:20:29Z</time>
+				<extensions>
+					<speed>4.714847564697266</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013051776338655" lon="-84.20062977693019">
+				<ele>955.1660293629393</ele>
+				<time>2017-11-13T18:20:30Z</time>
+				<extensions>
+					<speed>5.88742208480835</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01309825669782" lon="-84.20059196125857">
+				<ele>955.2490241993219</ele>
+				<time>2017-11-13T18:20:31Z</time>
+				<extensions>
+					<speed>6.982785224914551</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013154144349645" lon="-84.20054916810935">
+				<ele>955.5301586184651</ele>
+				<time>2017-11-13T18:20:32Z</time>
+				<extensions>
+					<speed>7.701977729797363</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013208531306526" lon="-84.20050910653423">
+				<ele>955.7829741640016</ele>
+				<time>2017-11-13T18:20:33Z</time>
+				<extensions>
+					<speed>7.681739807128906</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013262455299381" lon="-84.20046650999558">
+				<ele>955.9979605497792</ele>
+				<time>2017-11-13T18:20:34Z</time>
+				<extensions>
+					<speed>7.320011615753174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013313408768116" lon="-84.2004249081941">
+				<ele>956.1466130968183</ele>
+				<time>2017-11-13T18:20:35Z</time>
+				<extensions>
+					<speed>6.658230781555176</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013358899891056" lon="-84.20038732349786">
+				<ele>956.1249741623178</ele>
+				<time>2017-11-13T18:20:36Z</time>
+				<extensions>
+					<speed>6.118836402893066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013387165952683" lon="-84.20033887702827">
+				<ele>953.3303080499172</ele>
+				<time>2017-11-13T18:20:37Z</time>
+				<extensions>
+					<speed>5.891989231109619</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013443501731937" lon="-84.20031102221704">
+				<ele>959.027106855996</ele>
+				<time>2017-11-13T18:20:38Z</time>
+				<extensions>
+					<speed>5.864029884338379</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01348606867543" lon="-84.200276744016">
+				<ele>959.8123126858845</ele>
+				<time>2017-11-13T18:20:39Z</time>
+				<extensions>
+					<speed>5.694001197814941</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0135348865727" lon="-84.20024300091416">
+				<ele>961.1008313894272</ele>
+				<time>2017-11-13T18:20:40Z</time>
+				<extensions>
+					<speed>5.681934356689453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013583020243212" lon="-84.20020749603493">
+				<ele>961.7927350150421</ele>
+				<time>2017-11-13T18:20:41Z</time>
+				<extensions>
+					<speed>5.818918228149414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013639459924871" lon="-84.20017238966268">
+				<ele>962.3003174187616</ele>
+				<time>2017-11-13T18:20:42Z</time>
+				<extensions>
+					<speed>6.365521430969238</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0136906752399" lon="-84.20013918834306">
+				<ele>962.7677596090361</ele>
+				<time>2017-11-13T18:20:43Z</time>
+				<extensions>
+					<speed>6.446730136871338</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013739139148461" lon="-84.20010854380817">
+				<ele>963.2040119813755</ele>
+				<time>2017-11-13T18:20:44Z</time>
+				<extensions>
+					<speed>6.1072211265563965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013787323972961" lon="-84.20007969610323">
+				<ele>963.3298651324585</ele>
+				<time>2017-11-13T18:20:45Z</time>
+				<extensions>
+					<speed>6.282977104187012</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013833501068477" lon="-84.20004634618442">
+				<ele>963.413246396929</ele>
+				<time>2017-11-13T18:20:46Z</time>
+				<extensions>
+					<speed>6.467790603637695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013882206568168" lon="-84.20000678151493">
+				<ele>964.0475447224453</ele>
+				<time>2017-11-13T18:20:47Z</time>
+				<extensions>
+					<speed>7.272974491119385</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01393801394791" lon="-84.19994981692865">
+				<ele>964.3014295268804</ele>
+				<time>2017-11-13T18:20:48Z</time>
+				<extensions>
+					<speed>8.0374116897583</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013992726534736" lon="-84.19988979731305">
+				<ele>964.6577239520848</ele>
+				<time>2017-11-13T18:20:49Z</time>
+				<extensions>
+					<speed>8.298704147338867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014040964666993" lon="-84.19983907511421">
+				<ele>965.2043069908395</ele>
+				<time>2017-11-13T18:20:50Z</time>
+				<extensions>
+					<speed>7.740846157073975</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01408384423129" lon="-84.1997883013706">
+				<ele>965.7726101046428</ele>
+				<time>2017-11-13T18:20:51Z</time>
+				<extensions>
+					<speed>7.210615158081055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01412261098005" lon="-84.19973799931391">
+				<ele>966.2479346105829</ele>
+				<time>2017-11-13T18:20:52Z</time>
+				<extensions>
+					<speed>7.16267204284668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014164136327187" lon="-84.19969126690806">
+				<ele>967.0512939663604</ele>
+				<time>2017-11-13T18:20:53Z</time>
+				<extensions>
+					<speed>7.076246738433838</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014212617565093" lon="-84.19966430072797">
+				<ele>968.2065597260371</ele>
+				<time>2017-11-13T18:20:54Z</time>
+				<extensions>
+					<speed>6.610691070556641</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014258836041602" lon="-84.19964472024007">
+				<ele>968.7655038172379</ele>
+				<time>2017-11-13T18:20:55Z</time>
+				<extensions>
+					<speed>6.182799339294434</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014296442798692" lon="-84.19961777849326">
+				<ele>969.6757598761469</ele>
+				<time>2017-11-13T18:20:56Z</time>
+				<extensions>
+					<speed>6.092522621154785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01433805382882" lon="-84.19958717547408">
+				<ele>970.2279919376597</ele>
+				<time>2017-11-13T18:20:57Z</time>
+				<extensions>
+					<speed>5.997918128967285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014378837323365" lon="-84.19955744604606">
+				<ele>970.7173559777439</ele>
+				<time>2017-11-13T18:20:58Z</time>
+				<extensions>
+					<speed>5.728127479553223</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014408099526221" lon="-84.19950030759497">
+				<ele>974.5549374185503</ele>
+				<time>2017-11-13T18:20:59Z</time>
+				<extensions>
+					<speed>5.298333644866943</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014440750868678" lon="-84.19950068703363">
+				<ele>973.2698275204748</ele>
+				<time>2017-11-13T18:21:00Z</time>
+				<extensions>
+					<speed>4.740423202514648</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014468325185021" lon="-84.1995014105615">
+				<ele>971.8240381283686</ele>
+				<time>2017-11-13T18:21:01Z</time>
+				<extensions>
+					<speed>3.57778000831604</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014487356840693" lon="-84.19948863796236">
+				<ele>972.0059818150476</ele>
+				<time>2017-11-13T18:21:02Z</time>
+				<extensions>
+					<speed>1.8182705640792847</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014497052668208" lon="-84.19948767755076">
+				<ele>971.9420855594799</ele>
+				<time>2017-11-13T18:21:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014494837505344" lon="-84.19949443030644">
+				<ele>971.2862386144698</ele>
+				<time>2017-11-13T18:21:04Z</time>
+				<extensions>
+					<speed>0.7773672938346863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014487693525416" lon="-84.19950347421444">
+				<ele>971.7534267604351</ele>
+				<time>2017-11-13T18:21:05Z</time>
+				<extensions>
+					<speed>1.6887893676757813</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014482658936041" lon="-84.199517406166">
+				<ele>972.4359248820692</ele>
+				<time>2017-11-13T18:21:06Z</time>
+				<extensions>
+					<speed>1.0628317594528198</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014484058876343" lon="-84.19951715779595">
+				<ele>972.5293657118455</ele>
+				<time>2017-11-13T18:21:07Z</time>
+				<extensions>
+					<speed>0.7215967774391174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014484058876343" lon="-84.19951715779595">
+				<ele>972.5293657118455</ele>
+				<time>2017-11-13T18:21:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014487381136494" lon="-84.19951415620132">
+				<ele>971.6441479567438</ele>
+				<time>2017-11-13T18:21:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014487381136494" lon="-84.19951415620132">
+				<ele>971.6441479567438</ele>
+				<time>2017-11-13T18:21:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014493143164371" lon="-84.19950861038525">
+				<ele>970.5682311672717</ele>
+				<time>2017-11-13T18:21:11Z</time>
+				<extensions>
+					<speed>0.9314135313034058</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014509356934141" lon="-84.19950185790981">
+				<ele>970.5869448622689</ele>
+				<time>2017-11-13T18:21:12Z</time>
+				<extensions>
+					<speed>2.81675386428833</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014533171448539" lon="-84.19948823686084">
+				<ele>970.0063636982813</ele>
+				<time>2017-11-13T18:21:13Z</time>
+				<extensions>
+					<speed>3.609372854232788</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014568580989383" lon="-84.19946086522887">
+				<ele>969.5830236598849</ele>
+				<time>2017-11-13T18:21:14Z</time>
+				<extensions>
+					<speed>5.368017673492432</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01461131444124" lon="-84.19943212093075">
+				<ele>968.9165417551994</ele>
+				<time>2017-11-13T18:21:15Z</time>
+				<extensions>
+					<speed>5.983191967010498</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014657991853133" lon="-84.19940206535937">
+				<ele>967.6700485814363</ele>
+				<time>2017-11-13T18:21:16Z</time>
+				<extensions>
+					<speed>6.1511945724487305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708001047511" lon="-84.19936194967883">
+				<ele>967.2919597374275</ele>
+				<time>2017-11-13T18:21:17Z</time>
+				<extensions>
+					<speed>7.2557692527771</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014760890495324" lon="-84.19931572951144">
+				<ele>966.9266046946868</ele>
+				<time>2017-11-13T18:21:18Z</time>
+				<extensions>
+					<speed>7.399569034576416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014813384161123" lon="-84.19927159580078">
+				<ele>966.7288520149887</ele>
+				<time>2017-11-13T18:21:19Z</time>
+				<extensions>
+					<speed>7.274633884429932</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014866607631937" lon="-84.19923087813368">
+				<ele>966.6181662399322</ele>
+				<time>2017-11-13T18:21:20Z</time>
+				<extensions>
+					<speed>7.210504531860352</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01491533649148" lon="-84.19919469598871">
+				<ele>966.1078424835578</ele>
+				<time>2017-11-13T18:21:21Z</time>
+				<extensions>
+					<speed>6.7541327476501465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014959698925969" lon="-84.19915907406948">
+				<ele>965.2205713903531</ele>
+				<time>2017-11-13T18:21:22Z</time>
+				<extensions>
+					<speed>6.433696269989014</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015001646001352" lon="-84.19912427407661">
+				<ele>965.2017633859068</ele>
+				<time>2017-11-13T18:21:23Z</time>
+				<extensions>
+					<speed>5.988115310668945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0150398476912" lon="-84.19909123354896">
+				<ele>964.9120529349893</ele>
+				<time>2017-11-13T18:21:24Z</time>
+				<extensions>
+					<speed>5.337775230407715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0150738755507" lon="-84.19906234034677">
+				<ele>964.9390019904822</ele>
+				<time>2017-11-13T18:21:25Z</time>
+				<extensions>
+					<speed>4.740720748901367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015104200781867" lon="-84.19903309408379">
+				<ele>964.8144229995087</ele>
+				<time>2017-11-13T18:21:26Z</time>
+				<extensions>
+					<speed>4.786450386047363</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015133274571948" lon="-84.199005677842">
+				<ele>964.8248694613576</ele>
+				<time>2017-11-13T18:21:27Z</time>
+				<extensions>
+					<speed>4.709481239318848</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015163788633926" lon="-84.19897913235621">
+				<ele>964.7100554518402</ele>
+				<time>2017-11-13T18:21:28Z</time>
+				<extensions>
+					<speed>4.826523303985596</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015199327298385" lon="-84.19895137069298">
+				<ele>964.88623422198</ele>
+				<time>2017-11-13T18:21:29Z</time>
+				<extensions>
+					<speed>5.143184185028076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015240168043777" lon="-84.19891621188714">
+				<ele>964.718690042384</ele>
+				<time>2017-11-13T18:21:30Z</time>
+				<extensions>
+					<speed>5.8102126121521</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015282645774224" lon="-84.19887465293701">
+				<ele>964.9133545132354</ele>
+				<time>2017-11-13T18:21:31Z</time>
+				<extensions>
+					<speed>6.693561553955078</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015329428348812" lon="-84.19882895534927">
+				<ele>964.954885168001</ele>
+				<time>2017-11-13T18:21:32Z</time>
+				<extensions>
+					<speed>6.961655139923096</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015377267818156" lon="-84.19878091157763">
+				<ele>964.9345697304234</ele>
+				<time>2017-11-13T18:21:33Z</time>
+				<extensions>
+					<speed>7.284412384033203</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015419256635498" lon="-84.19872935966688">
+				<ele>966.0269987434149</ele>
+				<time>2017-11-13T18:21:34Z</time>
+				<extensions>
+					<speed>7.280423164367676</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01545770151259" lon="-84.1986733045917">
+				<ele>967.7868965175003</ele>
+				<time>2017-11-13T18:21:35Z</time>
+				<extensions>
+					<speed>7.788577079772949</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015489685894877" lon="-84.19861059702977">
+				<ele>968.4409826695919</ele>
+				<time>2017-11-13T18:21:36Z</time>
+				<extensions>
+					<speed>7.568170547485352</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015517045898369" lon="-84.19854226607802">
+				<ele>969.1032995106652</ele>
+				<time>2017-11-13T18:21:37Z</time>
+				<extensions>
+					<speed>7.889195919036865</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015542716352046" lon="-84.19846803715107">
+				<ele>968.9024603366852</ele>
+				<time>2017-11-13T18:21:38Z</time>
+				<extensions>
+					<speed>8.429378509521484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015568636492542" lon="-84.19839257604941">
+				<ele>968.4448717636988</ele>
+				<time>2017-11-13T18:21:39Z</time>
+				<extensions>
+					<speed>8.47957992553711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01559431196985" lon="-84.19831977016825">
+				<ele>968.4183018365875</ele>
+				<time>2017-11-13T18:21:40Z</time>
+				<extensions>
+					<speed>8.02216911315918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015618397628433" lon="-84.19825261371386">
+				<ele>968.588386612013</ele>
+				<time>2017-11-13T18:21:41Z</time>
+				<extensions>
+					<speed>7.353940010070801</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01563916137593" lon="-84.19819002731612">
+				<ele>967.9887952012941</ele>
+				<time>2017-11-13T18:21:42Z</time>
+				<extensions>
+					<speed>6.543674468994141</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015660265095992" lon="-84.19813023836336">
+				<ele>967.8508589575067</ele>
+				<time>2017-11-13T18:21:43Z</time>
+				<extensions>
+					<speed>6.479002952575684</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015682340778186" lon="-84.19807247293232">
+				<ele>967.7436753334478</ele>
+				<time>2017-11-13T18:21:44Z</time>
+				<extensions>
+					<speed>6.641621112823486</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01570474416697" lon="-84.19801628042286">
+				<ele>967.5775103745982</ele>
+				<time>2017-11-13T18:21:45Z</time>
+				<extensions>
+					<speed>6.355174541473389</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015727754067264" lon="-84.19796357944192">
+				<ele>967.498786341399</ele>
+				<time>2017-11-13T18:21:46Z</time>
+				<extensions>
+					<speed>6.106516361236572</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015749597028792" lon="-84.1979131752293">
+				<ele>967.880296330899</ele>
+				<time>2017-11-13T18:21:47Z</time>
+				<extensions>
+					<speed>5.927494049072266</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01576806799456" lon="-84.19786430961155">
+				<ele>968.2426194567233</ele>
+				<time>2017-11-13T18:21:48Z</time>
+				<extensions>
+					<speed>5.694658279418945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015786243855448" lon="-84.19781773325214">
+				<ele>968.4114151811227</ele>
+				<time>2017-11-13T18:21:49Z</time>
+				<extensions>
+					<speed>5.198047637939453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015802795916873" lon="-84.19777251577509">
+				<ele>968.530475826934</ele>
+				<time>2017-11-13T18:21:50Z</time>
+				<extensions>
+					<speed>5.132867336273193</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015820402029021" lon="-84.19772765480356">
+				<ele>968.5789956534281</ele>
+				<time>2017-11-13T18:21:51Z</time>
+				<extensions>
+					<speed>4.977144718170166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015837854272261" lon="-84.19768209049737">
+				<ele>968.6168698007241</ele>
+				<time>2017-11-13T18:21:52Z</time>
+				<extensions>
+					<speed>4.870748996734619</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015857196390396" lon="-84.1976370628346">
+				<ele>968.5099065899849</ele>
+				<time>2017-11-13T18:21:53Z</time>
+				<extensions>
+					<speed>4.929263114929199</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015878110611025" lon="-84.19759096297739">
+				<ele>968.5750855822116</ele>
+				<time>2017-11-13T18:21:54Z</time>
+				<extensions>
+					<speed>5.276113510131836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015899630089542" lon="-84.197543938858">
+				<ele>968.3824980836362</ele>
+				<time>2017-11-13T18:21:55Z</time>
+				<extensions>
+					<speed>5.337828159332275</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015919168326933" lon="-84.19749993736015">
+				<ele>968.3520331298932</ele>
+				<time>2017-11-13T18:21:56Z</time>
+				<extensions>
+					<speed>5.086203098297119</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01593902064802" lon="-84.19745808445577">
+				<ele>968.2160541694611</ele>
+				<time>2017-11-13T18:21:57Z</time>
+				<extensions>
+					<speed>4.982780456542969</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015961390645398" lon="-84.1974149177825">
+				<ele>968.2679965812713</ele>
+				<time>2017-11-13T18:21:58Z</time>
+				<extensions>
+					<speed>5.492551326751709</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015984926865208" lon="-84.19736898784303">
+				<ele>968.9989570202306</ele>
+				<time>2017-11-13T18:21:59Z</time>
+				<extensions>
+					<speed>5.701713562011719</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016008124786547" lon="-84.19732114004555">
+				<ele>969.2793787177652</ele>
+				<time>2017-11-13T18:22:00Z</time>
+				<extensions>
+					<speed>5.843469142913818</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016033402321051" lon="-84.1972721419789">
+				<ele>969.6551568638533</ele>
+				<time>2017-11-13T18:22:01Z</time>
+				<extensions>
+					<speed>6.081159591674805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016060672850363" lon="-84.19722008167874">
+				<ele>970.0952178537846</ele>
+				<time>2017-11-13T18:22:02Z</time>
+				<extensions>
+					<speed>6.543381214141846</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016086469828748" lon="-84.19716604328639">
+				<ele>970.042930024676</ele>
+				<time>2017-11-13T18:22:03Z</time>
+				<extensions>
+					<speed>6.321759223937988</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01610932670286" lon="-84.19711356490923">
+				<ele>970.1386943785474</ele>
+				<time>2017-11-13T18:22:04Z</time>
+				<extensions>
+					<speed>6.1485466957092285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01613410890559" lon="-84.19705902461975">
+				<ele>970.4098016312346</ele>
+				<time>2017-11-13T18:22:05Z</time>
+				<extensions>
+					<speed>6.196497440338135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01615758562643" lon="-84.19700696148523">
+				<ele>970.679213388823</ele>
+				<time>2017-11-13T18:22:06Z</time>
+				<extensions>
+					<speed>6.099855422973633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016181510532402" lon="-84.19695590703832">
+				<ele>970.9163350677118</ele>
+				<time>2017-11-13T18:22:07Z</time>
+				<extensions>
+					<speed>6.046019077301025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01621195928575" lon="-84.1969076763243">
+				<ele>970.7984323864803</ele>
+				<time>2017-11-13T18:22:08Z</time>
+				<extensions>
+					<speed>5.95395040512085</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016243609055925" lon="-84.19685959223256">
+				<ele>970.5756173757836</ele>
+				<time>2017-11-13T18:22:09Z</time>
+				<extensions>
+					<speed>5.940356731414795</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016273258218515" lon="-84.19681902730625">
+				<ele>970.7370777009055</ele>
+				<time>2017-11-13T18:22:10Z</time>
+				<extensions>
+					<speed>5.272316932678223</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016304611669092" lon="-84.19678255643029">
+				<ele>971.0088660912588</ele>
+				<time>2017-11-13T18:22:11Z</time>
+				<extensions>
+					<speed>5.223336219787598</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016333561547377" lon="-84.19674624248006">
+				<ele>971.262917086482</ele>
+				<time>2017-11-13T18:22:12Z</time>
+				<extensions>
+					<speed>5.113037109375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016359839021318" lon="-84.19670999196248">
+				<ele>971.6847873069346</ele>
+				<time>2017-11-13T18:22:13Z</time>
+				<extensions>
+					<speed>4.935541152954102</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016388878862953" lon="-84.19667660554627">
+				<ele>972.3852727040648</ele>
+				<time>2017-11-13T18:22:14Z</time>
+				<extensions>
+					<speed>5.181066989898682</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016418890992723" lon="-84.1966428400006">
+				<ele>972.8994608651847</ele>
+				<time>2017-11-13T18:22:15Z</time>
+				<extensions>
+					<speed>5.503940582275391</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016452528535403" lon="-84.19660735661495">
+				<ele>973.718368967995</ele>
+				<time>2017-11-13T18:22:16Z</time>
+				<extensions>
+					<speed>5.569201469421387</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016486082459416" lon="-84.19656987793815">
+				<ele>974.3979181461036</ele>
+				<time>2017-11-13T18:22:17Z</time>
+				<extensions>
+					<speed>5.587606906890869</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016519462259224" lon="-84.19653006781164">
+				<ele>974.8395333383232</ele>
+				<time>2017-11-13T18:22:18Z</time>
+				<extensions>
+					<speed>5.621687412261963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01655170115057" lon="-84.19648924893217">
+				<ele>975.1279363082722</ele>
+				<time>2017-11-13T18:22:19Z</time>
+				<extensions>
+					<speed>5.952437877655029</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016593243872626" lon="-84.19644865671872">
+				<ele>976.7898317212239</ele>
+				<time>2017-11-13T18:22:20Z</time>
+				<extensions>
+					<speed>6.131175518035889</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016633547364815" lon="-84.19640802367597">
+				<ele>977.6056904308498</ele>
+				<time>2017-11-13T18:22:21Z</time>
+				<extensions>
+					<speed>5.971865653991699</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016669313730457" lon="-84.19637014861543">
+				<ele>977.5881847636774</ele>
+				<time>2017-11-13T18:22:22Z</time>
+				<extensions>
+					<speed>5.273808002471924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016702473454457" lon="-84.19634220712103">
+				<ele>977.6851239744574</ele>
+				<time>2017-11-13T18:22:23Z</time>
+				<extensions>
+					<speed>4.267196178436279</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016728082211147" lon="-84.19632399861251">
+				<ele>977.6760851340368</ele>
+				<time>2017-11-13T18:22:24Z</time>
+				<extensions>
+					<speed>2.669677257537842</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016745253330729" lon="-84.19631255548948">
+				<ele>977.7929653413594</ele>
+				<time>2017-11-13T18:22:25Z</time>
+				<extensions>
+					<speed>1.659551978111267</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016758885426869" lon="-84.19630045899858">
+				<ele>977.4667083006352</ele>
+				<time>2017-11-13T18:22:26Z</time>
+				<extensions>
+					<speed>1.799190878868103</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016774292477969" lon="-84.19628791047997">
+				<ele>976.8458224115893</ele>
+				<time>2017-11-13T18:22:27Z</time>
+				<extensions>
+					<speed>1.9572393894195557</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016792146113215" lon="-84.19627348020337">
+				<ele>975.7887879535556</ele>
+				<time>2017-11-13T18:22:28Z</time>
+				<extensions>
+					<speed>2.496427059173584</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016815158971886" lon="-84.19625633210087">
+				<ele>975.389042573981</ele>
+				<time>2017-11-13T18:22:29Z</time>
+				<extensions>
+					<speed>3.1679251194000244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01684606892551" lon="-84.19623380137139">
+				<ele>974.8356808284298</ele>
+				<time>2017-11-13T18:22:30Z</time>
+				<extensions>
+					<speed>4.114449501037598</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016882054153266" lon="-84.19620874640641">
+				<ele>974.9046296076849</ele>
+				<time>2017-11-13T18:22:31Z</time>
+				<extensions>
+					<speed>4.635778427124023</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01691976987729" lon="-84.19618101785012">
+				<ele>974.9583294969052</ele>
+				<time>2017-11-13T18:22:32Z</time>
+				<extensions>
+					<speed>4.905384063720703</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016957934716558" lon="-84.19615154380827">
+				<ele>975.1753049641848</ele>
+				<time>2017-11-13T18:22:33Z</time>
+				<extensions>
+					<speed>5.137485027313232</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016993492330096" lon="-84.19612000795283">
+				<ele>975.3305704975501</ele>
+				<time>2017-11-13T18:22:34Z</time>
+				<extensions>
+					<speed>4.836462497711182</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017031195750812" lon="-84.19608993016756">
+				<ele>975.1575422044843</ele>
+				<time>2017-11-13T18:22:35Z</time>
+				<extensions>
+					<speed>4.978046417236328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017067836057173" lon="-84.19606214120714">
+				<ele>974.8997390167788</ele>
+				<time>2017-11-13T18:22:36Z</time>
+				<extensions>
+					<speed>4.594191074371338</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017102542757925" lon="-84.19603342255773">
+				<ele>975.2162581998855</ele>
+				<time>2017-11-13T18:22:37Z</time>
+				<extensions>
+					<speed>4.158199787139893</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017134454033897" lon="-84.19601060334624">
+				<ele>975.2369667235762</ele>
+				<time>2017-11-13T18:22:38Z</time>
+				<extensions>
+					<speed>4.08542537689209</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017164825373854" lon="-84.19599169469149">
+				<ele>975.8249661745504</ele>
+				<time>2017-11-13T18:22:39Z</time>
+				<extensions>
+					<speed>3.4678726196289063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017187064923398" lon="-84.19597736899809">
+				<ele>976.0056272121146</ele>
+				<time>2017-11-13T18:22:40Z</time>
+				<extensions>
+					<speed>2.4561548233032227</speed>
+				</extensions>
+			</trkpt>
+		</trkseg>
+	</trk>
+</gpx>

--- a/bus_alajuela-targuases/asistentes/fran_2017_11_20.gpx
+++ b/bus_alajuela-targuases/asistentes/fran_2017_11_20.gpx
@@ -1,0 +1,18999 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="OSMTracker for Android™ - https://github.com/nguillaumin/osmtracker-android" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd ">
+	<wpt lat="10.014330747302324" lon="-84.21692149504864">
+		<ele>931.3282575542107</ele>
+		<time>2017-11-20T18:38:57Z</time>
+		<name><![CDATA[Terciaria]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.014330747302324" lon="-84.21692149504864">
+		<ele>931.3282575542107</ele>
+		<time>2017-11-20T18:38:59Z</time>
+		<name><![CDATA[Terciaria]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.014320078147982" lon="-84.21691576086513">
+		<ele>931.9981452785432</ele>
+		<time>2017-11-20T18:39:29Z</time>
+		<name><![CDATA[Terciaria]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.014320078147982" lon="-84.21691576086513">
+		<ele>931.9981452785432</ele>
+		<time>2017-11-20T18:39:55Z</time>
+		<name><![CDATA[Terciaria]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.014320078147982" lon="-84.21691576086513">
+		<ele>931.9981452785432</ele>
+		<time>2017-11-20T18:39:55Z</time>
+		<name><![CDATA[Terciaria]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.01525575759011" lon="-84.21345920545504">
+		<ele>971.6115047400817</ele>
+		<time>2017-11-20T18:48:30Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.01525458081538" lon="-84.21347839641258">
+		<ele>972.0908097391948</ele>
+		<time>2017-11-20T18:48:31Z</time>
+		<name><![CDATA[3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015734970407925" lon="-84.21186747867601">
+		<ele>968.2783922338858</ele>
+		<time>2017-11-20T18:49:45Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015734970407925" lon="-84.21186747867601">
+		<ele>968.2783922338858</ele>
+		<time>2017-11-20T18:49:46Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.014050598292997" lon="-84.21073597688078">
+		<ele>970.3866566428915</ele>
+		<time>2017-11-20T18:51:05Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.014030379772906" lon="-84.21072417352765">
+		<ele>970.4714941373095</ele>
+		<time>2017-11-20T18:51:06Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.010126500437492" lon="-84.21287700686236">
+		<ele>951.9455301705748</ele>
+		<time>2017-11-20T18:55:11Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.010130506897628" lon="-84.21287835434546">
+		<ele>952.1849596444517</ele>
+		<time>2017-11-20T18:55:12Z</time>
+		<name><![CDATA[2]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008618537855613" lon="-84.2101402591209">
+		<ele>949.7862998424098</ele>
+		<time>2017-11-20T18:56:34Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008622503634747" lon="-84.21013067977717">
+		<ele>949.3647096091881</ele>
+		<time>2017-11-20T18:56:35Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008668067053119" lon="-84.20846678283829">
+		<ele>936.3445620369166</ele>
+		<time>2017-11-20T18:57:50Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008668691948616" lon="-84.208415972918">
+		<ele>936.0171980615705</ele>
+		<time>2017-11-20T18:57:51Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.005795774976834" lon="-84.20601677512826">
+		<ele>930.9443719442934</ele>
+		<time>2017-11-20T18:59:28Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.005800029043524" lon="-84.2060213032811">
+		<ele>931.5637114606798</ele>
+		<time>2017-11-20T18:59:29Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.004774173289901" lon="-84.20665049391145">
+		<ele>930.3783632535487</ele>
+		<time>2017-11-20T19:00:16Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.004774173289901" lon="-84.20665049391145">
+		<ele>930.3783632535487</ele>
+		<time>2017-11-20T19:00:17Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.005994345259575" lon="-84.20436229231574">
+		<ele>944.263673861511</ele>
+		<time>2017-11-20T19:02:44Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.00600040997375" lon="-84.20435852456113">
+		<ele>944.2344946423545</ele>
+		<time>2017-11-20T19:02:45Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.007367595037612" lon="-84.20454898355736">
+		<ele>947.8960783192888</ele>
+		<time>2017-11-20T19:03:34Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.007380631085965" lon="-84.20454414100386">
+		<ele>948.5131155038252</ele>
+		<time>2017-11-20T19:03:35Z</time>
+		<name><![CDATA[3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008964289299612" lon="-84.20317898984413">
+		<ele>943.669817911461</ele>
+		<time>2017-11-20T19:04:31Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008958075375622" lon="-84.20318651090669">
+		<ele>943.9194647818804</ele>
+		<time>2017-11-20T19:04:32Z</time>
+		<name><![CDATA[3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.010185526357303" lon="-84.2021541602572">
+		<ele>949.9858867591247</ele>
+		<time>2017-11-20T19:05:18Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.010182100769285" lon="-84.20215213471258">
+		<ele>950.9201492834836</ele>
+		<time>2017-11-20T19:05:22Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.0120874445267" lon="-84.20110359535511">
+		<ele>959.5335583370179</ele>
+		<time>2017-11-20T19:06:28Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.0120874445267" lon="-84.20110359535511">
+		<ele>959.5335583370179</ele>
+		<time>2017-11-20T19:06:29Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.012744181421313" lon="-84.20076349517711">
+		<ele>959.5735775521025</ele>
+		<time>2017-11-20T19:06:46Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.012777955338708" lon="-84.20074190418988">
+		<ele>959.3671088069677</ele>
+		<time>2017-11-20T19:06:47Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015333109435423" lon="-84.20190292453239">
+		<ele>960.2941835522652</ele>
+		<time>2017-11-20T19:07:59Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015333109435423" lon="-84.20190292453239">
+		<ele>960.2941835522652</ele>
+		<time>2017-11-20T19:07:59Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<trk>
+		<name><![CDATA[Trazado con OSMTracker para Android™]]></name>
+		<trkseg>
+			<trkpt lat="10.013926559485462" lon="-84.21660081567313">
+				<ele>985.5653966218233</ele>
+				<time>2017-11-20T18:26:13Z</time>
+				<extensions>
+					<speed>0.7068222761154175</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014424229413162" lon="-84.21670010427391">
+				<ele>895.7504087742418</ele>
+				<time>2017-11-20T18:26:14Z</time>
+				<extensions>
+					<speed>1.4698680639266968</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014770082134445" lon="-84.21737974187073">
+				<ele>897.5555491838604</ele>
+				<time>2017-11-20T18:26:19Z</time>
+				<extensions>
+					<speed>0.3627999722957611</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014770852676776" lon="-84.21718736066602">
+				<ele>892.517426266335</ele>
+				<time>2017-11-20T18:26:20Z</time>
+				<extensions>
+					<speed>0.6393740773200989</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014592183046844" lon="-84.21700415951076">
+				<ele>909.9754636446014</ele>
+				<time>2017-11-20T18:26:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:26:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:27:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:27:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:27:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:27:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:27:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:27:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:27:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:27:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:27:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:27:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:27:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450710363064" lon="-84.21694020312813">
+				<ele>921.559015199542</ele>
+				<time>2017-11-20T18:27:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01449822215562" lon="-84.21694774325451">
+				<ele>923.2221019687131</ele>
+				<time>2017-11-20T18:27:12Z</time>
+				<extensions>
+					<speed>0.6163766384124756</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014485678643629" lon="-84.21695158964394">
+				<ele>924.2857115725055</ele>
+				<time>2017-11-20T18:27:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:27:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:28:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:29:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:30:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:31:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:31:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:31:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:31:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:31:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:31:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:31:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:31:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:31:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:31:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:31:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447614559196" lon="-84.21695403146529">
+				<ele>925.2377495886758</ele>
+				<time>2017-11-20T18:31:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447328095172" lon="-84.21696019828624">
+				<ele>925.4818006688729</ele>
+				<time>2017-11-20T18:31:12Z</time>
+				<extensions>
+					<speed>0.8711214661598206</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014464282327696" lon="-84.21696463520692">
+				<ele>925.7404584316537</ele>
+				<time>2017-11-20T18:31:13Z</time>
+				<extensions>
+					<speed>0.826647937297821</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014456183115964" lon="-84.21696626617998">
+				<ele>926.6744741052389</ele>
+				<time>2017-11-20T18:31:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:31:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:32:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:33:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:33:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:33:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:33:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:33:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:33:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:33:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:33:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:33:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:33:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:33:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:33:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014453266639999" lon="-84.21696573442138">
+				<ele>927.262332755141</ele>
+				<time>2017-11-20T18:33:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014443156811064" lon="-84.21696673515116">
+				<ele>927.3213816899806</ele>
+				<time>2017-11-20T18:33:13Z</time>
+				<extensions>
+					<speed>0.7464872002601624</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014433337707269" lon="-84.21696776820153">
+				<ele>927.5877840798348</ele>
+				<time>2017-11-20T18:33:14Z</time>
+				<extensions>
+					<speed>0.6637723445892334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014426358547514" lon="-84.21696957238557">
+				<ele>927.8284502010792</ele>
+				<time>2017-11-20T18:33:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:33:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:34:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:34:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:34:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:34:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:34:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:34:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:34:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:34:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:34:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:34:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:34:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:34:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:34:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:34:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421921329632" lon="-84.21697093772586">
+				<ele>927.8678892366588</ele>
+				<time>2017-11-20T18:34:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014421165589088" lon="-84.21697874559142">
+				<ele>927.9668345805258</ele>
+				<time>2017-11-20T18:34:15Z</time>
+				<extensions>
+					<speed>0.8722066283226013</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014417622665132" lon="-84.2169806251933">
+				<ele>927.9182507703081</ele>
+				<time>2017-11-20T18:34:16Z</time>
+				<extensions>
+					<speed>0.7743549942970276</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014416120308873" lon="-84.2169832714593">
+				<ele>928.0227987291291</ele>
+				<time>2017-11-20T18:34:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014412247175295" lon="-84.21698213581945">
+				<ele>927.9318589270115</ele>
+				<time>2017-11-20T18:34:18Z</time>
+				<extensions>
+					<speed>0.17481699585914612</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014412247175295" lon="-84.21698213581945">
+				<ele>927.9318589270115</ele>
+				<time>2017-11-20T18:34:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014412247175295" lon="-84.21698213581945">
+				<ele>927.9318589270115</ele>
+				<time>2017-11-20T18:34:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014412247175295" lon="-84.21698213581945">
+				<ele>927.9318589270115</ele>
+				<time>2017-11-20T18:34:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014412247175295" lon="-84.21698213581945">
+				<ele>927.9318589270115</ele>
+				<time>2017-11-20T18:34:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014412247175295" lon="-84.21698213581945">
+				<ele>927.9318589270115</ele>
+				<time>2017-11-20T18:34:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014412247175295" lon="-84.21698213581945">
+				<ele>927.9318589270115</ele>
+				<time>2017-11-20T18:34:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014412247175295" lon="-84.21698213581945">
+				<ele>927.9318589270115</ele>
+				<time>2017-11-20T18:34:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014412247175295" lon="-84.21698213581945">
+				<ele>927.9318589270115</ele>
+				<time>2017-11-20T18:34:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014412247175295" lon="-84.21698213581945">
+				<ele>927.9318589270115</ele>
+				<time>2017-11-20T18:34:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014412247175295" lon="-84.21698213581945">
+				<ele>927.9318589270115</ele>
+				<time>2017-11-20T18:34:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014412247175295" lon="-84.21698213581945">
+				<ele>927.9318589270115</ele>
+				<time>2017-11-20T18:34:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014412247175295" lon="-84.21698213581945">
+				<ele>927.9318589270115</ele>
+				<time>2017-11-20T18:34:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014412247175295" lon="-84.21698213581945">
+				<ele>927.9318589270115</ele>
+				<time>2017-11-20T18:34:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014412247175295" lon="-84.21698213581945">
+				<ele>927.9318589270115</ele>
+				<time>2017-11-20T18:34:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014412247175295" lon="-84.21698213581945">
+				<ele>927.9318589270115</ele>
+				<time>2017-11-20T18:34:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014412247175295" lon="-84.21698213581945">
+				<ele>927.9318589270115</ele>
+				<time>2017-11-20T18:34:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014412247175295" lon="-84.21698213581945">
+				<ele>927.9318589270115</ele>
+				<time>2017-11-20T18:34:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014413085484886" lon="-84.21698021420636">
+				<ele>928.0091616408899</ele>
+				<time>2017-11-20T18:34:36Z</time>
+				<extensions>
+					<speed>0.6387227773666382</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014414629897745" lon="-84.21697877254863">
+				<ele>928.006197203882</ele>
+				<time>2017-11-20T18:34:37Z</time>
+				<extensions>
+					<speed>0.56246018409729</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014414698882115" lon="-84.21697792103315">
+				<ele>928.5114386184141</ele>
+				<time>2017-11-20T18:34:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014414698882115" lon="-84.21697792103315">
+				<ele>928.5114386184141</ele>
+				<time>2017-11-20T18:34:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014414698882115" lon="-84.21697792103315">
+				<ele>928.5114386184141</ele>
+				<time>2017-11-20T18:34:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014414698882115" lon="-84.21697792103315">
+				<ele>928.5114386184141</ele>
+				<time>2017-11-20T18:34:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014414698882115" lon="-84.21697792103315">
+				<ele>928.5114386184141</ele>
+				<time>2017-11-20T18:34:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014414698882115" lon="-84.21697792103315">
+				<ele>928.5114386184141</ele>
+				<time>2017-11-20T18:34:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014414698882115" lon="-84.21697792103315">
+				<ele>928.5114386184141</ele>
+				<time>2017-11-20T18:34:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014414717405016" lon="-84.21697915250442">
+				<ele>928.6313014226034</ele>
+				<time>2017-11-20T18:34:45Z</time>
+				<extensions>
+					<speed>0.7498646378517151</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014415073743942" lon="-84.21698182200545">
+				<ele>928.7774412054569</ele>
+				<time>2017-11-20T18:34:46Z</time>
+				<extensions>
+					<speed>0.6491032242774963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01441250256543" lon="-84.21698145369724">
+				<ele>929.0078315651044</ele>
+				<time>2017-11-20T18:34:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014410003878119" lon="-84.21698181984536">
+				<ele>929.1731132566929</ele>
+				<time>2017-11-20T18:34:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014410003878119" lon="-84.21698181984536">
+				<ele>929.1731132566929</ele>
+				<time>2017-11-20T18:34:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014410003878119" lon="-84.21698181984536">
+				<ele>929.1731132566929</ele>
+				<time>2017-11-20T18:34:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014410003878119" lon="-84.21698181984536">
+				<ele>929.1731132566929</ele>
+				<time>2017-11-20T18:34:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014410003878119" lon="-84.21698181984536">
+				<ele>929.1731132566929</ele>
+				<time>2017-11-20T18:34:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014410003878119" lon="-84.21698181984536">
+				<ele>929.1731132566929</ele>
+				<time>2017-11-20T18:34:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014410003878119" lon="-84.21698181984536">
+				<ele>929.1731132566929</ele>
+				<time>2017-11-20T18:34:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014410003878119" lon="-84.21698181984536">
+				<ele>929.1731132566929</ele>
+				<time>2017-11-20T18:34:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014410003878119" lon="-84.21698181984536">
+				<ele>929.1731132566929</ele>
+				<time>2017-11-20T18:34:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014410003878119" lon="-84.21698181984536">
+				<ele>929.1731132566929</ele>
+				<time>2017-11-20T18:34:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014410003878119" lon="-84.21698181984536">
+				<ele>929.1731132566929</ele>
+				<time>2017-11-20T18:34:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014410003878119" lon="-84.21698181984536">
+				<ele>929.1731132566929</ele>
+				<time>2017-11-20T18:34:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014399457430807" lon="-84.21697525332175">
+				<ele>929.2591486154124</ele>
+				<time>2017-11-20T18:35:00Z</time>
+				<extensions>
+					<speed>0.9149670600891113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014390104412312" lon="-84.21696671091529">
+				<ele>929.2783680800349</ele>
+				<time>2017-11-20T18:35:01Z</time>
+				<extensions>
+					<speed>1.2635669708251953</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01438489508127" lon="-84.21696096392323">
+				<ele>929.2977040084079</ele>
+				<time>2017-11-20T18:35:02Z</time>
+				<extensions>
+					<speed>0.6387509107589722</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014383088286534" lon="-84.21695792042087">
+				<ele>929.4512253832072</ele>
+				<time>2017-11-20T18:35:03Z</time>
+				<extensions>
+					<speed>0.18075160682201385</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014381734737983" lon="-84.21695859127585">
+				<ele>929.7578928023577</ele>
+				<time>2017-11-20T18:35:04Z</time>
+				<extensions>
+					<speed>0.4398050606250763</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014381734737983" lon="-84.21695859127585">
+				<ele>929.7578928023577</ele>
+				<time>2017-11-20T18:35:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014381407943063" lon="-84.21695909069105">
+				<ele>930.0099117914215</ele>
+				<time>2017-11-20T18:35:06Z</time>
+				<extensions>
+					<speed>0.3524729311466217</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014381407943063" lon="-84.21695909069105">
+				<ele>930.0099117914215</ele>
+				<time>2017-11-20T18:35:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014381407943063" lon="-84.21695909069105">
+				<ele>930.0099117914215</ele>
+				<time>2017-11-20T18:35:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437579849525" lon="-84.21695399104843">
+				<ele>930.3073319140822</ele>
+				<time>2017-11-20T18:35:09Z</time>
+				<extensions>
+					<speed>0.6061879992485046</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014368888343911" lon="-84.21694765999135">
+				<ele>930.3852902343497</ele>
+				<time>2017-11-20T18:35:10Z</time>
+				<extensions>
+					<speed>0.794871985912323</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01435877215951" lon="-84.21693934523215">
+				<ele>930.0340427877381</ele>
+				<time>2017-11-20T18:35:11Z</time>
+				<extensions>
+					<speed>0.9514586329460144</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014347727816427" lon="-84.21693444500244">
+				<ele>930.0753229772672</ele>
+				<time>2017-11-20T18:35:12Z</time>
+				<extensions>
+					<speed>0.9831007122993469</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014337918894777" lon="-84.21693024858276">
+				<ele>930.0578085305169</ele>
+				<time>2017-11-20T18:35:13Z</time>
+				<extensions>
+					<speed>0.8844242691993713</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330231136505" lon="-84.21692520726397">
+				<ele>929.7313377773389</ele>
+				<time>2017-11-20T18:35:14Z</time>
+				<extensions>
+					<speed>0.8419284224510193</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014324664984105" lon="-84.21691633997892">
+				<ele>929.5025947261602</ele>
+				<time>2017-11-20T18:35:15Z</time>
+				<extensions>
+					<speed>0.8211866021156311</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014323807243674" lon="-84.21691050523033">
+				<ele>930.0785079551861</ele>
+				<time>2017-11-20T18:35:16Z</time>
+				<extensions>
+					<speed>0.8157056570053101</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014321083116462" lon="-84.21690692179031">
+				<ele>930.5711443973705</ele>
+				<time>2017-11-20T18:35:17Z</time>
+				<extensions>
+					<speed>0.67575603723526</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320129596296" lon="-84.21690356481706">
+				<ele>930.773986119777</ele>
+				<time>2017-11-20T18:35:18Z</time>
+				<extensions>
+					<speed>0.6057356595993042</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01431721290641" lon="-84.21690928025606">
+				<ele>931.2389187831432</ele>
+				<time>2017-11-20T18:35:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:20Z</time>
+				<extensions>
+					<speed>0.13563957810401917</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014313483088479" lon="-84.21691884101644">
+				<ele>931.5285981455818</ele>
+				<time>2017-11-20T18:35:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014322891240875" lon="-84.21692275164622">
+				<ele>931.4825647417456</ele>
+				<time>2017-11-20T18:36:00Z</time>
+				<extensions>
+					<speed>1.0924357175827026</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014329822644191" lon="-84.21692684201273">
+				<ele>931.7773371236399</ele>
+				<time>2017-11-20T18:36:01Z</time>
+				<extensions>
+					<speed>1.1334223747253418</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014334792738481" lon="-84.21693049563112">
+				<ele>932.3356668101624</ele>
+				<time>2017-11-20T18:36:02Z</time>
+				<extensions>
+					<speed>0.9799218773841858</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014338095163534" lon="-84.21693491629757">
+				<ele>932.4621018730104</ele>
+				<time>2017-11-20T18:36:03Z</time>
+				<extensions>
+					<speed>0.8238523006439209</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014339320524723" lon="-84.2169391377882">
+				<ele>932.8299110447988</ele>
+				<time>2017-11-20T18:36:04Z</time>
+				<extensions>
+					<speed>0.7075905203819275</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014336628156512" lon="-84.21693634772775">
+				<ele>932.916589085944</ele>
+				<time>2017-11-20T18:36:05Z</time>
+				<extensions>
+					<speed>0.2925112843513489</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014333880399487" lon="-84.2169329208127">
+				<ele>932.9858623817563</ele>
+				<time>2017-11-20T18:36:06Z</time>
+				<extensions>
+					<speed>0.3082554340362549</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014333880399487" lon="-84.2169329208127">
+				<ele>932.9858623817563</ele>
+				<time>2017-11-20T18:36:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014333880399487" lon="-84.2169329208127">
+				<ele>932.9858623817563</ele>
+				<time>2017-11-20T18:36:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014333880399487" lon="-84.2169329208127">
+				<ele>932.9858623817563</ele>
+				<time>2017-11-20T18:36:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014333880399487" lon="-84.2169329208127">
+				<ele>932.9858623817563</ele>
+				<time>2017-11-20T18:36:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014333880399487" lon="-84.2169329208127">
+				<ele>932.9858623817563</ele>
+				<time>2017-11-20T18:36:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014333880399487" lon="-84.2169329208127">
+				<ele>932.9858623817563</ele>
+				<time>2017-11-20T18:36:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014333880399487" lon="-84.2169329208127">
+				<ele>932.9858623817563</ele>
+				<time>2017-11-20T18:36:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330691771006" lon="-84.21692646046077">
+				<ele>932.3483183709905</ele>
+				<time>2017-11-20T18:36:14Z</time>
+				<extensions>
+					<speed>0.7427346706390381</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432175866904" lon="-84.21691830837847">
+				<ele>931.3025499591604</ele>
+				<time>2017-11-20T18:36:15Z</time>
+				<extensions>
+					<speed>0.6413780450820923</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014315963473088" lon="-84.21691369830346">
+				<ele>930.9315399248153</ele>
+				<time>2017-11-20T18:36:16Z</time>
+				<extensions>
+					<speed>0.7519640326499939</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014311907449281" lon="-84.21690952307998">
+				<ele>930.7201519859955</ele>
+				<time>2017-11-20T18:36:17Z</time>
+				<extensions>
+					<speed>0.7346517443656921</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014316544527762" lon="-84.2169112919661">
+				<ele>930.2720801234245</ele>
+				<time>2017-11-20T18:36:18Z</time>
+				<extensions>
+					<speed>0.5234798789024353</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:19Z</time>
+				<extensions>
+					<speed>0.034357815980911255</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:36:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014318697024656" lon="-84.216914365853">
+				<ele>930.3244780935347</ele>
+				<time>2017-11-20T18:37:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014326344840597" lon="-84.21692133981927">
+				<ele>930.2013494158164</ele>
+				<time>2017-11-20T18:37:45Z</time>
+				<extensions>
+					<speed>0.8871238827705383</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014333124038515" lon="-84.21692429942703">
+				<ele>930.3648914629593</ele>
+				<time>2017-11-20T18:37:46Z</time>
+				<extensions>
+					<speed>1.166526198387146</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01433456343366" lon="-84.21692412624765">
+				<ele>930.9330302421004</ele>
+				<time>2017-11-20T18:37:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:37:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:37:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:37:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:37:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:37:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:37:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:37:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:37:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:37:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:37:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:37:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:37:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:38:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:39:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:39:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:39:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:39:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:39:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:39:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:39:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:39:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:39:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:39:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:39:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:39:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:39:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:39:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:39:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:39:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:39:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:39:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:39:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330747302324" lon="-84.21692149504864">
+				<ele>931.3282575542107</ele>
+				<time>2017-11-20T18:39:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014329930679128" lon="-84.21691667274965">
+				<ele>931.5699113216251</ele>
+				<time>2017-11-20T18:39:20Z</time>
+				<extensions>
+					<speed>0.7827282547950745</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432593521359" lon="-84.216912640899">
+				<ele>931.7385314600542</ele>
+				<time>2017-11-20T18:39:21Z</time>
+				<extensions>
+					<speed>0.6832770109176636</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01432218751395" lon="-84.21691242326419">
+				<ele>931.9339752262458</ele>
+				<time>2017-11-20T18:39:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:39:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:40:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:41:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:41:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:41:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:41:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:41:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:41:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:41:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:41:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:41:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:41:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:41:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:41:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:41:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:41:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:41:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:41:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:41:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:41:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014320078147982" lon="-84.21691576086513">
+				<ele>931.9981452785432</ele>
+				<time>2017-11-20T18:41:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014324229003273" lon="-84.21692076878541">
+				<ele>932.0975339217111</ele>
+				<time>2017-11-20T18:41:19Z</time>
+				<extensions>
+					<speed>0.6306987404823303</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014328047633681" lon="-84.21693004318105">
+				<ele>932.4556418759748</ele>
+				<time>2017-11-20T18:41:20Z</time>
+				<extensions>
+					<speed>0.9299554824829102</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014330614553833" lon="-84.21693709429756">
+				<ele>933.3989069070667</ele>
+				<time>2017-11-20T18:41:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:22Z</time>
+				<extensions>
+					<speed>0.1958763301372528</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:41:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:42:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:42:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:42:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:42:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:42:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:42:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:42:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:42:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:42:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:42:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:42:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:42:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:42:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014327995234929" lon="-84.21693847730198">
+				<ele>933.4144609998912</ele>
+				<time>2017-11-20T18:42:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014332622130073" lon="-84.21694456148535">
+				<ele>933.6291863610968</ele>
+				<time>2017-11-20T18:42:15Z</time>
+				<extensions>
+					<speed>0.7193276882171631</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014335930862226" lon="-84.21694900449923">
+				<ele>933.9716504393145</ele>
+				<time>2017-11-20T18:42:16Z</time>
+				<extensions>
+					<speed>0.44438862800598145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345876902752" lon="-84.21694885149864">
+				<ele>934.3074187384918</ele>
+				<time>2017-11-20T18:42:17Z</time>
+				<extensions>
+					<speed>0.2704773545265198</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345876902752" lon="-84.21694885149864">
+				<ele>934.3074187384918</ele>
+				<time>2017-11-20T18:42:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345876902752" lon="-84.21694885149864">
+				<ele>934.3074187384918</ele>
+				<time>2017-11-20T18:42:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345876902752" lon="-84.21694885149864">
+				<ele>934.3074187384918</ele>
+				<time>2017-11-20T18:42:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345876902752" lon="-84.21694885149864">
+				<ele>934.3074187384918</ele>
+				<time>2017-11-20T18:42:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345876902752" lon="-84.21694885149864">
+				<ele>934.3074187384918</ele>
+				<time>2017-11-20T18:42:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345876902752" lon="-84.21694885149864">
+				<ele>934.3074187384918</ele>
+				<time>2017-11-20T18:42:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345876902752" lon="-84.21694885149864">
+				<ele>934.3074187384918</ele>
+				<time>2017-11-20T18:42:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345876902752" lon="-84.21694885149864">
+				<ele>934.3074187384918</ele>
+				<time>2017-11-20T18:42:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345876902752" lon="-84.21694885149864">
+				<ele>934.3074187384918</ele>
+				<time>2017-11-20T18:42:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345876902752" lon="-84.21694885149864">
+				<ele>934.3074187384918</ele>
+				<time>2017-11-20T18:42:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014345876902752" lon="-84.21694885149864">
+				<ele>934.3074187384918</ele>
+				<time>2017-11-20T18:42:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014343145880618" lon="-84.2169532165301">
+				<ele>934.5120093394071</ele>
+				<time>2017-11-20T18:42:29Z</time>
+				<extensions>
+					<speed>0.8029643297195435</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014349594030607" lon="-84.21696183041466">
+				<ele>934.5945071456954</ele>
+				<time>2017-11-20T18:42:30Z</time>
+				<extensions>
+					<speed>1.3421329259872437</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014356109835703" lon="-84.2169699644475">
+				<ele>934.8144086794928</ele>
+				<time>2017-11-20T18:42:31Z</time>
+				<extensions>
+					<speed>1.0637152194976807</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014361350535859" lon="-84.2169766542556">
+				<ele>935.0684006167576</ele>
+				<time>2017-11-20T18:42:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:42:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:43:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01436043679456" lon="-84.21697915191288">
+				<ele>935.3384329406545</ele>
+				<time>2017-11-20T18:44:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01435781937938" lon="-84.21697931038847">
+				<ele>935.7610647324473</ele>
+				<time>2017-11-20T18:44:35Z</time>
+				<extensions>
+					<speed>0.7353625893592834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014356003044494" lon="-84.21698546361847">
+				<ele>936.0998131539673</ele>
+				<time>2017-11-20T18:44:36Z</time>
+				<extensions>
+					<speed>0.7610872983932495</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014356377179878" lon="-84.21698836687627">
+				<ele>937.0520741995424</ele>
+				<time>2017-11-20T18:44:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:44:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014350451648415" lon="-84.21698632386182">
+				<ele>936.8830014541745</ele>
+				<time>2017-11-20T18:45:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01435063787593" lon="-84.21697930200085">
+				<ele>936.8538138251752</ele>
+				<time>2017-11-20T18:45:40Z</time>
+				<extensions>
+					<speed>0.6479511857032776</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014352260539262" lon="-84.21696450392956">
+				<ele>936.6902464358136</ele>
+				<time>2017-11-20T18:45:41Z</time>
+				<extensions>
+					<speed>1.4082428216934204</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014355719863016" lon="-84.21694661402772">
+				<ele>936.9188003204763</ele>
+				<time>2017-11-20T18:45:42Z</time>
+				<extensions>
+					<speed>2.0475096702575684</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014364272346302" lon="-84.21692445907962">
+				<ele>937.447307843715</ele>
+				<time>2017-11-20T18:45:43Z</time>
+				<extensions>
+					<speed>2.549010753631592</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014376710384958" lon="-84.21689645641658">
+				<ele>937.300817602314</ele>
+				<time>2017-11-20T18:45:44Z</time>
+				<extensions>
+					<speed>3.085531711578369</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01438954950019" lon="-84.21686365928849">
+				<ele>937.5732643278316</ele>
+				<time>2017-11-20T18:45:45Z</time>
+				<extensions>
+					<speed>4.139695167541504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014402600507779" lon="-84.21682337321285">
+				<ele>938.0370127670467</ele>
+				<time>2017-11-20T18:45:46Z</time>
+				<extensions>
+					<speed>4.92608118057251</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014414171437654" lon="-84.21677557161973">
+				<ele>938.204558134079</ele>
+				<time>2017-11-20T18:45:47Z</time>
+				<extensions>
+					<speed>5.540737628936768</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014424747314704" lon="-84.21672373729274">
+				<ele>938.4291921639815</ele>
+				<time>2017-11-20T18:45:48Z</time>
+				<extensions>
+					<speed>5.514076232910156</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014433028634647" lon="-84.21667665580804">
+				<ele>938.748213945888</ele>
+				<time>2017-11-20T18:45:49Z</time>
+				<extensions>
+					<speed>4.670246124267578</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014442389814928" lon="-84.21663933020608">
+				<ele>939.4258341705427</ele>
+				<time>2017-11-20T18:45:50Z</time>
+				<extensions>
+					<speed>3.380286455154419</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014450406108203" lon="-84.21661431840378">
+				<ele>940.1537268580869</ele>
+				<time>2017-11-20T18:45:51Z</time>
+				<extensions>
+					<speed>2.098806142807007</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014454257964518" lon="-84.21659903400413">
+				<ele>940.5693512652069</ele>
+				<time>2017-11-20T18:45:52Z</time>
+				<extensions>
+					<speed>1.181422472000122</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0144557775172" lon="-84.21659335930016">
+				<ele>940.9802025677636</ele>
+				<time>2017-11-20T18:45:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0144557775172" lon="-84.21659335930016">
+				<ele>940.9802025677636</ele>
+				<time>2017-11-20T18:45:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445261411929" lon="-84.21659581572226">
+				<ele>941.2839971603826</ele>
+				<time>2017-11-20T18:45:55Z</time>
+				<extensions>
+					<speed>0.7504593133926392</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014449764010264" lon="-84.21660409948846">
+				<ele>941.4255410088226</ele>
+				<time>2017-11-20T18:45:56Z</time>
+				<extensions>
+					<speed>1.2191119194030762</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014443797361388" lon="-84.21661463698533">
+				<ele>941.6012177877128</ele>
+				<time>2017-11-20T18:45:57Z</time>
+				<extensions>
+					<speed>1.536345362663269</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014435373066261" lon="-84.21662318248218">
+				<ele>941.8154188431799</ele>
+				<time>2017-11-20T18:45:58Z</time>
+				<extensions>
+					<speed>1.3276499509811401</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014428356790937" lon="-84.21662915081464">
+				<ele>941.9823442865163</ele>
+				<time>2017-11-20T18:45:59Z</time>
+				<extensions>
+					<speed>1.0452587604522705</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014423925796553" lon="-84.21663321885684">
+				<ele>942.0289298286662</ele>
+				<time>2017-11-20T18:46:00Z</time>
+				<extensions>
+					<speed>0.8083462119102478</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014423925796553" lon="-84.21663321885684">
+				<ele>942.0289298286662</ele>
+				<time>2017-11-20T18:46:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01442088873671" lon="-84.21663406634872">
+				<ele>942.2654553586617</ele>
+				<time>2017-11-20T18:46:02Z</time>
+				<extensions>
+					<speed>0.5269980430603027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01442088873671" lon="-84.21663406634872">
+				<ele>942.2654553586617</ele>
+				<time>2017-11-20T18:46:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014420814476782" lon="-84.21663039105844">
+				<ele>942.5132517693564</ele>
+				<time>2017-11-20T18:46:04Z</time>
+				<extensions>
+					<speed>0.16288982331752777</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014420814476782" lon="-84.21663039105844">
+				<ele>942.5132517693564</ele>
+				<time>2017-11-20T18:46:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014420814476782" lon="-84.21663039105844">
+				<ele>942.5132517693564</ele>
+				<time>2017-11-20T18:46:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014424679585012" lon="-84.21662536376796">
+				<ele>943.0409371424466</ele>
+				<time>2017-11-20T18:46:07Z</time>
+				<extensions>
+					<speed>0.763091504573822</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014424679585012" lon="-84.21662536376796">
+				<ele>943.0409371424466</ele>
+				<time>2017-11-20T18:46:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01442825159431" lon="-84.21661895817458">
+				<ele>943.2913337284699</ele>
+				<time>2017-11-20T18:46:09Z</time>
+				<extensions>
+					<speed>0.7684516906738281</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01442825159431" lon="-84.21661895817458">
+				<ele>943.2913337284699</ele>
+				<time>2017-11-20T18:46:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014426801333654" lon="-84.216617922014">
+				<ele>943.670612776652</ele>
+				<time>2017-11-20T18:46:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014426801333654" lon="-84.216617922014">
+				<ele>943.670612776652</ele>
+				<time>2017-11-20T18:46:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014426801333654" lon="-84.216617922014">
+				<ele>943.670612776652</ele>
+				<time>2017-11-20T18:46:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014426801333654" lon="-84.216617922014">
+				<ele>943.670612776652</ele>
+				<time>2017-11-20T18:46:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014426801333654" lon="-84.216617922014">
+				<ele>943.670612776652</ele>
+				<time>2017-11-20T18:46:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014426801333654" lon="-84.216617922014">
+				<ele>943.670612776652</ele>
+				<time>2017-11-20T18:46:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014426801333654" lon="-84.216617922014">
+				<ele>943.670612776652</ele>
+				<time>2017-11-20T18:46:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014426801333654" lon="-84.216617922014">
+				<ele>943.670612776652</ele>
+				<time>2017-11-20T18:46:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014430260860493" lon="-84.21660743562997">
+				<ele>943.6612101430073</ele>
+				<time>2017-11-20T18:46:19Z</time>
+				<extensions>
+					<speed>1.2506734132766724</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014435130628211" lon="-84.21659097445057">
+				<ele>943.6764181694016</ele>
+				<time>2017-11-20T18:46:20Z</time>
+				<extensions>
+					<speed>1.5945158004760742</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01443933806781" lon="-84.21657421333872">
+				<ele>946.2471676897258</ele>
+				<time>2017-11-20T18:46:21Z</time>
+				<extensions>
+					<speed>1.543773889541626</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014432189013979" lon="-84.21655697740829">
+				<ele>946.6302660275251</ele>
+				<time>2017-11-20T18:46:22Z</time>
+				<extensions>
+					<speed>1.5659617185592651</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014430133051345" lon="-84.21654666100795">
+				<ele>947.8052702005953</ele>
+				<time>2017-11-20T18:46:23Z</time>
+				<extensions>
+					<speed>0.5723326802253723</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01443782840466" lon="-84.21653376342356">
+				<ele>948.9950095657259</ele>
+				<time>2017-11-20T18:46:24Z</time>
+				<extensions>
+					<speed>1.9706811904907227</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014448821021794" lon="-84.21650637591527">
+				<ele>950.1516015399247</ele>
+				<time>2017-11-20T18:46:25Z</time>
+				<extensions>
+					<speed>3.4247372150421143</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445905777593" lon="-84.2164627539683">
+				<ele>950.6163403913379</ele>
+				<time>2017-11-20T18:46:26Z</time>
+				<extensions>
+					<speed>4.845724582672119</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014470636936625" lon="-84.21641229510608">
+				<ele>951.3363658636808</ele>
+				<time>2017-11-20T18:46:27Z</time>
+				<extensions>
+					<speed>4.918935775756836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01448897959511" lon="-84.21635885015706">
+				<ele>951.4802135955542</ele>
+				<time>2017-11-20T18:46:28Z</time>
+				<extensions>
+					<speed>5.09212589263916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014507962994024" lon="-84.21630546263768">
+				<ele>951.5994060579687</ele>
+				<time>2017-11-20T18:46:29Z</time>
+				<extensions>
+					<speed>5.321928024291992</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014526797240771" lon="-84.21625384380161">
+				<ele>951.7734729275107</ele>
+				<time>2017-11-20T18:46:30Z</time>
+				<extensions>
+					<speed>5.4806132316589355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014544597747944" lon="-84.21620450556074">
+				<ele>952.1913290293887</ele>
+				<time>2017-11-20T18:46:31Z</time>
+				<extensions>
+					<speed>5.283897876739502</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014559826364131" lon="-84.21615981008627">
+				<ele>952.4560400238261</ele>
+				<time>2017-11-20T18:46:32Z</time>
+				<extensions>
+					<speed>4.549704074859619</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014575864614491" lon="-84.2161137682525">
+				<ele>952.2740254318342</ele>
+				<time>2017-11-20T18:46:33Z</time>
+				<extensions>
+					<speed>4.096926689147949</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014588338266421" lon="-84.21607773339521">
+				<ele>952.6031911736354</ele>
+				<time>2017-11-20T18:46:34Z</time>
+				<extensions>
+					<speed>3.474682569503784</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014602322680032" lon="-84.21604388657927">
+				<ele>953.0837495392188</ele>
+				<time>2017-11-20T18:46:35Z</time>
+				<extensions>
+					<speed>3.413823127746582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01461520588143" lon="-84.2160126017412">
+				<ele>953.5512452637777</ele>
+				<time>2017-11-20T18:46:36Z</time>
+				<extensions>
+					<speed>3.2736289501190186</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014625966973627" lon="-84.21597650490826">
+				<ele>954.0896807983518</ele>
+				<time>2017-11-20T18:46:37Z</time>
+				<extensions>
+					<speed>3.5390145778656006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014635283459516" lon="-84.2159375705343">
+				<ele>954.4486181922257</ele>
+				<time>2017-11-20T18:46:38Z</time>
+				<extensions>
+					<speed>4.173933982849121</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01464544766706" lon="-84.21589578845439">
+				<ele>954.7184100830927</ele>
+				<time>2017-11-20T18:46:39Z</time>
+				<extensions>
+					<speed>4.5029296875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014654175976782" lon="-84.21584813123472">
+				<ele>954.8257337445393</ele>
+				<time>2017-11-20T18:46:40Z</time>
+				<extensions>
+					<speed>5.204372882843018</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014662609825773" lon="-84.21579270421579">
+				<ele>955.0042938189581</ele>
+				<time>2017-11-20T18:46:41Z</time>
+				<extensions>
+					<speed>6.167464256286621</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01467207716452" lon="-84.21572177136744">
+				<ele>955.7491241656244</ele>
+				<time>2017-11-20T18:46:42Z</time>
+				<extensions>
+					<speed>6.597303867340088</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014684311220098" lon="-84.21566178644603">
+				<ele>955.8036539042369</ele>
+				<time>2017-11-20T18:46:43Z</time>
+				<extensions>
+					<speed>6.393009662628174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01469795138495" lon="-84.2156016396559">
+				<ele>956.109970651567</ele>
+				<time>2017-11-20T18:46:44Z</time>
+				<extensions>
+					<speed>6.696870803833008</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014712834360358" lon="-84.2155399546594">
+				<ele>956.4606251623482</ele>
+				<time>2017-11-20T18:46:45Z</time>
+				<extensions>
+					<speed>6.873768329620361</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014730470327562" lon="-84.21547620514538">
+				<ele>956.7901571691036</ele>
+				<time>2017-11-20T18:46:46Z</time>
+				<extensions>
+					<speed>6.9563798904418945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014748313662482" lon="-84.21541308281498">
+				<ele>957.1621535820886</ele>
+				<time>2017-11-20T18:46:47Z</time>
+				<extensions>
+					<speed>6.8193206787109375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014766529717033" lon="-84.2153505800492">
+				<ele>957.4484062278643</ele>
+				<time>2017-11-20T18:46:48Z</time>
+				<extensions>
+					<speed>6.877893924713135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01478677749828" lon="-84.21528949845421">
+				<ele>957.7045637285337</ele>
+				<time>2017-11-20T18:46:49Z</time>
+				<extensions>
+					<speed>6.8708600997924805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014806932624104" lon="-84.21522790401707">
+				<ele>957.9289468936622</ele>
+				<time>2017-11-20T18:46:50Z</time>
+				<extensions>
+					<speed>6.6534552574157715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825303875067" lon="-84.21516938941265">
+				<ele>957.9920898741111</ele>
+				<time>2017-11-20T18:46:51Z</time>
+				<extensions>
+					<speed>6.181596755981445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843263937863" lon="-84.21511956341162">
+				<ele>957.782401483506</ele>
+				<time>2017-11-20T18:46:52Z</time>
+				<extensions>
+					<speed>4.5881733894348145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014856108215424" lon="-84.21508442324873">
+				<ele>957.7306864652783</ele>
+				<time>2017-11-20T18:46:53Z</time>
+				<extensions>
+					<speed>2.686877727508545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014862717229049" lon="-84.21506363510072">
+				<ele>957.6438520140946</ele>
+				<time>2017-11-20T18:46:54Z</time>
+				<extensions>
+					<speed>0.9408899545669556</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014864537773981" lon="-84.21505481246199">
+				<ele>957.7103098416701</ele>
+				<time>2017-11-20T18:46:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014864537773981" lon="-84.21505481246199">
+				<ele>957.7103098416701</ele>
+				<time>2017-11-20T18:46:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014860523347227" lon="-84.21505586134349">
+				<ele>957.7340507367626</ele>
+				<time>2017-11-20T18:46:57Z</time>
+				<extensions>
+					<speed>1.0971150398254395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014854176839297" lon="-84.21505836527146">
+				<ele>957.7217997433618</ele>
+				<time>2017-11-20T18:46:58Z</time>
+				<extensions>
+					<speed>1.233196496963501</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014847722147207" lon="-84.21506177978682">
+				<ele>957.6768097374588</ele>
+				<time>2017-11-20T18:46:59Z</time>
+				<extensions>
+					<speed>1.0443753004074097</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843862748162" lon="-84.21506434815122">
+				<ele>957.6315898261964</ele>
+				<time>2017-11-20T18:47:00Z</time>
+				<extensions>
+					<speed>0.8182981014251709</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843862748162" lon="-84.21506434815122">
+				<ele>957.6315898261964</ele>
+				<time>2017-11-20T18:47:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:02Z</time>
+				<extensions>
+					<speed>0.34975823760032654</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014845707297154" lon="-84.21505706740132">
+				<ele>957.4647195339203</ele>
+				<time>2017-11-20T18:47:19Z</time>
+				<extensions>
+					<speed>0.6111129522323608</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843086113222" lon="-84.21506505267101">
+				<ele>957.6762575889006</ele>
+				<time>2017-11-20T18:47:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843490213615" lon="-84.2150554957968">
+				<ele>957.2873628158122</ele>
+				<time>2017-11-20T18:47:28Z</time>
+				<extensions>
+					<speed>0.7588191032409668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014846958196628" lon="-84.21503579179229">
+				<ele>957.0784541284665</ele>
+				<time>2017-11-20T18:47:29Z</time>
+				<extensions>
+					<speed>1.9558403491973877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014850493728815" lon="-84.21500543450186">
+				<ele>957.0562651176006</ele>
+				<time>2017-11-20T18:47:30Z</time>
+				<extensions>
+					<speed>3.156005859375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014855781452336" lon="-84.21496819730328">
+				<ele>956.9231279827654</ele>
+				<time>2017-11-20T18:47:31Z</time>
+				<extensions>
+					<speed>3.9700796604156494</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014865836864479" lon="-84.21492923887062">
+				<ele>957.3584486860782</ele>
+				<time>2017-11-20T18:47:32Z</time>
+				<extensions>
+					<speed>4.269560813903809</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014872114673512" lon="-84.21488805402429">
+				<ele>958.0047086672857</ele>
+				<time>2017-11-20T18:47:33Z</time>
+				<extensions>
+					<speed>4.705965042114258</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014882163957228" lon="-84.21484755873438">
+				<ele>958.4762861263007</ele>
+				<time>2017-11-20T18:47:34Z</time>
+				<extensions>
+					<speed>4.490494728088379</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014891637394614" lon="-84.21481497389716">
+				<ele>959.8397340346128</ele>
+				<time>2017-11-20T18:47:35Z</time>
+				<extensions>
+					<speed>5.535733699798584</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014906686830516" lon="-84.21476335219141">
+				<ele>960.3764811782166</ele>
+				<time>2017-11-20T18:47:36Z</time>
+				<extensions>
+					<speed>5.621800899505615</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0149313863439" lon="-84.21470176259271">
+				<ele>961.0321134049445</ele>
+				<time>2017-11-20T18:47:37Z</time>
+				<extensions>
+					<speed>6.6639604568481445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014954037235507" lon="-84.21464080897402">
+				<ele>961.3500466849655</ele>
+				<time>2017-11-20T18:47:38Z</time>
+				<extensions>
+					<speed>6.802525520324707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014973796895958" lon="-84.21457711005193">
+				<ele>961.3945070020854</ele>
+				<time>2017-11-20T18:47:39Z</time>
+				<extensions>
+					<speed>6.668242931365967</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014988395013717" lon="-84.21451918003719">
+				<ele>961.4032017691061</ele>
+				<time>2017-11-20T18:47:40Z</time>
+				<extensions>
+					<speed>6.084112644195557</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01499674928837" lon="-84.21446639948579">
+				<ele>961.5707661621273</ele>
+				<time>2017-11-20T18:47:41Z</time>
+				<extensions>
+					<speed>5.247164726257324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01500216903866" lon="-84.214418662109">
+				<ele>961.8288692720234</ele>
+				<time>2017-11-20T18:47:42Z</time>
+				<extensions>
+					<speed>4.652194023132324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015007899441466" lon="-84.21437308545396">
+				<ele>962.3703495971859</ele>
+				<time>2017-11-20T18:47:43Z</time>
+				<extensions>
+					<speed>4.365062236785889</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015019451367456" lon="-84.2143315138595">
+				<ele>964.3974917763844</ele>
+				<time>2017-11-20T18:47:44Z</time>
+				<extensions>
+					<speed>3.8338096141815186</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01503170032109" lon="-84.21429872752512">
+				<ele>965.0028647817671</ele>
+				<time>2017-11-20T18:47:45Z</time>
+				<extensions>
+					<speed>2.9510202407836914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015040764029575" lon="-84.21427499671111">
+				<ele>965.3664968973026</ele>
+				<time>2017-11-20T18:47:46Z</time>
+				<extensions>
+					<speed>1.748288631439209</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015044381876756" lon="-84.214256918176">
+				<ele>965.4794044839218</ele>
+				<time>2017-11-20T18:47:47Z</time>
+				<extensions>
+					<speed>1.2020636796951294</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015044132583139" lon="-84.21424838317803">
+				<ele>965.7207829495892</ele>
+				<time>2017-11-20T18:47:48Z</time>
+				<extensions>
+					<speed>0.5482907295227051</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015044132583139" lon="-84.21424838317803">
+				<ele>965.7207829495892</ele>
+				<time>2017-11-20T18:47:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0150425275718" lon="-84.21425585190148">
+				<ele>965.8871784461662</ele>
+				<time>2017-11-20T18:47:50Z</time>
+				<extensions>
+					<speed>1.0748227834701538</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015042911678735" lon="-84.21426442356285">
+				<ele>965.9480765135959</ele>
+				<time>2017-11-20T18:47:51Z</time>
+				<extensions>
+					<speed>1.3468431234359741</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015040268257543" lon="-84.21427277565319">
+				<ele>966.1880970709026</ele>
+				<time>2017-11-20T18:47:52Z</time>
+				<extensions>
+					<speed>1.1418298482894897</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037223553488" lon="-84.21427006549379">
+				<ele>966.6039441721514</ele>
+				<time>2017-11-20T18:47:53Z</time>
+				<extensions>
+					<speed>0.8238957524299622</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037223553488" lon="-84.21427006549379">
+				<ele>966.6039441721514</ele>
+				<time>2017-11-20T18:47:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01503794566905" lon="-84.21426670965914">
+				<ele>966.7735927253962</ele>
+				<time>2017-11-20T18:47:55Z</time>
+				<extensions>
+					<speed>0.4440458118915558</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01503794566905" lon="-84.21426670965914">
+				<ele>966.7735927253962</ele>
+				<time>2017-11-20T18:47:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015040115442005" lon="-84.21426147951973">
+				<ele>966.9020103598014</ele>
+				<time>2017-11-20T18:47:57Z</time>
+				<extensions>
+					<speed>0.08241570740938187</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015040115442005" lon="-84.21426147951973">
+				<ele>966.9020103598014</ele>
+				<time>2017-11-20T18:47:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015040115442005" lon="-84.21426147951973">
+				<ele>966.9020103598014</ele>
+				<time>2017-11-20T18:47:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015040115442005" lon="-84.21426147951973">
+				<ele>966.9020103598014</ele>
+				<time>2017-11-20T18:48:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015040115442005" lon="-84.21426147951973">
+				<ele>966.9020103598014</ele>
+				<time>2017-11-20T18:48:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015040115442005" lon="-84.21426147951973">
+				<ele>966.9020103598014</ele>
+				<time>2017-11-20T18:48:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015040115442005" lon="-84.21426147951973">
+				<ele>966.9020103598014</ele>
+				<time>2017-11-20T18:48:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015040115442005" lon="-84.21426147951973">
+				<ele>966.9020103598014</ele>
+				<time>2017-11-20T18:48:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015040115442005" lon="-84.21426147951973">
+				<ele>966.9020103598014</ele>
+				<time>2017-11-20T18:48:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015040115442005" lon="-84.21426147951973">
+				<ele>966.9020103598014</ele>
+				<time>2017-11-20T18:48:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015040115442005" lon="-84.21426147951973">
+				<ele>966.9020103598014</ele>
+				<time>2017-11-20T18:48:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015040115442005" lon="-84.21426147951973">
+				<ele>966.9020103598014</ele>
+				<time>2017-11-20T18:48:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01504477648773" lon="-84.21425184371778">
+				<ele>966.7545997519046</ele>
+				<time>2017-11-20T18:48:09Z</time>
+				<extensions>
+					<speed>0.6349523067474365</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015040115442005" lon="-84.21426147951973">
+				<ele>966.9020103598014</ele>
+				<time>2017-11-20T18:48:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015046289636906" lon="-84.21423816386358">
+				<ele>966.9103550603613</ele>
+				<time>2017-11-20T18:48:11Z</time>
+				<extensions>
+					<speed>1.0383292436599731</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015052590991145" lon="-84.2142194598502">
+				<ele>966.7485038591549</ele>
+				<time>2017-11-20T18:48:12Z</time>
+				<extensions>
+					<speed>1.1650152206420898</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015064194319846" lon="-84.21414934021958">
+				<ele>966.9286165833473</ele>
+				<time>2017-11-20T18:48:13Z</time>
+				<extensions>
+					<speed>2.4929392337799072</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015076281347033" lon="-84.21409268122788">
+				<ele>966.9148198366165</ele>
+				<time>2017-11-20T18:48:14Z</time>
+				<extensions>
+					<speed>4.765689849853516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015086643212184" lon="-84.21402787685123">
+				<ele>967.5042816866189</ele>
+				<time>2017-11-20T18:48:15Z</time>
+				<extensions>
+					<speed>6.568182468414307</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015110806617802" lon="-84.21392718427795">
+				<ele>968.1340185059234</ele>
+				<time>2017-11-20T18:48:16Z</time>
+				<extensions>
+					<speed>6.499966144561768</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015136847788435" lon="-84.2138374523939">
+				<ele>970.4006930598989</ele>
+				<time>2017-11-20T18:48:17Z</time>
+				<extensions>
+					<speed>7.7472381591796875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015151448653796" lon="-84.21374979924029">
+				<ele>971.4918269915506</ele>
+				<time>2017-11-20T18:48:18Z</time>
+				<extensions>
+					<speed>8.061607360839844</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015165891470355" lon="-84.21367677924832">
+				<ele>972.4240237781778</ele>
+				<time>2017-11-20T18:48:19Z</time>
+				<extensions>
+					<speed>8.418964385986328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01517828802631" lon="-84.213596647705">
+				<ele>972.4450765382499</ele>
+				<time>2017-11-20T18:48:20Z</time>
+				<extensions>
+					<speed>7.94567346572876</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01519784761028" lon="-84.2135218993534">
+				<ele>971.9753488106653</ele>
+				<time>2017-11-20T18:48:21Z</time>
+				<extensions>
+					<speed>7.394549369812012</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015215059827254" lon="-84.21345410468483">
+				<ele>972.2811529589817</ele>
+				<time>2017-11-20T18:48:22Z</time>
+				<extensions>
+					<speed>7.380092620849609</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015228880263097" lon="-84.21341078288962">
+				<ele>971.5200981935486</ele>
+				<time>2017-11-20T18:48:23Z</time>
+				<extensions>
+					<speed>5.256168842315674</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015240721838724" lon="-84.21338822064233">
+				<ele>971.1679780334234</ele>
+				<time>2017-11-20T18:48:24Z</time>
+				<extensions>
+					<speed>1.5341156721115112</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015247069759262" lon="-84.21337803385046">
+				<ele>971.4579797070473</ele>
+				<time>2017-11-20T18:48:25Z</time>
+				<extensions>
+					<speed>0.3027587831020355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015252013682458" lon="-84.21338143554635">
+				<ele>971.5229011261836</ele>
+				<time>2017-11-20T18:48:26Z</time>
+				<extensions>
+					<speed>0.8200686573982239</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015253488284186" lon="-84.21339495607245">
+				<ele>971.4583113370463</ele>
+				<time>2017-11-20T18:48:27Z</time>
+				<extensions>
+					<speed>1.6546810865402222</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015250227810842" lon="-84.21340971066442">
+				<ele>971.0251560006291</ele>
+				<time>2017-11-20T18:48:28Z</time>
+				<extensions>
+					<speed>2.1823477745056152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015251400386907" lon="-84.21343214697201">
+				<ele>971.0730109550059</ele>
+				<time>2017-11-20T18:48:29Z</time>
+				<extensions>
+					<speed>2.382535934448242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525575759011" lon="-84.21345920545504">
+				<ele>971.6115047400817</ele>
+				<time>2017-11-20T18:48:30Z</time>
+				<extensions>
+					<speed>2.277916669845581</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525458081538" lon="-84.21347839641258">
+				<ele>972.0908097391948</ele>
+				<time>2017-11-20T18:48:31Z</time>
+				<extensions>
+					<speed>1.8358367681503296</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015253834951823" lon="-84.21349548274846">
+				<ele>972.2420189250261</ele>
+				<time>2017-11-20T18:48:32Z</time>
+				<extensions>
+					<speed>1.4599155187606812</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015255759516698" lon="-84.21350353519459">
+				<ele>972.3344116052613</ele>
+				<time>2017-11-20T18:48:33Z</time>
+				<extensions>
+					<speed>0.862500011920929</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015255759516698" lon="-84.21350353519459">
+				<ele>972.3344116052613</ele>
+				<time>2017-11-20T18:48:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:35Z</time>
+				<extensions>
+					<speed>0.07578994333744049</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:48:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:49:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:49:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:49:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:49:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:49:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:49:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:49:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:49:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:49:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525850581039" lon="-84.21350498987182">
+				<ele>972.3958450732753</ele>
+				<time>2017-11-20T18:49:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015264485437314" lon="-84.21348416675592">
+				<ele>972.1901620980352</ele>
+				<time>2017-11-20T18:49:10Z</time>
+				<extensions>
+					<speed>0.9934717416763306</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015271158070467" lon="-84.21344999004093">
+				<ele>972.7759747719392</ele>
+				<time>2017-11-20T18:49:11Z</time>
+				<extensions>
+					<speed>1.7849459648132324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01528165931444" lon="-84.21341844402954">
+				<ele>972.5134612871334</ele>
+				<time>2017-11-20T18:49:12Z</time>
+				<extensions>
+					<speed>2.2751197814941406</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01530171213248" lon="-84.21337093649349">
+				<ele>971.817238105461</ele>
+				<time>2017-11-20T18:49:13Z</time>
+				<extensions>
+					<speed>3.416642904281616</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015319912920116" lon="-84.21331388671152">
+				<ele>970.9429763285443</ele>
+				<time>2017-11-20T18:49:14Z</time>
+				<extensions>
+					<speed>4.222579002380371</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01533852135874" lon="-84.21325464778751">
+				<ele>970.1335007930174</ele>
+				<time>2017-11-20T18:49:15Z</time>
+				<extensions>
+					<speed>4.529007911682129</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015355406902206" lon="-84.21319684443186">
+				<ele>969.4067888939753</ele>
+				<time>2017-11-20T18:49:16Z</time>
+				<extensions>
+					<speed>4.656351089477539</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015367742345964" lon="-84.21314262453043">
+				<ele>968.8900349074975</ele>
+				<time>2017-11-20T18:49:17Z</time>
+				<extensions>
+					<speed>4.710819721221924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015382438734425" lon="-84.21309614466698">
+				<ele>968.4948388561606</ele>
+				<time>2017-11-20T18:49:18Z</time>
+				<extensions>
+					<speed>4.64014196395874</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015392103349194" lon="-84.21304191983799">
+				<ele>968.6101756980643</ele>
+				<time>2017-11-20T18:49:19Z</time>
+				<extensions>
+					<speed>5.00643253326416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015410312678975" lon="-84.21300253107404">
+				<ele>968.7893139338121</ele>
+				<time>2017-11-20T18:49:20Z</time>
+				<extensions>
+					<speed>4.968131065368652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015430870729693" lon="-84.21296157693446">
+				<ele>969.0754762170836</ele>
+				<time>2017-11-20T18:49:21Z</time>
+				<extensions>
+					<speed>5.040337562561035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01544813131159" lon="-84.21291838660703">
+				<ele>969.1816594786942</ele>
+				<time>2017-11-20T18:49:22Z</time>
+				<extensions>
+					<speed>5.066212177276611</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015462178540238" lon="-84.21287506691807">
+				<ele>969.2148270728067</ele>
+				<time>2017-11-20T18:49:23Z</time>
+				<extensions>
+					<speed>5.100772857666016</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0154791302577" lon="-84.21282631504793">
+				<ele>969.3351955479011</ele>
+				<time>2017-11-20T18:49:24Z</time>
+				<extensions>
+					<speed>5.28054141998291</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01549468196353" lon="-84.21276817826951">
+				<ele>969.8290556948632</ele>
+				<time>2017-11-20T18:49:25Z</time>
+				<extensions>
+					<speed>5.653283596038818</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01550980854427" lon="-84.21270939183137">
+				<ele>970.0139608476311</ele>
+				<time>2017-11-20T18:49:26Z</time>
+				<extensions>
+					<speed>5.9007697105407715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015527212025791" lon="-84.21263720961548">
+				<ele>970.0165699617937</ele>
+				<time>2017-11-20T18:49:27Z</time>
+				<extensions>
+					<speed>6.335524082183838</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015543551193986" lon="-84.21255998790308">
+				<ele>970.0184805095196</ele>
+				<time>2017-11-20T18:49:28Z</time>
+				<extensions>
+					<speed>6.691532135009766</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015555034931657" lon="-84.21249137915383">
+				<ele>969.943450530991</ele>
+				<time>2017-11-20T18:49:29Z</time>
+				<extensions>
+					<speed>6.85623025894165</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015581495129322" lon="-84.21236994076088">
+				<ele>969.3360614096746</ele>
+				<time>2017-11-20T18:49:30Z</time>
+				<extensions>
+					<speed>7.592256546020508</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015598403494028" lon="-84.21227937354698">
+				<ele>969.0110747842118</ele>
+				<time>2017-11-20T18:49:31Z</time>
+				<extensions>
+					<speed>7.766037940979004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015622633660527" lon="-84.2121968547131">
+				<ele>968.7687207143754</ele>
+				<time>2017-11-20T18:49:32Z</time>
+				<extensions>
+					<speed>8.057164192199707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015643651250123" lon="-84.21212621396973">
+				<ele>968.7068789368495</ele>
+				<time>2017-11-20T18:49:33Z</time>
+				<extensions>
+					<speed>8.070363998413086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015671147163607" lon="-84.21204396215857">
+				<ele>968.4427587492391</ele>
+				<time>2017-11-20T18:49:34Z</time>
+				<extensions>
+					<speed>8.009858131408691</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015694234345991" lon="-84.21196629361086">
+				<ele>968.2671615649015</ele>
+				<time>2017-11-20T18:49:35Z</time>
+				<extensions>
+					<speed>7.866507530212402</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015715098577008" lon="-84.21190219892569">
+				<ele>968.3501047156751</ele>
+				<time>2017-11-20T18:49:36Z</time>
+				<extensions>
+					<speed>7.430418968200684</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015738371289542" lon="-84.21185095281498">
+				<ele>968.6139273494482</ele>
+				<time>2017-11-20T18:49:37Z</time>
+				<extensions>
+					<speed>6.061852931976318</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01576087365359" lon="-84.2118261082972">
+				<ele>968.6174287144095</ele>
+				<time>2017-11-20T18:49:38Z</time>
+				<extensions>
+					<speed>4.086187839508057</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015771063541955" lon="-84.21181673925976">
+				<ele>968.5959032177925</ele>
+				<time>2017-11-20T18:49:39Z</time>
+				<extensions>
+					<speed>1.8818645477294922</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015772376651002" lon="-84.21181843940658">
+				<ele>968.6918792007491</ele>
+				<time>2017-11-20T18:49:40Z</time>
+				<extensions>
+					<speed>0.1182597354054451</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015765640679648" lon="-84.21182566065603">
+				<ele>968.7232056949288</ele>
+				<time>2017-11-20T18:49:41Z</time>
+				<extensions>
+					<speed>1.1288745403289795</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015752922747023" lon="-84.21184002228307">
+				<ele>968.5062405765057</ele>
+				<time>2017-11-20T18:49:42Z</time>
+				<extensions>
+					<speed>1.457183599472046</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0157455610143" lon="-84.21185382567448">
+				<ele>968.4678629254922</ele>
+				<time>2017-11-20T18:49:43Z</time>
+				<extensions>
+					<speed>1.2837244272232056</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015740059784097" lon="-84.2118633370162">
+				<ele>968.3432791000232</ele>
+				<time>2017-11-20T18:49:44Z</time>
+				<extensions>
+					<speed>1.0613179206848145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015734970407925" lon="-84.21186747867601">
+				<ele>968.2783922338858</ele>
+				<time>2017-11-20T18:49:45Z</time>
+				<extensions>
+					<speed>0.6758716702461243</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015734970407925" lon="-84.21186747867601">
+				<ele>968.2783922338858</ele>
+				<time>2017-11-20T18:49:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:49:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:49:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:49:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:49:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:49:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:49:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:49:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:49:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:49:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:49:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:49:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:49:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:49:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:50:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:50:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:50:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:50:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:50:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:50:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:50:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:50:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:50:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:50:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:50:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:50:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572001688755" lon="-84.21187047522218">
+				<ele>967.9345927275717</ele>
+				<time>2017-11-20T18:50:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01572196239749" lon="-84.21186325690407">
+				<ele>968.2593139819801</ele>
+				<time>2017-11-20T18:50:13Z</time>
+				<extensions>
+					<speed>0.7392629384994507</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015720959406105" lon="-84.21184757339803">
+				<ele>968.40853034053</ele>
+				<time>2017-11-20T18:50:14Z</time>
+				<extensions>
+					<speed>1.426926851272583</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015724795095691" lon="-84.21183026824973">
+				<ele>968.4622107576579</ele>
+				<time>2017-11-20T18:50:15Z</time>
+				<extensions>
+					<speed>1.7033958435058594</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015730224592083" lon="-84.21181064319426">
+				<ele>968.44570636563</ele>
+				<time>2017-11-20T18:50:16Z</time>
+				<extensions>
+					<speed>2.008763313293457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01573794745385" lon="-84.21177274787732">
+				<ele>968.4578688004985</ele>
+				<time>2017-11-20T18:50:17Z</time>
+				<extensions>
+					<speed>2.976142644882202</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015750384721356" lon="-84.21172723570439">
+				<ele>968.3774666339159</ele>
+				<time>2017-11-20T18:50:18Z</time>
+				<extensions>
+					<speed>3.9940969944000244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015772693554366" lon="-84.2116844519645">
+				<ele>968.3386277426034</ele>
+				<time>2017-11-20T18:50:19Z</time>
+				<extensions>
+					<speed>4.336185455322266</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015790949010889" lon="-84.21164558156302">
+				<ele>968.4545773072168</ele>
+				<time>2017-11-20T18:50:20Z</time>
+				<extensions>
+					<speed>4.229722499847412</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015807711793473" lon="-84.21160576328853">
+				<ele>968.6086954642087</ele>
+				<time>2017-11-20T18:50:21Z</time>
+				<extensions>
+					<speed>4.28806209564209</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015820984918246" lon="-84.21156923058737">
+				<ele>969.0123114697635</ele>
+				<time>2017-11-20T18:50:22Z</time>
+				<extensions>
+					<speed>4.20752477645874</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015836128311244" lon="-84.21153946718584">
+				<ele>970.1042606905103</ele>
+				<time>2017-11-20T18:50:23Z</time>
+				<extensions>
+					<speed>3.975541830062866</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015843756263111" lon="-84.21151730743219">
+				<ele>971.1299782497808</ele>
+				<time>2017-11-20T18:50:24Z</time>
+				<extensions>
+					<speed>3.5137150287628174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01584006605437" lon="-84.2115064253122">
+				<ele>971.2494343658909</ele>
+				<time>2017-11-20T18:50:25Z</time>
+				<extensions>
+					<speed>2.600332736968994</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015837380157304" lon="-84.21149100114799">
+				<ele>971.1794985579327</ele>
+				<time>2017-11-20T18:50:26Z</time>
+				<extensions>
+					<speed>1.9056131839752197</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01583504388827" lon="-84.21146981395742">
+				<ele>971.0702759856358</ele>
+				<time>2017-11-20T18:50:27Z</time>
+				<extensions>
+					<speed>2.1127684116363525</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015840396513562" lon="-84.21146683274377">
+				<ele>970.5572608858347</ele>
+				<time>2017-11-20T18:50:28Z</time>
+				<extensions>
+					<speed>2.327719211578369</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015828639688987" lon="-84.21143190276517">
+				<ele>969.9612997919321</ele>
+				<time>2017-11-20T18:50:29Z</time>
+				<extensions>
+					<speed>3.235569953918457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01579867737345" lon="-84.21141766273783">
+				<ele>969.9787344662473</ele>
+				<time>2017-11-20T18:50:30Z</time>
+				<extensions>
+					<speed>4.1613945960998535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015748768662524" lon="-84.21140896279101">
+				<ele>970.0196396093816</ele>
+				<time>2017-11-20T18:50:31Z</time>
+				<extensions>
+					<speed>5.1869730949401855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015692483282605" lon="-84.21139833109291">
+				<ele>970.4109003180638</ele>
+				<time>2017-11-20T18:50:32Z</time>
+				<extensions>
+					<speed>6.371551513671875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015621705475038" lon="-84.21138746169606">
+				<ele>970.9855287941173</ele>
+				<time>2017-11-20T18:50:33Z</time>
+				<extensions>
+					<speed>7.597144603729248</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015543825112795" lon="-84.21137845417793">
+				<ele>971.725261692889</ele>
+				<time>2017-11-20T18:50:34Z</time>
+				<extensions>
+					<speed>8.378036499023438</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015465064843019" lon="-84.21138374142772">
+				<ele>972.4086270025</ele>
+				<time>2017-11-20T18:50:35Z</time>
+				<extensions>
+					<speed>8.56242561340332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015386888340304" lon="-84.2113784703873">
+				<ele>972.5425092522055</ele>
+				<time>2017-11-20T18:50:36Z</time>
+				<extensions>
+					<speed>8.340858459472656</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015313596010422" lon="-84.21136747335439">
+				<ele>972.5273433132097</ele>
+				<time>2017-11-20T18:50:37Z</time>
+				<extensions>
+					<speed>8.223767280578613</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015239094110692" lon="-84.21134910500042">
+				<ele>972.4513107100502</ele>
+				<time>2017-11-20T18:50:38Z</time>
+				<extensions>
+					<speed>7.859293460845947</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015165778497257" lon="-84.21131549337409">
+				<ele>972.3751497762278</ele>
+				<time>2017-11-20T18:50:39Z</time>
+				<extensions>
+					<speed>7.639996528625488</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01509743135918" lon="-84.21128865396346">
+				<ele>972.2545521548018</ele>
+				<time>2017-11-20T18:50:40Z</time>
+				<extensions>
+					<speed>7.555273532867432</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015023533566197" lon="-84.21125788536722">
+				<ele>973.101882959716</ele>
+				<time>2017-11-20T18:50:41Z</time>
+				<extensions>
+					<speed>7.80895471572876</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014956345608663" lon="-84.21123124745502">
+				<ele>973.6160111874342</ele>
+				<time>2017-11-20T18:50:42Z</time>
+				<extensions>
+					<speed>8.024157524108887</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014886820696635" lon="-84.21119677559214">
+				<ele>973.6416130773723</ele>
+				<time>2017-11-20T18:50:43Z</time>
+				<extensions>
+					<speed>8.126304626464844</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014812575019791" lon="-84.21116530979509">
+				<ele>973.6113354023546</ele>
+				<time>2017-11-20T18:50:44Z</time>
+				<extensions>
+					<speed>8.329299926757813</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014732967815219" lon="-84.2111348705206">
+				<ele>973.3078766595572</ele>
+				<time>2017-11-20T18:50:45Z</time>
+				<extensions>
+					<speed>8.694019317626953</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01464517497985" lon="-84.21107048609393">
+				<ele>972.5098339058459</ele>
+				<time>2017-11-20T18:50:46Z</time>
+				<extensions>
+					<speed>9.539143562316895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01455373262828" lon="-84.21102882307584">
+				<ele>972.2008599834517</ele>
+				<time>2017-11-20T18:50:47Z</time>
+				<extensions>
+					<speed>10.161263465881348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014460640124257" lon="-84.2109877866724">
+				<ele>971.8167375288904</ele>
+				<time>2017-11-20T18:50:48Z</time>
+				<extensions>
+					<speed>10.514323234558105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014370983716413" lon="-84.21093989407552">
+				<ele>971.0455467235297</ele>
+				<time>2017-11-20T18:50:49Z</time>
+				<extensions>
+					<speed>10.580909729003906</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014276588618625" lon="-84.2108931015928">
+				<ele>970.4376575211063</ele>
+				<time>2017-11-20T18:50:50Z</time>
+				<extensions>
+					<speed>10.700868606567383</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014199599898674" lon="-84.21084701839715">
+				<ele>970.1759282303974</ele>
+				<time>2017-11-20T18:50:51Z</time>
+				<extensions>
+					<speed>10.311563491821289</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014125556024853" lon="-84.21080293982838">
+				<ele>969.9219570420682</ele>
+				<time>2017-11-20T18:50:52Z</time>
+				<extensions>
+					<speed>9.701078414916992</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014064381764168" lon="-84.21076496855075">
+				<ele>969.6709433114156</ele>
+				<time>2017-11-20T18:50:53Z</time>
+				<extensions>
+					<speed>8.652457237243652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014019032194316" lon="-84.21074019575889">
+				<ele>969.3361790534109</ele>
+				<time>2017-11-20T18:50:54Z</time>
+				<extensions>
+					<speed>6.2811408042907715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013989954141767" lon="-84.21072026522654">
+				<ele>968.8011491540819</ele>
+				<time>2017-11-20T18:50:55Z</time>
+				<extensions>
+					<speed>3.1403160095214844</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013984031383732" lon="-84.2107049485609">
+				<ele>968.5717287063599</ele>
+				<time>2017-11-20T18:50:56Z</time>
+				<extensions>
+					<speed>1.4424231052398682</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01399143848216" lon="-84.21068130387084">
+				<ele>969.6872867280617</ele>
+				<time>2017-11-20T18:50:57Z</time>
+				<extensions>
+					<speed>0.8379728198051453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013997225656636" lon="-84.21069765497394">
+				<ele>969.8708518603817</ele>
+				<time>2017-11-20T18:50:58Z</time>
+				<extensions>
+					<speed>1.5472267866134644</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014011750847617" lon="-84.21071165410264">
+				<ele>970.052308242768</ele>
+				<time>2017-11-20T18:50:59Z</time>
+				<extensions>
+					<speed>1.81764817237854</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014028315173801" lon="-84.21072554135054">
+				<ele>970.3594320053235</ele>
+				<time>2017-11-20T18:51:00Z</time>
+				<extensions>
+					<speed>1.725433349609375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01404114199422" lon="-84.21073607193347">
+				<ele>970.7665312318131</ele>
+				<time>2017-11-20T18:51:01Z</time>
+				<extensions>
+					<speed>1.6611992120742798</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014053291362385" lon="-84.21074418701306">
+				<ele>970.6582946302369</ele>
+				<time>2017-11-20T18:51:02Z</time>
+				<extensions>
+					<speed>1.3406717777252197</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014061409001185" lon="-84.21074298555767">
+				<ele>970.414275647141</ele>
+				<time>2017-11-20T18:51:03Z</time>
+				<extensions>
+					<speed>0.5103247165679932</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014061409001185" lon="-84.21074298555767">
+				<ele>970.414275647141</ele>
+				<time>2017-11-20T18:51:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014050598292997" lon="-84.21073597688078">
+				<ele>970.3866566428915</ele>
+				<time>2017-11-20T18:51:05Z</time>
+				<extensions>
+					<speed>1.2648123502731323</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014030379772906" lon="-84.21072417352765">
+				<ele>970.4714941373095</ele>
+				<time>2017-11-20T18:51:06Z</time>
+				<extensions>
+					<speed>2.057239532470703</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01400102745081" lon="-84.2107202204754">
+				<ele>970.8491081697866</ele>
+				<time>2017-11-20T18:51:07Z</time>
+				<extensions>
+					<speed>2.7452945709228516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013957404591455" lon="-84.21070539647563">
+				<ele>970.9947892576456</ele>
+				<time>2017-11-20T18:51:08Z</time>
+				<extensions>
+					<speed>3.757282257080078</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013906018396845" lon="-84.21067719503743">
+				<ele>969.9434996573254</ele>
+				<time>2017-11-20T18:51:09Z</time>
+				<extensions>
+					<speed>5.171456336975098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013837854861146" lon="-84.21065430196846">
+				<ele>972.10479101073</ele>
+				<time>2017-11-20T18:51:10Z</time>
+				<extensions>
+					<speed>6.384049892425537</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013786030590651" lon="-84.2106291659109">
+				<ele>971.111947549507</ele>
+				<time>2017-11-20T18:51:11Z</time>
+				<extensions>
+					<speed>6.744274616241455</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013726175698755" lon="-84.2106019084347">
+				<ele>970.7701456723735</ele>
+				<time>2017-11-20T18:51:12Z</time>
+				<extensions>
+					<speed>7.031269073486328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013653366745956" lon="-84.21057115512842">
+				<ele>970.6005037445575</ele>
+				<time>2017-11-20T18:51:13Z</time>
+				<extensions>
+					<speed>7.8939433097839355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013581719221992" lon="-84.21055220949675">
+				<ele>970.9618274904788</ele>
+				<time>2017-11-20T18:51:14Z</time>
+				<extensions>
+					<speed>8.072334289550781</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013500774470034" lon="-84.21052204906262">
+				<ele>970.878344681114</ele>
+				<time>2017-11-20T18:51:15Z</time>
+				<extensions>
+					<speed>8.233125686645508</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013433974005704" lon="-84.21048418827947">
+				<ele>970.2761858534068</ele>
+				<time>2017-11-20T18:51:16Z</time>
+				<extensions>
+					<speed>7.699844837188721</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013374252035236" lon="-84.21045118494968">
+				<ele>969.4979348024353</ele>
+				<time>2017-11-20T18:51:17Z</time>
+				<extensions>
+					<speed>6.746646881103516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01332759403014" lon="-84.21043253418466">
+				<ele>968.9322190908715</ele>
+				<time>2017-11-20T18:51:18Z</time>
+				<extensions>
+					<speed>5.398413181304932</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013293433147114" lon="-84.21042125287991">
+				<ele>968.56723536551</ele>
+				<time>2017-11-20T18:51:19Z</time>
+				<extensions>
+					<speed>3.8707590103149414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013272783987771" lon="-84.21041310801887">
+				<ele>967.8766393512487</ele>
+				<time>2017-11-20T18:51:20Z</time>
+				<extensions>
+					<speed>2.490589141845703</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013260781051832" lon="-84.21041137495102">
+				<ele>967.6179742570966</ele>
+				<time>2017-11-20T18:51:21Z</time>
+				<extensions>
+					<speed>1.4810303449630737</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0132613844588" lon="-84.21042151933129">
+				<ele>967.1029229275882</ele>
+				<time>2017-11-20T18:51:22Z</time>
+				<extensions>
+					<speed>0.1279287338256836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0132613844588" lon="-84.21042151933129">
+				<ele>967.1029229275882</ele>
+				<time>2017-11-20T18:51:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01326573105726" lon="-84.21042759477527">
+				<ele>967.0175367854536</ele>
+				<time>2017-11-20T18:51:24Z</time>
+				<extensions>
+					<speed>0.8620828986167908</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0132613844588" lon="-84.21042151933129">
+				<ele>967.1029229275882</ele>
+				<time>2017-11-20T18:51:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013265987527497" lon="-84.21041684849452">
+				<ele>967.552809914574</ele>
+				<time>2017-11-20T18:51:26Z</time>
+				<extensions>
+					<speed>0.7726536989212036</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0132613844588" lon="-84.21042151933129">
+				<ele>967.1029229275882</ele>
+				<time>2017-11-20T18:51:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0132613844588" lon="-84.21042151933129">
+				<ele>967.1029229275882</ele>
+				<time>2017-11-20T18:51:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013250037861166" lon="-84.21040295325501">
+				<ele>968.600597252138</ele>
+				<time>2017-11-20T18:51:29Z</time>
+				<extensions>
+					<speed>0.7216534614562988</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013234264095438" lon="-84.21038240856032">
+				<ele>970.6774051813409</ele>
+				<time>2017-11-20T18:51:30Z</time>
+				<extensions>
+					<speed>1.56611967086792</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013214099288971" lon="-84.21037202481772">
+				<ele>971.5355285145342</ele>
+				<time>2017-11-20T18:51:31Z</time>
+				<extensions>
+					<speed>3.001380443572998</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013188226164463" lon="-84.21035762760518">
+				<ele>971.9396772747859</ele>
+				<time>2017-11-20T18:51:32Z</time>
+				<extensions>
+					<speed>3.4366402626037598</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013152582865832" lon="-84.2103394110142">
+				<ele>972.2125700023025</ele>
+				<time>2017-11-20T18:51:33Z</time>
+				<extensions>
+					<speed>3.6423192024230957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013115733481278" lon="-84.2103279083645">
+				<ele>969.9275317098945</ele>
+				<time>2017-11-20T18:51:34Z</time>
+				<extensions>
+					<speed>3.4832167625427246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013077810868479" lon="-84.21031587888444">
+				<ele>968.2379747601226</ele>
+				<time>2017-11-20T18:51:35Z</time>
+				<extensions>
+					<speed>2.575021266937256</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013055726437623" lon="-84.21031226856037">
+				<ele>967.9093410307541</ele>
+				<time>2017-11-20T18:51:36Z</time>
+				<extensions>
+					<speed>1.4132424592971802</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013038358064708" lon="-84.21030456100229">
+				<ele>965.8672880707309</ele>
+				<time>2017-11-20T18:51:37Z</time>
+				<extensions>
+					<speed>0.48295068740844727</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013038358064708" lon="-84.21030456100229">
+				<ele>965.8672880707309</ele>
+				<time>2017-11-20T18:51:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013030812805061" lon="-84.21030794678478">
+				<ele>965.6350032510236</ele>
+				<time>2017-11-20T18:51:39Z</time>
+				<extensions>
+					<speed>0.4999631345272064</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013030812805061" lon="-84.21030794678478">
+				<ele>965.6350032510236</ele>
+				<time>2017-11-20T18:51:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013027193793489" lon="-84.2103107022516">
+				<ele>964.9095167722553</ele>
+				<time>2017-11-20T18:51:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013027193793489" lon="-84.2103107022516">
+				<ele>964.9095167722553</ele>
+				<time>2017-11-20T18:51:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013027193793489" lon="-84.2103107022516">
+				<ele>964.9095167722553</ele>
+				<time>2017-11-20T18:51:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013027193793489" lon="-84.2103107022516">
+				<ele>964.9095167722553</ele>
+				<time>2017-11-20T18:51:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013027193793489" lon="-84.2103107022516">
+				<ele>964.9095167722553</ele>
+				<time>2017-11-20T18:51:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013027193793489" lon="-84.2103107022516">
+				<ele>964.9095167722553</ele>
+				<time>2017-11-20T18:51:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013027193793489" lon="-84.2103107022516">
+				<ele>964.9095167722553</ele>
+				<time>2017-11-20T18:51:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013027193793489" lon="-84.2103107022516">
+				<ele>964.9095167722553</ele>
+				<time>2017-11-20T18:51:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013027193793489" lon="-84.2103107022516">
+				<ele>964.9095167722553</ele>
+				<time>2017-11-20T18:51:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013027193793489" lon="-84.2103107022516">
+				<ele>964.9095167722553</ele>
+				<time>2017-11-20T18:51:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013027193793489" lon="-84.2103107022516">
+				<ele>964.9095167722553</ele>
+				<time>2017-11-20T18:51:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013027193793489" lon="-84.2103107022516">
+				<ele>964.9095167722553</ele>
+				<time>2017-11-20T18:51:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013030985024654" lon="-84.21031578926976">
+				<ele>963.1639030361548</ele>
+				<time>2017-11-20T18:51:53Z</time>
+				<extensions>
+					<speed>0.7026093006134033</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013030985024654" lon="-84.21031578926976">
+				<ele>963.1639030361548</ele>
+				<time>2017-11-20T18:51:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013031694460773" lon="-84.21031996038717">
+				<ele>962.5092093609273</ele>
+				<time>2017-11-20T18:51:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013031694460773" lon="-84.21031996038717">
+				<ele>962.5092093609273</ele>
+				<time>2017-11-20T18:51:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013031694460773" lon="-84.21031996038717">
+				<ele>962.5092093609273</ele>
+				<time>2017-11-20T18:51:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013031694460773" lon="-84.21031996038717">
+				<ele>962.5092093609273</ele>
+				<time>2017-11-20T18:51:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013031694460773" lon="-84.21031996038717">
+				<ele>962.5092093609273</ele>
+				<time>2017-11-20T18:51:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013031694460773" lon="-84.21031996038717">
+				<ele>962.5092093609273</ele>
+				<time>2017-11-20T18:52:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013031694460773" lon="-84.21031996038717">
+				<ele>962.5092093609273</ele>
+				<time>2017-11-20T18:52:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013031694460773" lon="-84.21031996038717">
+				<ele>962.5092093609273</ele>
+				<time>2017-11-20T18:52:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013031694460773" lon="-84.21031996038717">
+				<ele>962.5092093609273</ele>
+				<time>2017-11-20T18:52:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013031694460773" lon="-84.21031996038717">
+				<ele>962.5092093609273</ele>
+				<time>2017-11-20T18:52:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013031694460773" lon="-84.21031996038717">
+				<ele>962.5092093609273</ele>
+				<time>2017-11-20T18:52:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013031694460773" lon="-84.21031996038717">
+				<ele>962.5092093609273</ele>
+				<time>2017-11-20T18:52:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013031694460773" lon="-84.21031996038717">
+				<ele>962.5092093609273</ele>
+				<time>2017-11-20T18:52:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01302456129859" lon="-84.21031710554969">
+				<ele>962.6410589972511</ele>
+				<time>2017-11-20T18:52:08Z</time>
+				<extensions>
+					<speed>1.2803058624267578</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013015143213723" lon="-84.2103067449449">
+				<ele>962.109165689908</ele>
+				<time>2017-11-20T18:52:09Z</time>
+				<extensions>
+					<speed>1.8219492435455322</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012998976335629" lon="-84.21030511657209">
+				<ele>962.4131812099367</ele>
+				<time>2017-11-20T18:52:10Z</time>
+				<extensions>
+					<speed>2.703230857849121</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012972156296412" lon="-84.21029753590904">
+				<ele>962.5636191284284</ele>
+				<time>2017-11-20T18:52:11Z</time>
+				<extensions>
+					<speed>3.8714258670806885</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012932340371936" lon="-84.21028364160014">
+				<ele>962.4964830214158</ele>
+				<time>2017-11-20T18:52:12Z</time>
+				<extensions>
+					<speed>5.215619087219238</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012885226190107" lon="-84.21027080982465">
+				<ele>962.6342290025204</ele>
+				<time>2017-11-20T18:52:13Z</time>
+				<extensions>
+					<speed>5.591827869415283</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012841592102628" lon="-84.21025654364473">
+				<ele>962.5656290724874</ele>
+				<time>2017-11-20T18:52:14Z</time>
+				<extensions>
+					<speed>4.928205490112305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012806029731857" lon="-84.21023860331124">
+				<ele>962.6749197933823</ele>
+				<time>2017-11-20T18:52:15Z</time>
+				<extensions>
+					<speed>4.339681625366211</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01277431986523" lon="-84.2102241502472">
+				<ele>963.0669410265982</ele>
+				<time>2017-11-20T18:52:16Z</time>
+				<extensions>
+					<speed>3.6846516132354736</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01274656883199" lon="-84.21021314655016">
+				<ele>963.7795038940385</ele>
+				<time>2017-11-20T18:52:17Z</time>
+				<extensions>
+					<speed>3.4701955318450928</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012722032071347" lon="-84.21020694360627">
+				<ele>964.2401033863425</ele>
+				<time>2017-11-20T18:52:18Z</time>
+				<extensions>
+					<speed>2.7898614406585693</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012701699180882" lon="-84.2102107737148">
+				<ele>964.5272146090865</ele>
+				<time>2017-11-20T18:52:19Z</time>
+				<extensions>
+					<speed>2.257035732269287</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012685178489432" lon="-84.21022090960791">
+				<ele>964.7898574667051</ele>
+				<time>2017-11-20T18:52:20Z</time>
+				<extensions>
+					<speed>2.519258737564087</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012668487051023" lon="-84.21023701459373">
+				<ele>964.3938094386831</ele>
+				<time>2017-11-20T18:52:21Z</time>
+				<extensions>
+					<speed>2.8612568378448486</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012652856919077" lon="-84.21025792980336">
+				<ele>964.1897682240233</ele>
+				<time>2017-11-20T18:52:22Z</time>
+				<extensions>
+					<speed>2.7073519229888916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012637573925767" lon="-84.21027888287279">
+				<ele>963.7350692003965</ele>
+				<time>2017-11-20T18:52:23Z</time>
+				<extensions>
+					<speed>2.9600274562835693</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012625677133459" lon="-84.21030579209918">
+				<ele>963.3602614887059</ele>
+				<time>2017-11-20T18:52:24Z</time>
+				<extensions>
+					<speed>3.567382335662842</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012613834051148" lon="-84.21034007472704">
+				<ele>963.186340467073</ele>
+				<time>2017-11-20T18:52:25Z</time>
+				<extensions>
+					<speed>4.18811559677124</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012601666460416" lon="-84.21037833207824">
+				<ele>963.0353778460994</ele>
+				<time>2017-11-20T18:52:26Z</time>
+				<extensions>
+					<speed>4.46257209777832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01258817826519" lon="-84.21042080552941">
+				<ele>962.8312085298821</ele>
+				<time>2017-11-20T18:52:27Z</time>
+				<extensions>
+					<speed>4.953824043273926</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012572700560945" lon="-84.21046976667871">
+				<ele>962.7250877507031</ele>
+				<time>2017-11-20T18:52:28Z</time>
+				<extensions>
+					<speed>5.782803535461426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012561337878857" lon="-84.21052285044149">
+				<ele>962.7318196594715</ele>
+				<time>2017-11-20T18:52:29Z</time>
+				<extensions>
+					<speed>6.009708404541016</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012551277140235" lon="-84.21057936628235">
+				<ele>962.9295985242352</ele>
+				<time>2017-11-20T18:52:30Z</time>
+				<extensions>
+					<speed>6.211245536804199</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012538065000511" lon="-84.2106376051734">
+				<ele>963.0808147517964</ele>
+				<time>2017-11-20T18:52:31Z</time>
+				<extensions>
+					<speed>6.342739105224609</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012528132567109" lon="-84.21069947439831">
+				<ele>963.0873160539195</ele>
+				<time>2017-11-20T18:52:32Z</time>
+				<extensions>
+					<speed>6.769930839538574</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012516345234399" lon="-84.21076916745137">
+				<ele>963.1801945660263</ele>
+				<time>2017-11-20T18:52:33Z</time>
+				<extensions>
+					<speed>7.433724403381348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012500085008949" lon="-84.2108397685081">
+				<ele>963.2819707179442</ele>
+				<time>2017-11-20T18:52:34Z</time>
+				<extensions>
+					<speed>7.744797706604004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012471312767383" lon="-84.2109355655409">
+				<ele>963.2411990817636</ele>
+				<time>2017-11-20T18:52:35Z</time>
+				<extensions>
+					<speed>9.484452247619629</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012442894091318" lon="-84.21103933612966">
+				<ele>963.1222749464214</ele>
+				<time>2017-11-20T18:52:36Z</time>
+				<extensions>
+					<speed>11.19124984741211</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012413169842642" lon="-84.21114947840174">
+				<ele>962.7672263272107</ele>
+				<time>2017-11-20T18:52:37Z</time>
+				<extensions>
+					<speed>11.59045696258545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012388351317556" lon="-84.21126879720099">
+				<ele>962.500529662706</ele>
+				<time>2017-11-20T18:52:38Z</time>
+				<extensions>
+					<speed>12.433505058288574</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012340575825625" lon="-84.21140021314008">
+				<ele>962.0236167572439</ele>
+				<time>2017-11-20T18:52:39Z</time>
+				<extensions>
+					<speed>12.222216606140137</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012297039748946" lon="-84.21152466338057">
+				<ele>961.6804895298555</ele>
+				<time>2017-11-20T18:52:40Z</time>
+				<extensions>
+					<speed>11.342812538146973</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01226557104705" lon="-84.21162810972112">
+				<ele>961.6351826163009</ele>
+				<time>2017-11-20T18:52:41Z</time>
+				<extensions>
+					<speed>11.113821029663086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012235117695559" lon="-84.21172448066966">
+				<ele>961.6293952381238</ele>
+				<time>2017-11-20T18:52:42Z</time>
+				<extensions>
+					<speed>10.510701179504395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012206597181978" lon="-84.21181539435254">
+				<ele>961.3872436443344</ele>
+				<time>2017-11-20T18:52:43Z</time>
+				<extensions>
+					<speed>9.800943374633789</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012180176371752" lon="-84.21189950903785">
+				<ele>961.2519731456414</ele>
+				<time>2017-11-20T18:52:44Z</time>
+				<extensions>
+					<speed>9.317854881286621</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012155113475561" lon="-84.21197998708402">
+				<ele>961.203616335988</ele>
+				<time>2017-11-20T18:52:45Z</time>
+				<extensions>
+					<speed>8.892526626586914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012132477859366" lon="-84.21206083867813">
+				<ele>961.1098524183035</ele>
+				<time>2017-11-20T18:52:46Z</time>
+				<extensions>
+					<speed>9.204906463623047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012104514927978" lon="-84.21214136625314">
+				<ele>961.1836986187845</ele>
+				<time>2017-11-20T18:52:47Z</time>
+				<extensions>
+					<speed>8.634336471557617</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01207985800998" lon="-84.21221695815368">
+				<ele>961.0186355505139</ele>
+				<time>2017-11-20T18:52:48Z</time>
+				<extensions>
+					<speed>8.96984577178955</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012048568225275" lon="-84.21229418587586">
+				<ele>961.0149745056406</ele>
+				<time>2017-11-20T18:52:49Z</time>
+				<extensions>
+					<speed>8.980257987976074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012016676294149" lon="-84.21237068869665">
+				<ele>961.0191379915923</ele>
+				<time>2017-11-20T18:52:50Z</time>
+				<extensions>
+					<speed>8.680593490600586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011990232473421" lon="-84.21244672941307">
+				<ele>961.5175673030317</ele>
+				<time>2017-11-20T18:52:51Z</time>
+				<extensions>
+					<speed>7.91666316986084</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011968959012734" lon="-84.21251537082163">
+				<ele>961.8743657395244</ele>
+				<time>2017-11-20T18:52:52Z</time>
+				<extensions>
+					<speed>7.191589832305908</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011952472918617" lon="-84.212571998035">
+				<ele>962.0483538415283</ele>
+				<time>2017-11-20T18:52:53Z</time>
+				<extensions>
+					<speed>5.657254219055176</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011945538350128" lon="-84.21260968037699">
+				<ele>962.1076686941087</ele>
+				<time>2017-11-20T18:52:54Z</time>
+				<extensions>
+					<speed>3.4700400829315186</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011944365011416" lon="-84.21263023691779">
+				<ele>961.7856902023777</ele>
+				<time>2017-11-20T18:52:55Z</time>
+				<extensions>
+					<speed>1.5946323871612549</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011942616755665" lon="-84.21264369986619">
+				<ele>961.2956273052841</ele>
+				<time>2017-11-20T18:52:56Z</time>
+				<extensions>
+					<speed>0.9942123293876648</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01193702843812" lon="-84.21265169120845">
+				<ele>961.2868837397546</ele>
+				<time>2017-11-20T18:52:57Z</time>
+				<extensions>
+					<speed>0.5434539318084717</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01193702843812" lon="-84.21265169120845">
+				<ele>961.2868837397546</ele>
+				<time>2017-11-20T18:52:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01193463618303" lon="-84.21266148836659">
+				<ele>960.8175482591614</ele>
+				<time>2017-11-20T18:52:59Z</time>
+				<extensions>
+					<speed>0.42666125297546387</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01193463618303" lon="-84.21266148836659">
+				<ele>960.8175482591614</ele>
+				<time>2017-11-20T18:53:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011930079559622" lon="-84.21266658335358">
+				<ele>960.4835882531479</ele>
+				<time>2017-11-20T18:53:01Z</time>
+				<extensions>
+					<speed>0.5503897666931152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011930079559622" lon="-84.21266658335358">
+				<ele>960.4835882531479</ele>
+				<time>2017-11-20T18:53:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011918356321818" lon="-84.21266851925344">
+				<ele>960.235393426381</ele>
+				<time>2017-11-20T18:53:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011917640429019" lon="-84.212684526725">
+				<ele>959.7511579645798</ele>
+				<time>2017-11-20T18:53:47Z</time>
+				<extensions>
+					<speed>1.4956122636795044</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011912879147532" lon="-84.2127042659319">
+				<ele>959.7096123220399</ele>
+				<time>2017-11-20T18:53:48Z</time>
+				<extensions>
+					<speed>2.30572772026062</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011905738271604" lon="-84.21273216575561">
+				<ele>959.9144600816071</ele>
+				<time>2017-11-20T18:53:49Z</time>
+				<extensions>
+					<speed>3.1518256664276123</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01189522950655" lon="-84.21276850870282">
+				<ele>960.31336408481</ele>
+				<time>2017-11-20T18:53:50Z</time>
+				<extensions>
+					<speed>4.085789680480957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011879657314958" lon="-84.212808066944">
+				<ele>960.6543236542493</ele>
+				<time>2017-11-20T18:53:51Z</time>
+				<extensions>
+					<speed>4.846315860748291</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011860909844513" lon="-84.2128568176793">
+				<ele>960.7338483994827</ele>
+				<time>2017-11-20T18:53:52Z</time>
+				<extensions>
+					<speed>5.857002258300781</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011841122676769" lon="-84.21291300938285">
+				<ele>960.741880598478</ele>
+				<time>2017-11-20T18:53:53Z</time>
+				<extensions>
+					<speed>6.688931465148926</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011820198214968" lon="-84.21297828886227">
+				<ele>960.8214690582827</ele>
+				<time>2017-11-20T18:53:54Z</time>
+				<extensions>
+					<speed>7.70496940612793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011799999929908" lon="-84.21305177782213">
+				<ele>960.8336274847388</ele>
+				<time>2017-11-20T18:53:55Z</time>
+				<extensions>
+					<speed>8.158337593078613</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011778362712196" lon="-84.21312467669927">
+				<ele>960.4677304746583</ele>
+				<time>2017-11-20T18:53:56Z</time>
+				<extensions>
+					<speed>7.885974407196045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011760575035062" lon="-84.2131962929711">
+				<ele>960.2489736322314</ele>
+				<time>2017-11-20T18:53:57Z</time>
+				<extensions>
+					<speed>7.7153754234313965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011742107814666" lon="-84.2132629450907">
+				<ele>960.1255361577496</ele>
+				<time>2017-11-20T18:53:58Z</time>
+				<extensions>
+					<speed>7.353017807006836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01172466006547" lon="-84.2133296757009">
+				<ele>960.0764724286273</ele>
+				<time>2017-11-20T18:53:59Z</time>
+				<extensions>
+					<speed>7.47020149230957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011712658734405" lon="-84.21338480900457">
+				<ele>959.5693320995197</ele>
+				<time>2017-11-20T18:54:00Z</time>
+				<extensions>
+					<speed>6.059370040893555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011704874466007" lon="-84.21343416043452">
+				<ele>958.8857390191406</ele>
+				<time>2017-11-20T18:54:01Z</time>
+				<extensions>
+					<speed>5.008915424346924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011703516609966" lon="-84.21348105640003">
+				<ele>958.4434356186539</ele>
+				<time>2017-11-20T18:54:02Z</time>
+				<extensions>
+					<speed>4.914991855621338</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011705683082289" lon="-84.21352754228164">
+				<ele>957.9781951606274</ele>
+				<time>2017-11-20T18:54:03Z</time>
+				<extensions>
+					<speed>4.777645587921143</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01171021278366" lon="-84.21355856574557">
+				<ele>957.2480760943145</ele>
+				<time>2017-11-20T18:54:04Z</time>
+				<extensions>
+					<speed>3.374819278717041</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011711908712652" lon="-84.2135888136786">
+				<ele>956.8296482348815</ele>
+				<time>2017-11-20T18:54:05Z</time>
+				<extensions>
+					<speed>2.93100643157959</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011710718235989" lon="-84.21360762162325">
+				<ele>956.49649523478</ele>
+				<time>2017-11-20T18:54:06Z</time>
+				<extensions>
+					<speed>1.9749842882156372</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011711935537642" lon="-84.21361336696418">
+				<ele>955.9205417260528</ele>
+				<time>2017-11-20T18:54:07Z</time>
+				<extensions>
+					<speed>0.5065450072288513</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011709730060067" lon="-84.213608648869">
+				<ele>955.6337962020189</ele>
+				<time>2017-11-20T18:54:08Z</time>
+				<extensions>
+					<speed>0.8388580083847046</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01170729018867" lon="-84.2135962899961">
+				<ele>955.5101966289803</ele>
+				<time>2017-11-20T18:54:09Z</time>
+				<extensions>
+					<speed>1.232499122619629</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011703781039996" lon="-84.21358441435672">
+				<ele>955.638793961145</ele>
+				<time>2017-11-20T18:54:10Z</time>
+				<extensions>
+					<speed>0.942481279373169</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011703781039996" lon="-84.21358441435672">
+				<ele>955.638793961145</ele>
+				<time>2017-11-20T18:54:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01170329645356" lon="-84.21358113930297">
+				<ele>954.1612885603681</ele>
+				<time>2017-11-20T18:54:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01170329645356" lon="-84.21358113930297">
+				<ele>954.1612885603681</ele>
+				<time>2017-11-20T18:54:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01170329645356" lon="-84.21358113930297">
+				<ele>954.1612885603681</ele>
+				<time>2017-11-20T18:54:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01170329645356" lon="-84.21358113930297">
+				<ele>954.1612885603681</ele>
+				<time>2017-11-20T18:54:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01170329645356" lon="-84.21358113930297">
+				<ele>954.1612885603681</ele>
+				<time>2017-11-20T18:54:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01170329645356" lon="-84.21358113930297">
+				<ele>954.1612885603681</ele>
+				<time>2017-11-20T18:54:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01170329645356" lon="-84.21358113930297">
+				<ele>954.1612885603681</ele>
+				<time>2017-11-20T18:54:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01169403591113" lon="-84.2135845589644">
+				<ele>954.030820437707</ele>
+				<time>2017-11-20T18:54:19Z</time>
+				<extensions>
+					<speed>1.068532943725586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011681423169602" lon="-84.21359715070795">
+				<ele>953.3407449712977</ele>
+				<time>2017-11-20T18:54:20Z</time>
+				<extensions>
+					<speed>1.8933405876159668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011664210029707" lon="-84.21361666421951">
+				<ele>952.7745288694277</ele>
+				<time>2017-11-20T18:54:21Z</time>
+				<extensions>
+					<speed>2.619480848312378</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011644929014523" lon="-84.2136428084354">
+				<ele>952.6023235935718</ele>
+				<time>2017-11-20T18:54:22Z</time>
+				<extensions>
+					<speed>3.5565738677978516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011621214968931" lon="-84.2136752924568">
+				<ele>952.5255736019462</ele>
+				<time>2017-11-20T18:54:23Z</time>
+				<extensions>
+					<speed>4.515771389007568</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01159269601181" lon="-84.21370807744513">
+				<ele>952.529975714162</ele>
+				<time>2017-11-20T18:54:24Z</time>
+				<extensions>
+					<speed>4.869592666625977</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011556952202811" lon="-84.21373925921556">
+				<ele>952.0833970941603</ele>
+				<time>2017-11-20T18:54:25Z</time>
+				<extensions>
+					<speed>5.118711948394775</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011509901773136" lon="-84.21375711771576">
+				<ele>951.9104696977884</ele>
+				<time>2017-11-20T18:54:26Z</time>
+				<extensions>
+					<speed>5.862110614776611</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011451413817271" lon="-84.21376684717458">
+				<ele>950.8766270466149</ele>
+				<time>2017-11-20T18:54:27Z</time>
+				<extensions>
+					<speed>6.918318748474121</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011382511503122" lon="-84.21376149793028">
+				<ele>950.5635998109356</ele>
+				<time>2017-11-20T18:54:28Z</time>
+				<extensions>
+					<speed>8.196338653564453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011307997798275" lon="-84.2137410432054">
+				<ele>950.472139487043</ele>
+				<time>2017-11-20T18:54:29Z</time>
+				<extensions>
+					<speed>8.929916381835938</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011230088827608" lon="-84.21371484038524">
+				<ele>950.2417354425415</ele>
+				<time>2017-11-20T18:54:30Z</time>
+				<extensions>
+					<speed>9.413447380065918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011151595907798" lon="-84.21368975820488">
+				<ele>950.03693566937</ele>
+				<time>2017-11-20T18:54:31Z</time>
+				<extensions>
+					<speed>9.190329551696777</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011077014918694" lon="-84.21366245902706">
+				<ele>950.3428388694301</ele>
+				<time>2017-11-20T18:54:32Z</time>
+				<extensions>
+					<speed>8.741249084472656</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011003839162248" lon="-84.21363898493344">
+				<ele>950.5489456253126</ele>
+				<time>2017-11-20T18:54:33Z</time>
+				<extensions>
+					<speed>8.393719673156738</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010930092102736" lon="-84.21361989241579">
+				<ele>950.4732664581388</ele>
+				<time>2017-11-20T18:54:34Z</time>
+				<extensions>
+					<speed>8.490486145019531</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010857728848084" lon="-84.2136118566658">
+				<ele>948.4094709847122</ele>
+				<time>2017-11-20T18:54:35Z</time>
+				<extensions>
+					<speed>8.07717227935791</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01078686623387" lon="-84.2135943361927">
+				<ele>947.8283165432513</ele>
+				<time>2017-11-20T18:54:36Z</time>
+				<extensions>
+					<speed>8.154463768005371</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010717286028555" lon="-84.21357581115394">
+				<ele>947.5181323131546</ele>
+				<time>2017-11-20T18:54:37Z</time>
+				<extensions>
+					<speed>7.843451499938965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010648687025705" lon="-84.21356011069692">
+				<ele>946.0676315249875</ele>
+				<time>2017-11-20T18:54:38Z</time>
+				<extensions>
+					<speed>7.882652282714844</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010579719228815" lon="-84.21354405331661">
+				<ele>945.510788875632</ele>
+				<time>2017-11-20T18:54:39Z</time>
+				<extensions>
+					<speed>7.880804061889648</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010507687649628" lon="-84.2135257773359">
+				<ele>945.305590769276</ele>
+				<time>2017-11-20T18:54:40Z</time>
+				<extensions>
+					<speed>8.10927963256836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010437202675242" lon="-84.21350837184316">
+				<ele>944.7830681772903</ele>
+				<time>2017-11-20T18:54:41Z</time>
+				<extensions>
+					<speed>7.94047212600708</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010373271695732" lon="-84.21349499632552">
+				<ele>944.490415728651</ele>
+				<time>2017-11-20T18:54:42Z</time>
+				<extensions>
+					<speed>6.77921724319458</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010319679611326" lon="-84.21347745311647">
+				<ele>944.3100206973031</ele>
+				<time>2017-11-20T18:54:43Z</time>
+				<extensions>
+					<speed>5.33643102645874</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010278609173541" lon="-84.21346121569213">
+				<ele>943.5587970409542</ele>
+				<time>2017-11-20T18:54:44Z</time>
+				<extensions>
+					<speed>4.335844993591309</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010248727156124" lon="-84.21343300346406">
+				<ele>944.1811972316355</ele>
+				<time>2017-11-20T18:54:45Z</time>
+				<extensions>
+					<speed>4.346713542938232</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010228178594348" lon="-84.21340074772652">
+				<ele>943.9880301002413</ele>
+				<time>2017-11-20T18:54:46Z</time>
+				<extensions>
+					<speed>4.114139080047607</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010218313697099" lon="-84.21336979216439">
+				<ele>943.7334569273517</ele>
+				<time>2017-11-20T18:54:47Z</time>
+				<extensions>
+					<speed>3.284634590148926</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010214598674594" lon="-84.21331385684717">
+				<ele>942.5347754182294</ele>
+				<time>2017-11-20T18:54:48Z</time>
+				<extensions>
+					<speed>3.7934730052948</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010216148930471" lon="-84.21326961656735">
+				<ele>941.6400488326326</ele>
+				<time>2017-11-20T18:54:49Z</time>
+				<extensions>
+					<speed>3.6726527214050293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010227587771647" lon="-84.21324067681472">
+				<ele>942.6048318902031</ele>
+				<time>2017-11-20T18:54:50Z</time>
+				<extensions>
+					<speed>3.1558494567871094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010243852276279" lon="-84.213217105847">
+				<ele>942.7928649550304</ele>
+				<time>2017-11-20T18:54:51Z</time>
+				<extensions>
+					<speed>2.47581148147583</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010260129052938" lon="-84.21320553272528">
+				<ele>942.7563423719257</ele>
+				<time>2017-11-20T18:54:52Z</time>
+				<extensions>
+					<speed>1.6233739852905273</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010274410739468" lon="-84.21319997277303">
+				<ele>943.7145123258233</ele>
+				<time>2017-11-20T18:54:53Z</time>
+				<extensions>
+					<speed>1.026645541191101</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010288466333943" lon="-84.21320115950992">
+				<ele>942.895409155637</ele>
+				<time>2017-11-20T18:54:54Z</time>
+				<extensions>
+					<speed>0.7024637460708618</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010288466333943" lon="-84.21320115950992">
+				<ele>942.895409155637</ele>
+				<time>2017-11-20T18:54:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010295731347925" lon="-84.21318884560155">
+				<ele>944.346835302189</ele>
+				<time>2017-11-20T18:54:56Z</time>
+				<extensions>
+					<speed>1.144371747970581</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010297842998902" lon="-84.21316861470413">
+				<ele>945.1027021706104</ele>
+				<time>2017-11-20T18:54:57Z</time>
+				<extensions>
+					<speed>1.483895182609558</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010297859725245" lon="-84.21314848151714">
+				<ele>946.5541453817859</ele>
+				<time>2017-11-20T18:54:58Z</time>
+				<extensions>
+					<speed>1.6307026147842407</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010293181739055" lon="-84.21312919466409">
+				<ele>948.2716887677088</ele>
+				<time>2017-11-20T18:54:59Z</time>
+				<extensions>
+					<speed>1.7544597387313843</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010287811553757" lon="-84.21310275811204">
+				<ele>949.8567756451666</ele>
+				<time>2017-11-20T18:55:00Z</time>
+				<extensions>
+					<speed>2.825922727584839</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010275816300522" lon="-84.21306674016887">
+				<ele>952.165208183229</ele>
+				<time>2017-11-20T18:55:01Z</time>
+				<extensions>
+					<speed>3.2015655040740967</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010257141145113" lon="-84.21303408513958">
+				<ele>952.8303085789084</ele>
+				<time>2017-11-20T18:55:02Z</time>
+				<extensions>
+					<speed>3.568246603012085</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010233006027422" lon="-84.21300239298515">
+				<ele>952.4752775942907</ele>
+				<time>2017-11-20T18:55:03Z</time>
+				<extensions>
+					<speed>3.9471664428710938</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010206729776314" lon="-84.21297326254194">
+				<ele>952.4143591513857</ele>
+				<time>2017-11-20T18:55:04Z</time>
+				<extensions>
+					<speed>4.293031692504883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010179969642643" lon="-84.2129457425623">
+				<ele>952.057109022513</ele>
+				<time>2017-11-20T18:55:05Z</time>
+				<extensions>
+					<speed>4.220876216888428</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01015960218645" lon="-84.21291897082949">
+				<ele>951.6725364336744</ele>
+				<time>2017-11-20T18:55:06Z</time>
+				<extensions>
+					<speed>3.1301794052124023</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010143428562808" lon="-84.21289642187375">
+				<ele>951.8409426677972</ele>
+				<time>2017-11-20T18:55:07Z</time>
+				<extensions>
+					<speed>2.591179132461548</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010131976214044" lon="-84.21288318135464">
+				<ele>951.7878875937313</ele>
+				<time>2017-11-20T18:55:08Z</time>
+				<extensions>
+					<speed>1.4653196334838867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010126500437492" lon="-84.21287700686236">
+				<ele>951.9455301705748</ele>
+				<time>2017-11-20T18:55:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010126500437492" lon="-84.21287700686236">
+				<ele>951.9455301705748</ele>
+				<time>2017-11-20T18:55:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010130506897628" lon="-84.21287835434546">
+				<ele>952.1849596444517</ele>
+				<time>2017-11-20T18:55:12Z</time>
+				<extensions>
+					<speed>0.6160705089569092</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010126500437492" lon="-84.21287700686236">
+				<ele>951.9455301705748</ele>
+				<time>2017-11-20T18:55:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010132336962622" lon="-84.21288647989104">
+				<ele>951.2551868166775</ele>
+				<time>2017-11-20T18:55:14Z</time>
+				<extensions>
+					<speed>1.4123598337173462</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010137829580401" lon="-84.21289083951352">
+				<ele>950.7331128213555</ele>
+				<time>2017-11-20T18:55:15Z</time>
+				<extensions>
+					<speed>0.4163249433040619</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010137829580401" lon="-84.21289083951352">
+				<ele>950.7331128213555</ele>
+				<time>2017-11-20T18:55:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010137718415177" lon="-84.21289055945442">
+				<ele>950.4266822421923</ele>
+				<time>2017-11-20T18:55:17Z</time>
+				<extensions>
+					<speed>0.3559170365333557</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010137718415177" lon="-84.21289055945442">
+				<ele>950.4266822421923</ele>
+				<time>2017-11-20T18:55:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010137718415177" lon="-84.21289055945442">
+				<ele>950.4266822421923</ele>
+				<time>2017-11-20T18:55:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010137718415177" lon="-84.21289055945442">
+				<ele>950.4266822421923</ele>
+				<time>2017-11-20T18:55:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01013687109467" lon="-84.21288922618253">
+				<ele>949.3687239866704</ele>
+				<time>2017-11-20T18:55:21Z</time>
+				<extensions>
+					<speed>0.9659388661384583</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010130153264358" lon="-84.21288144276214">
+				<ele>949.1557124564424</ele>
+				<time>2017-11-20T18:55:22Z</time>
+				<extensions>
+					<speed>1.6389069557189941</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010116402289388" lon="-84.21286773276897">
+				<ele>948.5802727714181</ele>
+				<time>2017-11-20T18:55:23Z</time>
+				<extensions>
+					<speed>2.508441686630249</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010097042310832" lon="-84.21285006843242">
+				<ele>948.0817010411993</ele>
+				<time>2017-11-20T18:55:24Z</time>
+				<extensions>
+					<speed>3.338974952697754</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010065893574453" lon="-84.21282766278694">
+				<ele>948.0722154909745</ele>
+				<time>2017-11-20T18:55:25Z</time>
+				<extensions>
+					<speed>4.422823429107666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010025123967083" lon="-84.21279403078061">
+				<ele>948.3354148296639</ele>
+				<time>2017-11-20T18:55:26Z</time>
+				<extensions>
+					<speed>5.901566982269287</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009978241901056" lon="-84.21275367654668">
+				<ele>948.4045525304973</ele>
+				<time>2017-11-20T18:55:27Z</time>
+				<extensions>
+					<speed>7.2826690673828125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00992679193849" lon="-84.21270557378905">
+				<ele>948.3668078975752</ele>
+				<time>2017-11-20T18:55:28Z</time>
+				<extensions>
+					<speed>8.301807403564453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009872091418377" lon="-84.21264692708411">
+				<ele>948.3741923896596</ele>
+				<time>2017-11-20T18:55:29Z</time>
+				<extensions>
+					<speed>8.595976829528809</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009814799068753" lon="-84.21258950237332">
+				<ele>948.2927442807704</ele>
+				<time>2017-11-20T18:55:30Z</time>
+				<extensions>
+					<speed>8.57592487335205</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009760635829856" lon="-84.21253303573044">
+				<ele>948.6303397128358</ele>
+				<time>2017-11-20T18:55:31Z</time>
+				<extensions>
+					<speed>7.859170913696289</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009709552919281" lon="-84.21248226846444">
+				<ele>948.6868654675782</ele>
+				<time>2017-11-20T18:55:32Z</time>
+				<extensions>
+					<speed>7.2826247215271</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009652263500548" lon="-84.21243732351331">
+				<ele>948.3652638429776</ele>
+				<time>2017-11-20T18:55:33Z</time>
+				<extensions>
+					<speed>7.164292812347412</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009601889757723" lon="-84.21239314006151">
+				<ele>948.1388092031702</ele>
+				<time>2017-11-20T18:55:34Z</time>
+				<extensions>
+					<speed>6.481961250305176</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009562451883093" lon="-84.21235098875991">
+				<ele>947.9990410171449</ele>
+				<time>2017-11-20T18:55:35Z</time>
+				<extensions>
+					<speed>6.059079647064209</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009521073982206" lon="-84.2123167212671">
+				<ele>947.5801074812189</ele>
+				<time>2017-11-20T18:55:36Z</time>
+				<extensions>
+					<speed>5.376697063446045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009481028643584" lon="-84.21228468483433">
+				<ele>946.8319406593218</ele>
+				<time>2017-11-20T18:55:37Z</time>
+				<extensions>
+					<speed>5.699552536010742</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009435445793098" lon="-84.21225394075141">
+				<ele>946.6831857962534</ele>
+				<time>2017-11-20T18:55:38Z</time>
+				<extensions>
+					<speed>5.705061435699463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00939020965405" lon="-84.21221722366504">
+				<ele>946.6954158935696</ele>
+				<time>2017-11-20T18:55:39Z</time>
+				<extensions>
+					<speed>6.364832878112793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009339844450938" lon="-84.21217513694664">
+				<ele>946.5936738690361</ele>
+				<time>2017-11-20T18:55:40Z</time>
+				<extensions>
+					<speed>7.175631046295166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009293669207027" lon="-84.21212425647327">
+				<ele>946.8679516734555</ele>
+				<time>2017-11-20T18:55:41Z</time>
+				<extensions>
+					<speed>7.464151859283447</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009248569115528" lon="-84.21206776578568">
+				<ele>947.1978980666026</ele>
+				<time>2017-11-20T18:55:42Z</time>
+				<extensions>
+					<speed>7.809972286224365</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009201380942194" lon="-84.21201046032121">
+				<ele>947.3670981815085</ele>
+				<time>2017-11-20T18:55:43Z</time>
+				<extensions>
+					<speed>7.896848678588867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009148575031642" lon="-84.211956889427">
+				<ele>947.2886373708025</ele>
+				<time>2017-11-20T18:55:44Z</time>
+				<extensions>
+					<speed>8.203147888183594</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009090495519548" lon="-84.21190468847865">
+				<ele>946.7935795309022</ele>
+				<time>2017-11-20T18:55:45Z</time>
+				<extensions>
+					<speed>8.257140159606934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009029713353222" lon="-84.21184619009276">
+				<ele>946.305707632564</ele>
+				<time>2017-11-20T18:55:46Z</time>
+				<extensions>
+					<speed>8.844426155090332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008973508432193" lon="-84.2117776770561">
+				<ele>946.483568361029</ele>
+				<time>2017-11-20T18:55:47Z</time>
+				<extensions>
+					<speed>9.675230979919434</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008918343284673" lon="-84.21170346425286">
+				<ele>946.5110731497407</ele>
+				<time>2017-11-20T18:55:48Z</time>
+				<extensions>
+					<speed>9.67505168914795</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008869046284316" lon="-84.2116250949772">
+				<ele>946.6807731324807</ele>
+				<time>2017-11-20T18:55:49Z</time>
+				<extensions>
+					<speed>9.831363677978516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0088244441491" lon="-84.21154278546645">
+				<ele>946.8914981745183</ele>
+				<time>2017-11-20T18:55:50Z</time>
+				<extensions>
+					<speed>10.242720603942871</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008780786820859" lon="-84.21145449286529">
+				<ele>947.50682185404</ele>
+				<time>2017-11-20T18:55:51Z</time>
+				<extensions>
+					<speed>10.533490180969238</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008744623076261" lon="-84.21136949778008">
+				<ele>947.7267906088382</ele>
+				<time>2017-11-20T18:55:52Z</time>
+				<extensions>
+					<speed>9.525569915771484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008701561139741" lon="-84.21122238140606">
+				<ele>947.6797325629741</ele>
+				<time>2017-11-20T18:55:54Z</time>
+				<extensions>
+					<speed>7.768589973449707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00868768477219" lon="-84.21114768653403">
+				<ele>947.9355936422944</ele>
+				<time>2017-11-20T18:55:55Z</time>
+				<extensions>
+					<speed>8.023862838745117</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00867545630619" lon="-84.2110734058908">
+				<ele>948.5687507595867</ele>
+				<time>2017-11-20T18:55:56Z</time>
+				<extensions>
+					<speed>8.096981048583984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00866591526891" lon="-84.211001613227">
+				<ele>948.6885843519121</ele>
+				<time>2017-11-20T18:55:57Z</time>
+				<extensions>
+					<speed>7.695353031158447</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008661947313529" lon="-84.2109314336367">
+				<ele>948.5739084621891</ele>
+				<time>2017-11-20T18:55:58Z</time>
+				<extensions>
+					<speed>8.019728660583496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008642831841515" lon="-84.21085844842518">
+				<ele>947.5784731823951</ele>
+				<time>2017-11-20T18:55:59Z</time>
+				<extensions>
+					<speed>8.000954627990723</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008639694668357" lon="-84.21078952169292">
+				<ele>947.4357943991199</ele>
+				<time>2017-11-20T18:56:00Z</time>
+				<extensions>
+					<speed>7.503252029418945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008638582551152" lon="-84.21072801131565">
+				<ele>947.2125697722659</ele>
+				<time>2017-11-20T18:56:01Z</time>
+				<extensions>
+					<speed>6.620293617248535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00863584668402" lon="-84.21067517862484">
+				<ele>947.1374611174688</ele>
+				<time>2017-11-20T18:56:02Z</time>
+				<extensions>
+					<speed>5.565315246582031</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008638366925119" lon="-84.21062745644326">
+				<ele>946.9144055442885</ele>
+				<time>2017-11-20T18:56:03Z</time>
+				<extensions>
+					<speed>5.013089656829834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008644112262017" lon="-84.21059076717282">
+				<ele>946.7818891284987</ele>
+				<time>2017-11-20T18:56:04Z</time>
+				<extensions>
+					<speed>3.8787317276000977</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008645298490109" lon="-84.21057032992024">
+				<ele>947.1518356595188</ele>
+				<time>2017-11-20T18:56:05Z</time>
+				<extensions>
+					<speed>1.7024668455123901</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008628325403144" lon="-84.21057685509147">
+				<ele>949.51354895439</ele>
+				<time>2017-11-20T18:56:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008624581109519" lon="-84.21058908577571">
+				<ele>950.7631849879399</ele>
+				<time>2017-11-20T18:56:07Z</time>
+				<extensions>
+					<speed>0.06224612519145012</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008624581109519" lon="-84.21058908577571">
+				<ele>950.7631849879399</ele>
+				<time>2017-11-20T18:56:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008624581109519" lon="-84.21058908577571">
+				<ele>950.7631849879399</ele>
+				<time>2017-11-20T18:56:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008624581109519" lon="-84.21058908577571">
+				<ele>950.7631849879399</ele>
+				<time>2017-11-20T18:56:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008624581109519" lon="-84.21058908577571">
+				<ele>950.7631849879399</ele>
+				<time>2017-11-20T18:56:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008624581109519" lon="-84.21058908577571">
+				<ele>950.7631849879399</ele>
+				<time>2017-11-20T18:56:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008624581109519" lon="-84.21058908577571">
+				<ele>950.7631849879399</ele>
+				<time>2017-11-20T18:56:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008624581109519" lon="-84.21058908577571">
+				<ele>950.7631849879399</ele>
+				<time>2017-11-20T18:56:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008624581109519" lon="-84.21058908577571">
+				<ele>950.7631849879399</ele>
+				<time>2017-11-20T18:56:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008624581109519" lon="-84.21058908577571">
+				<ele>950.7631849879399</ele>
+				<time>2017-11-20T18:56:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008624581109519" lon="-84.21058908577571">
+				<ele>950.7631849879399</ele>
+				<time>2017-11-20T18:56:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008624581109519" lon="-84.21058908577571">
+				<ele>950.7631849879399</ele>
+				<time>2017-11-20T18:56:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008624581109519" lon="-84.21058908577571">
+				<ele>950.7631849879399</ele>
+				<time>2017-11-20T18:56:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008624581109519" lon="-84.21058908577571">
+				<ele>950.7631849879399</ele>
+				<time>2017-11-20T18:56:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008625034565004" lon="-84.2105810012856">
+				<ele>950.6839271476492</ele>
+				<time>2017-11-20T18:56:21Z</time>
+				<extensions>
+					<speed>0.6882083415985107</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008624018889845" lon="-84.21056859896137">
+				<ele>950.6029032021761</ele>
+				<time>2017-11-20T18:56:22Z</time>
+				<extensions>
+					<speed>1.14429771900177</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008622824920602" lon="-84.21055078832778">
+				<ele>950.618355489336</ele>
+				<time>2017-11-20T18:56:23Z</time>
+				<extensions>
+					<speed>1.7842414379119873</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008620316642151" lon="-84.21052666072303">
+				<ele>950.6945022223517</ele>
+				<time>2017-11-20T18:56:24Z</time>
+				<extensions>
+					<speed>2.737633466720581</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008615929727899" lon="-84.2104982048153">
+				<ele>950.8363895947114</ele>
+				<time>2017-11-20T18:56:25Z</time>
+				<extensions>
+					<speed>3.324504852294922</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008611711700322" lon="-84.21046660910793">
+				<ele>950.9737064028159</ele>
+				<time>2017-11-20T18:56:26Z</time>
+				<extensions>
+					<speed>3.810835599899292</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008609116469367" lon="-84.21043157890654">
+				<ele>951.0663111042231</ele>
+				<time>2017-11-20T18:56:27Z</time>
+				<extensions>
+					<speed>3.9656264781951904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008607148111304" lon="-84.21039197656953">
+				<ele>951.1900892406702</ele>
+				<time>2017-11-20T18:56:28Z</time>
+				<extensions>
+					<speed>4.411942005157471</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00860727294047" lon="-84.21035994661894">
+				<ele>950.8965065721422</ele>
+				<time>2017-11-20T18:56:29Z</time>
+				<extensions>
+					<speed>4.307287216186523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008607402056864" lon="-84.2103145147657">
+				<ele>950.7886537825689</ele>
+				<time>2017-11-20T18:56:30Z</time>
+				<extensions>
+					<speed>5.162368297576904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008610422767479" lon="-84.21025911821383">
+				<ele>950.7586844386533</ele>
+				<time>2017-11-20T18:56:31Z</time>
+				<extensions>
+					<speed>6.752862930297852</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008616362136262" lon="-84.21020203730713">
+				<ele>950.6429053591564</ele>
+				<time>2017-11-20T18:56:32Z</time>
+				<extensions>
+					<speed>6.310470104217529</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00861946796029" lon="-84.21015836447954">
+				<ele>950.342723316513</ele>
+				<time>2017-11-20T18:56:33Z</time>
+				<extensions>
+					<speed>5.069015979766846</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008618537855613" lon="-84.2101402591209">
+				<ele>949.7862998424098</ele>
+				<time>2017-11-20T18:56:34Z</time>
+				<extensions>
+					<speed>1.556835412979126</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008622503634747" lon="-84.21013067977717">
+				<ele>949.3647096091881</ele>
+				<time>2017-11-20T18:56:35Z</time>
+				<extensions>
+					<speed>0.7643142342567444</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008630458166" lon="-84.21012967271488">
+				<ele>948.806884248741</ele>
+				<time>2017-11-20T18:56:36Z</time>
+				<extensions>
+					<speed>0.4634382128715515</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008630458166" lon="-84.21012967271488">
+				<ele>948.806884248741</ele>
+				<time>2017-11-20T18:56:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00863568456793" lon="-84.21012238596957">
+				<ele>948.1677421508357</ele>
+				<time>2017-11-20T18:56:38Z</time>
+				<extensions>
+					<speed>0.41779351234436035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00863568456793" lon="-84.21012238596957">
+				<ele>948.1677421508357</ele>
+				<time>2017-11-20T18:56:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633346555463" lon="-84.21012383124109">
+				<ele>948.00788221322</ele>
+				<time>2017-11-20T18:56:40Z</time>
+				<extensions>
+					<speed>0.17168022692203522</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633346555463" lon="-84.21012383124109">
+				<ele>948.00788221322</ele>
+				<time>2017-11-20T18:56:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633346555463" lon="-84.21012383124109">
+				<ele>948.00788221322</ele>
+				<time>2017-11-20T18:56:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633346555463" lon="-84.21012383124109">
+				<ele>948.00788221322</ele>
+				<time>2017-11-20T18:56:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633346555463" lon="-84.21012383124109">
+				<ele>948.00788221322</ele>
+				<time>2017-11-20T18:56:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633346555463" lon="-84.21012383124109">
+				<ele>948.00788221322</ele>
+				<time>2017-11-20T18:56:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633346555463" lon="-84.21012383124109">
+				<ele>948.00788221322</ele>
+				<time>2017-11-20T18:56:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633346555463" lon="-84.21012383124109">
+				<ele>948.00788221322</ele>
+				<time>2017-11-20T18:56:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633346555463" lon="-84.21012383124109">
+				<ele>948.00788221322</ele>
+				<time>2017-11-20T18:56:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633346555463" lon="-84.21012383124109">
+				<ele>948.00788221322</ele>
+				<time>2017-11-20T18:56:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633346555463" lon="-84.21012383124109">
+				<ele>948.00788221322</ele>
+				<time>2017-11-20T18:56:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00863553121434" lon="-84.21012730481891">
+				<ele>947.6806475184858</ele>
+				<time>2017-11-20T18:56:51Z</time>
+				<extensions>
+					<speed>0.6751842498779297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633346555463" lon="-84.21012383124109">
+				<ele>948.00788221322</ele>
+				<time>2017-11-20T18:56:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633346555463" lon="-84.21012383124109">
+				<ele>948.00788221322</ele>
+				<time>2017-11-20T18:56:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633346555463" lon="-84.21012383124109">
+				<ele>948.00788221322</ele>
+				<time>2017-11-20T18:56:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633346555463" lon="-84.21012383124109">
+				<ele>948.00788221322</ele>
+				<time>2017-11-20T18:56:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633346555463" lon="-84.21012383124109">
+				<ele>948.00788221322</ele>
+				<time>2017-11-20T18:56:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633346555463" lon="-84.21012383124109">
+				<ele>948.00788221322</ele>
+				<time>2017-11-20T18:56:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633346555463" lon="-84.21012383124109">
+				<ele>948.00788221322</ele>
+				<time>2017-11-20T18:56:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633346555463" lon="-84.21012383124109">
+				<ele>948.00788221322</ele>
+				<time>2017-11-20T18:56:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008637710814629" lon="-84.2101175499588">
+				<ele>947.490457537584</ele>
+				<time>2017-11-20T18:57:00Z</time>
+				<extensions>
+					<speed>1.0073509216308594</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00864634829333" lon="-84.21010597939012">
+				<ele>946.868348759599</ele>
+				<time>2017-11-20T18:57:01Z</time>
+				<extensions>
+					<speed>1.7265470027923584</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008654648507921" lon="-84.2100821468108">
+				<ele>946.3124744333327</ele>
+				<time>2017-11-20T18:57:02Z</time>
+				<extensions>
+					<speed>3.0024170875549316</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008658133970561" lon="-84.21005549013414">
+				<ele>946.4319057213143</ele>
+				<time>2017-11-20T18:57:03Z</time>
+				<extensions>
+					<speed>3.2009429931640625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008660350688459" lon="-84.21002506069556">
+				<ele>946.7859974354506</ele>
+				<time>2017-11-20T18:57:04Z</time>
+				<extensions>
+					<speed>3.7535746097564697</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008660052255761" lon="-84.20998730960127">
+				<ele>946.7998701259494</ele>
+				<time>2017-11-20T18:57:05Z</time>
+				<extensions>
+					<speed>4.405605316162109</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008661471032804" lon="-84.20994379187572">
+				<ele>946.8469440434128</ele>
+				<time>2017-11-20T18:57:06Z</time>
+				<extensions>
+					<speed>5.175826072692871</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008665652887428" lon="-84.20988508878227">
+				<ele>946.710603098385</ele>
+				<time>2017-11-20T18:57:07Z</time>
+				<extensions>
+					<speed>6.501688003540039</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008672406619858" lon="-84.20981707532451">
+				<ele>946.4135506143793</ele>
+				<time>2017-11-20T18:57:08Z</time>
+				<extensions>
+					<speed>7.2758378982543945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008673546465623" lon="-84.20972541282859">
+				<ele>945.9806753927842</ele>
+				<time>2017-11-20T18:57:09Z</time>
+				<extensions>
+					<speed>9.359424591064453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008678459114348" lon="-84.20963601062218">
+				<ele>945.7861022641882</ele>
+				<time>2017-11-20T18:57:10Z</time>
+				<extensions>
+					<speed>9.668217658996582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008682366234934" lon="-84.20954760428566">
+				<ele>945.2787893777713</ele>
+				<time>2017-11-20T18:57:11Z</time>
+				<extensions>
+					<speed>9.266144752502441</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008687858479245" lon="-84.20946913600712">
+				<ele>944.8180397329852</ele>
+				<time>2017-11-20T18:57:12Z</time>
+				<extensions>
+					<speed>7.967261791229248</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00869380896433" lon="-84.20940268072917">
+				<ele>944.7394277108833</ele>
+				<time>2017-11-20T18:57:13Z</time>
+				<extensions>
+					<speed>6.477066993713379</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008696212537295" lon="-84.20934814132664">
+				<ele>944.4855214459822</ele>
+				<time>2017-11-20T18:57:14Z</time>
+				<extensions>
+					<speed>5.6602959632873535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008698006960246" lon="-84.20930598493186">
+				<ele>944.2989755095914</ele>
+				<time>2017-11-20T18:57:15Z</time>
+				<extensions>
+					<speed>4.00930118560791</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008701048308152" lon="-84.20927581669763">
+				<ele>944.4343626266345</ele>
+				<time>2017-11-20T18:57:16Z</time>
+				<extensions>
+					<speed>2.829148292541504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008703611281087" lon="-84.20925629115561">
+				<ele>944.4635997926816</ele>
+				<time>2017-11-20T18:57:17Z</time>
+				<extensions>
+					<speed>1.6619240045547485</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008706947814561" lon="-84.20924338202464">
+				<ele>944.5742723504081</ele>
+				<time>2017-11-20T18:57:18Z</time>
+				<extensions>
+					<speed>1.29464852809906</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008711648591982" lon="-84.20923085608429">
+				<ele>944.8690024930984</ele>
+				<time>2017-11-20T18:57:19Z</time>
+				<extensions>
+					<speed>1.1701643466949463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008713487265103" lon="-84.20921604777404">
+				<ele>945.0925607774407</ele>
+				<time>2017-11-20T18:57:20Z</time>
+				<extensions>
+					<speed>1.1355189085006714</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008713872258111" lon="-84.20920050034925">
+				<ele>945.2041672552004</ele>
+				<time>2017-11-20T18:57:21Z</time>
+				<extensions>
+					<speed>1.599249005317688</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008714234717132" lon="-84.20918551740628">
+				<ele>945.2825843431056</ele>
+				<time>2017-11-20T18:57:22Z</time>
+				<extensions>
+					<speed>1.4180543422698975</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008716633035256" lon="-84.20916877888877">
+				<ele>945.3441162947565</ele>
+				<time>2017-11-20T18:57:23Z</time>
+				<extensions>
+					<speed>1.5994681119918823</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008717444018826" lon="-84.2091477053375">
+				<ele>945.5359856113791</ele>
+				<time>2017-11-20T18:57:24Z</time>
+				<extensions>
+					<speed>1.8877801895141602</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008715632767073" lon="-84.20912283937801">
+				<ele>945.6746348468587</ele>
+				<time>2017-11-20T18:57:25Z</time>
+				<extensions>
+					<speed>2.397576093673706</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00871313308586" lon="-84.20909244853331">
+				<ele>945.6997673818842</ele>
+				<time>2017-11-20T18:57:26Z</time>
+				<extensions>
+					<speed>3.2786879539489746</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008707879213931" lon="-84.20906158675275">
+				<ele>945.5338886063546</ele>
+				<time>2017-11-20T18:57:27Z</time>
+				<extensions>
+					<speed>4.141358852386475</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00870439891234" lon="-84.20902621127694">
+				<ele>945.2477732812986</ele>
+				<time>2017-11-20T18:57:28Z</time>
+				<extensions>
+					<speed>4.759027004241943</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008704195540028" lon="-84.20898343641956">
+				<ele>945.2432464752346</ele>
+				<time>2017-11-20T18:57:29Z</time>
+				<extensions>
+					<speed>5.4619903564453125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008710850101826" lon="-84.2089255155832">
+				<ele>945.2717709299177</ele>
+				<time>2017-11-20T18:57:30Z</time>
+				<extensions>
+					<speed>6.423982620239258</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008716167168144" lon="-84.20886160578267">
+				<ele>945.3103699879721</ele>
+				<time>2017-11-20T18:57:31Z</time>
+				<extensions>
+					<speed>7.584917068481445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008729174895608" lon="-84.20878492427369">
+				<ele>945.6114107174799</ele>
+				<time>2017-11-20T18:57:32Z</time>
+				<extensions>
+					<speed>8.043007850646973</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00873681154387" lon="-84.20871395110397">
+				<ele>946.2223975108936</ele>
+				<time>2017-11-20T18:57:33Z</time>
+				<extensions>
+					<speed>7.45134973526001</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008731623286183" lon="-84.20865635389546">
+				<ele>945.341373375617</ele>
+				<time>2017-11-20T18:57:34Z</time>
+				<extensions>
+					<speed>5.953326225280762</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008721547208763" lon="-84.20860805181324">
+				<ele>944.9673561649397</ele>
+				<time>2017-11-20T18:57:35Z</time>
+				<extensions>
+					<speed>4.6302618980407715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00871842596407" lon="-84.20857807719482">
+				<ele>944.8886294467375</ele>
+				<time>2017-11-20T18:57:36Z</time>
+				<extensions>
+					<speed>2.2732720375061035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008712868190317" lon="-84.20856441987506">
+				<ele>945.1279691727832</ele>
+				<time>2017-11-20T18:57:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008692667147947" lon="-84.20855366609239">
+				<ele>944.4492380367592</ele>
+				<time>2017-11-20T18:57:38Z</time>
+				<extensions>
+					<speed>0.7623375654220581</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008692667147947" lon="-84.20855366609239">
+				<ele>944.4492380367592</ele>
+				<time>2017-11-20T18:57:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00869358209546" lon="-84.2085597008901">
+				<ele>944.043456283398</ele>
+				<time>2017-11-20T18:57:40Z</time>
+				<extensions>
+					<speed>1.2291663885116577</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008680711240503" lon="-84.20855999880709">
+				<ele>941.6006203312427</ele>
+				<time>2017-11-20T18:57:41Z</time>
+				<extensions>
+					<speed>1.2308932542800903</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008674901112023" lon="-84.20856573605369">
+				<ele>939.7481946218759</ele>
+				<time>2017-11-20T18:57:42Z</time>
+				<extensions>
+					<speed>0.7803905010223389</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008674901112023" lon="-84.20856573605369">
+				<ele>939.7481946218759</ele>
+				<time>2017-11-20T18:57:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00867813764376" lon="-84.20856130083126">
+				<ele>937.8020421592519</ele>
+				<time>2017-11-20T18:57:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00867813764376" lon="-84.20856130083126">
+				<ele>937.8020421592519</ele>
+				<time>2017-11-20T18:57:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00867813764376" lon="-84.20856130083126">
+				<ele>937.8020421592519</ele>
+				<time>2017-11-20T18:57:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008677261590083" lon="-84.20855444572523">
+				<ele>937.134294109419</ele>
+				<time>2017-11-20T18:57:47Z</time>
+				<extensions>
+					<speed>1.4977691173553467</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008675281533675" lon="-84.20853382672776">
+				<ele>936.696126980707</ele>
+				<time>2017-11-20T18:57:48Z</time>
+				<extensions>
+					<speed>2.4992451667785645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00867140591909" lon="-84.20850458271315">
+				<ele>936.2984133753926</ele>
+				<time>2017-11-20T18:57:49Z</time>
+				<extensions>
+					<speed>3.535944700241089</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008668067053119" lon="-84.20846678283829">
+				<ele>936.3445620369166</ele>
+				<time>2017-11-20T18:57:50Z</time>
+				<extensions>
+					<speed>4.634178638458252</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008668691948616" lon="-84.208415972918">
+				<ele>936.0171980615705</ele>
+				<time>2017-11-20T18:57:51Z</time>
+				<extensions>
+					<speed>5.935037612915039</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008668452851927" lon="-84.2083557150852">
+				<ele>935.3726834971458</ele>
+				<time>2017-11-20T18:57:52Z</time>
+				<extensions>
+					<speed>6.391871452331543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008666914899687" lon="-84.20829536398722">
+				<ele>935.087239802815</ele>
+				<time>2017-11-20T18:57:53Z</time>
+				<extensions>
+					<speed>5.47657585144043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008664803224232" lon="-84.2082465452723">
+				<ele>934.6890707854182</ele>
+				<time>2017-11-20T18:57:54Z</time>
+				<extensions>
+					<speed>4.48146390914917</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008664133453376" lon="-84.20820797155388">
+				<ele>934.6092389738187</ele>
+				<time>2017-11-20T18:57:55Z</time>
+				<extensions>
+					<speed>3.4490673542022705</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008663523997116" lon="-84.20818157942932">
+				<ele>934.3487402833998</ele>
+				<time>2017-11-20T18:57:56Z</time>
+				<extensions>
+					<speed>1.9466488361358643</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008663147159865" lon="-84.20816697373377">
+				<ele>934.3816107315943</ele>
+				<time>2017-11-20T18:57:57Z</time>
+				<extensions>
+					<speed>0.8983911871910095</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:57:58Z</time>
+				<extensions>
+					<speed>0.1108393743634224</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:57:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008665495873064" lon="-84.20816358205585">
+				<ele>935.1796557391062</ele>
+				<time>2017-11-20T18:58:00Z</time>
+				<extensions>
+					<speed>0.7702094316482544</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:58:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:58:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:58:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:58:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:58:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:58:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:58:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:58:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:58:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:58:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:58:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:58:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:58:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:58:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:58:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:58:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:58:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:58:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:58:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662960949646" lon="-84.20816024772657">
+				<ele>935.0063447775319</ele>
+				<time>2017-11-20T18:58:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662788827468" lon="-84.20815353017143">
+				<ele>935.2947478312999</ele>
+				<time>2017-11-20T18:58:21Z</time>
+				<extensions>
+					<speed>1.4254921674728394</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008663909510492" lon="-84.20813442904485">
+				<ele>935.5859745834023</ele>
+				<time>2017-11-20T18:58:22Z</time>
+				<extensions>
+					<speed>2.458714246749878</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00866435280046" lon="-84.20810672799632">
+				<ele>935.9601905802265</ele>
+				<time>2017-11-20T18:58:23Z</time>
+				<extensions>
+					<speed>3.0636565685272217</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008662353697474" lon="-84.20807499587634">
+				<ele>935.9623104967177</ele>
+				<time>2017-11-20T18:58:24Z</time>
+				<extensions>
+					<speed>3.424470901489258</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008658106766632" lon="-84.20803941426111">
+				<ele>935.7879908140749</ele>
+				<time>2017-11-20T18:58:25Z</time>
+				<extensions>
+					<speed>3.778810501098633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008651884126232" lon="-84.20800259808864">
+				<ele>935.6248303093016</ele>
+				<time>2017-11-20T18:58:26Z</time>
+				<extensions>
+					<speed>3.6812193393707275</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640866075288" lon="-84.207968038583">
+				<ele>935.1582092847675</ele>
+				<time>2017-11-20T18:58:27Z</time>
+				<extensions>
+					<speed>3.5893149375915527</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008627229457728" lon="-84.2079373167565">
+				<ele>934.8092624982819</ele>
+				<time>2017-11-20T18:58:28Z</time>
+				<extensions>
+					<speed>3.2254810333251953</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008611267814393" lon="-84.20791066872616">
+				<ele>934.841884280555</ele>
+				<time>2017-11-20T18:58:29Z</time>
+				<extensions>
+					<speed>3.29276967048645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008591653806393" lon="-84.20788681659094">
+				<ele>934.9686238523573</ele>
+				<time>2017-11-20T18:58:30Z</time>
+				<extensions>
+					<speed>3.3217885494232178</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008569811573121" lon="-84.20786331500452">
+				<ele>934.8817043574527</ele>
+				<time>2017-11-20T18:58:31Z</time>
+				<extensions>
+					<speed>3.5152668952941895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008546307697545" lon="-84.20784344106659">
+				<ele>934.7973514655605</ele>
+				<time>2017-11-20T18:58:32Z</time>
+				<extensions>
+					<speed>3.2321693897247314</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008523860951124" lon="-84.20781657470356">
+				<ele>934.8825891176239</ele>
+				<time>2017-11-20T18:58:33Z</time>
+				<extensions>
+					<speed>4.059927940368652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008504319319528" lon="-84.20778922454183">
+				<ele>934.9199813064188</ele>
+				<time>2017-11-20T18:58:34Z</time>
+				<extensions>
+					<speed>3.174243688583374</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008483521992712" lon="-84.20776889058844">
+				<ele>934.9424120597541</ele>
+				<time>2017-11-20T18:58:35Z</time>
+				<extensions>
+					<speed>3.0932750701904297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008460459298195" lon="-84.2077475142089">
+				<ele>935.0084050185978</ele>
+				<time>2017-11-20T18:58:36Z</time>
+				<extensions>
+					<speed>3.3945140838623047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00843151020884" lon="-84.20772483766592">
+				<ele>934.8573790984228</ele>
+				<time>2017-11-20T18:58:37Z</time>
+				<extensions>
+					<speed>4.05961275100708</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008396322306945" lon="-84.20769966040382">
+				<ele>934.5211500823498</ele>
+				<time>2017-11-20T18:58:38Z</time>
+				<extensions>
+					<speed>5.030684947967529</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00835442726768" lon="-84.20766646058186">
+				<ele>934.1923186890781</ele>
+				<time>2017-11-20T18:58:39Z</time>
+				<extensions>
+					<speed>6.328278541564941</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008304533942946" lon="-84.207623006056">
+				<ele>933.8127583609894</ele>
+				<time>2017-11-20T18:58:40Z</time>
+				<extensions>
+					<speed>7.8864521980285645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008245140101886" lon="-84.20757286144725">
+				<ele>933.2392955385149</ele>
+				<time>2017-11-20T18:58:41Z</time>
+				<extensions>
+					<speed>8.78482437133789</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008180967775155" lon="-84.20751643483634">
+				<ele>932.9726059790701</ele>
+				<time>2017-11-20T18:58:42Z</time>
+				<extensions>
+					<speed>10.116698265075684</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008109499045842" lon="-84.20745443553983">
+				<ele>932.718283675611</ele>
+				<time>2017-11-20T18:58:43Z</time>
+				<extensions>
+					<speed>10.89885139465332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008032657538253" lon="-84.20738619918431">
+				<ele>932.3735026875511</ele>
+				<time>2017-11-20T18:58:44Z</time>
+				<extensions>
+					<speed>11.656399726867676</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007950402219516" lon="-84.20731304793149">
+				<ele>932.0263815326616</ele>
+				<time>2017-11-20T18:58:45Z</time>
+				<extensions>
+					<speed>12.047919273376465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00786522025253" lon="-84.20723864900529">
+				<ele>931.4725177930668</ele>
+				<time>2017-11-20T18:58:46Z</time>
+				<extensions>
+					<speed>12.332404136657715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007776392199492" lon="-84.20716627218694">
+				<ele>931.1714382441714</ele>
+				<time>2017-11-20T18:58:47Z</time>
+				<extensions>
+					<speed>12.068603515625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007691954692982" lon="-84.20709817966352">
+				<ele>930.8822624376044</ele>
+				<time>2017-11-20T18:58:48Z</time>
+				<extensions>
+					<speed>11.850821495056152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007609462484396" lon="-84.20702872376">
+				<ele>931.0997899305075</ele>
+				<time>2017-11-20T18:58:49Z</time>
+				<extensions>
+					<speed>11.732699394226074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00753056283842" lon="-84.20696014769935">
+				<ele>931.1236660266295</ele>
+				<time>2017-11-20T18:58:50Z</time>
+				<extensions>
+					<speed>11.404060363769531</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007454050331466" lon="-84.20689225648168">
+				<ele>930.9927945481613</ele>
+				<time>2017-11-20T18:58:51Z</time>
+				<extensions>
+					<speed>11.35599136352539</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007375906471117" lon="-84.20682354094684">
+				<ele>931.0213086344302</ele>
+				<time>2017-11-20T18:58:52Z</time>
+				<extensions>
+					<speed>11.472525596618652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007296065390376" lon="-84.20675475241944">
+				<ele>930.8658304316923</ele>
+				<time>2017-11-20T18:58:53Z</time>
+				<extensions>
+					<speed>11.634417533874512</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00721557505778" lon="-84.20668456396612">
+				<ele>930.4368595127016</ele>
+				<time>2017-11-20T18:58:54Z</time>
+				<extensions>
+					<speed>11.856361389160156</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00713438004968" lon="-84.20661428195682">
+				<ele>930.1858724029735</ele>
+				<time>2017-11-20T18:58:55Z</time>
+				<extensions>
+					<speed>11.885438919067383</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007053859708485" lon="-84.20654124225351">
+				<ele>929.872434024699</ele>
+				<time>2017-11-20T18:58:56Z</time>
+				<extensions>
+					<speed>12.234861373901367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006972209876741" lon="-84.20646477131785">
+				<ele>929.4962856583297</ele>
+				<time>2017-11-20T18:58:57Z</time>
+				<extensions>
+					<speed>12.518648147583008</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006891725179816" lon="-84.20638839620378">
+				<ele>929.3202607538551</ele>
+				<time>2017-11-20T18:58:58Z</time>
+				<extensions>
+					<speed>12.147690773010254</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006815208160614" lon="-84.20631332986775">
+				<ele>928.9983186032623</ele>
+				<time>2017-11-20T18:58:59Z</time>
+				<extensions>
+					<speed>11.680919647216797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006739304396241" lon="-84.20624235197879">
+				<ele>929.0208418080583</ele>
+				<time>2017-11-20T18:59:00Z</time>
+				<extensions>
+					<speed>11.170052528381348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00666472164912" lon="-84.20617417793218">
+				<ele>929.3833825290203</ele>
+				<time>2017-11-20T18:59:01Z</time>
+				<extensions>
+					<speed>10.316262245178223</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00659277143458" lon="-84.20611712832621">
+				<ele>929.5123498151079</ele>
+				<time>2017-11-20T18:59:02Z</time>
+				<extensions>
+					<speed>9.37741470336914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006524944446651" lon="-84.20606970315116">
+				<ele>929.4924332322553</ele>
+				<time>2017-11-20T18:59:03Z</time>
+				<extensions>
+					<speed>8.536383628845215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006461524400505" lon="-84.20602171141681">
+				<ele>930.2046003909782</ele>
+				<time>2017-11-20T18:59:04Z</time>
+				<extensions>
+					<speed>8.224943161010742</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006399771596906" lon="-84.20597591445821">
+				<ele>930.7001805398613</ele>
+				<time>2017-11-20T18:59:05Z</time>
+				<extensions>
+					<speed>8.011628150939941</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00634031993834" lon="-84.20592962149391">
+				<ele>931.4457337073982</ele>
+				<time>2017-11-20T18:59:06Z</time>
+				<extensions>
+					<speed>7.86986780166626</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006283204237267" lon="-84.20588261591281">
+				<ele>931.7492097616196</ele>
+				<time>2017-11-20T18:59:07Z</time>
+				<extensions>
+					<speed>8.203996658325195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006223969426864" lon="-84.20583411007091">
+				<ele>932.1155668469146</ele>
+				<time>2017-11-20T18:59:08Z</time>
+				<extensions>
+					<speed>8.205759048461914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006165806297261" lon="-84.20578498047192">
+				<ele>932.3503157161176</ele>
+				<time>2017-11-20T18:59:09Z</time>
+				<extensions>
+					<speed>8.293539047241211</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006111555559494" lon="-84.20574087178665">
+				<ele>932.1920449705794</ele>
+				<time>2017-11-20T18:59:10Z</time>
+				<extensions>
+					<speed>7.573372840881348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006064581453032" lon="-84.20570166086804">
+				<ele>932.2611887818202</ele>
+				<time>2017-11-20T18:59:11Z</time>
+				<extensions>
+					<speed>6.738284111022949</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006024904183732" lon="-84.20567001569246">
+				<ele>932.0715244049206</ele>
+				<time>2017-11-20T18:59:12Z</time>
+				<extensions>
+					<speed>5.188657283782959</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005993125630939" lon="-84.2056536072668">
+				<ele>932.1165696354583</ele>
+				<time>2017-11-20T18:59:13Z</time>
+				<extensions>
+					<speed>3.3910582065582275</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005970624967283" lon="-84.20565497729339">
+				<ele>932.2348929326981</ele>
+				<time>2017-11-20T18:59:14Z</time>
+				<extensions>
+					<speed>2.18461275100708</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005954999696836" lon="-84.20566697373481">
+				<ele>932.1180416112766</ele>
+				<time>2017-11-20T18:59:15Z</time>
+				<extensions>
+					<speed>2.090550184249878</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005943686908742" lon="-84.20568565692373">
+				<ele>931.7966675572097</ele>
+				<time>2017-11-20T18:59:16Z</time>
+				<extensions>
+					<speed>2.47802472114563</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005934146060948" lon="-84.20570934309409">
+				<ele>931.6390572665259</ele>
+				<time>2017-11-20T18:59:17Z</time>
+				<extensions>
+					<speed>3.0848135948181152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00592033831692" lon="-84.20574120487952">
+				<ele>931.7016168376431</ele>
+				<time>2017-11-20T18:59:18Z</time>
+				<extensions>
+					<speed>3.7794222831726074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005904153030896" lon="-84.20577327541892">
+				<ele>931.9561560573056</ele>
+				<time>2017-11-20T18:59:19Z</time>
+				<extensions>
+					<speed>4.226973533630371</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005885956381958" lon="-84.20581033384262">
+				<ele>932.2970697563142</ele>
+				<time>2017-11-20T18:59:20Z</time>
+				<extensions>
+					<speed>4.799797058105469</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005864252642548" lon="-84.20585095560915">
+				<ele>932.5020864838734</ele>
+				<time>2017-11-20T18:59:21Z</time>
+				<extensions>
+					<speed>5.322817325592041</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00583941095636" lon="-84.20589563224708">
+				<ele>932.5974807199091</ele>
+				<time>2017-11-20T18:59:22Z</time>
+				<extensions>
+					<speed>5.840847969055176</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005815991815739" lon="-84.20594012024866">
+				<ele>932.647143936716</ele>
+				<time>2017-11-20T18:59:23Z</time>
+				<extensions>
+					<speed>5.202930450439453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005803316662595" lon="-84.20597784716207">
+				<ele>932.6443137545139</ele>
+				<time>2017-11-20T18:59:24Z</time>
+				<extensions>
+					<speed>3.5466361045837402</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005800210204937" lon="-84.20600798637373">
+				<ele>932.1345944777131</ele>
+				<time>2017-11-20T18:59:25Z</time>
+				<extensions>
+					<speed>1.2584408521652222</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005800029043524" lon="-84.2060213032811">
+				<ele>931.5637114606798</ele>
+				<time>2017-11-20T18:59:26Z</time>
+				<extensions>
+					<speed>0.19316546618938446</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005800029043524" lon="-84.2060213032811">
+				<ele>931.5637114606798</ele>
+				<time>2017-11-20T18:59:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005795774976834" lon="-84.20601677512826">
+				<ele>930.9443719442934</ele>
+				<time>2017-11-20T18:59:28Z</time>
+				<extensions>
+					<speed>0.7824274897575378</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005800029043524" lon="-84.2060213032811">
+				<ele>931.5637114606798</ele>
+				<time>2017-11-20T18:59:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005800029043524" lon="-84.2060213032811">
+				<ele>931.5637114606798</ele>
+				<time>2017-11-20T18:59:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005788952057252" lon="-84.2060178509691">
+				<ele>931.6649901270866</ele>
+				<time>2017-11-20T18:59:31Z</time>
+				<extensions>
+					<speed>0.6895479559898376</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005788952057252" lon="-84.2060178509691">
+				<ele>931.6649901270866</ele>
+				<time>2017-11-20T18:59:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0057802548801" lon="-84.20601753892731">
+				<ele>932.1378578459844</ele>
+				<time>2017-11-20T18:59:33Z</time>
+				<extensions>
+					<speed>0.3925195336341858</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00576890605316" lon="-84.20602088313304">
+				<ele>932.5631717871875</ele>
+				<time>2017-11-20T18:59:34Z</time>
+				<extensions>
+					<speed>1.3034065961837769</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00575685335017" lon="-84.2060329332367">
+				<ele>932.3420065119863</ele>
+				<time>2017-11-20T18:59:35Z</time>
+				<extensions>
+					<speed>2.2577221393585205</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005737420286836" lon="-84.20605138130956">
+				<ele>932.147060725838</ele>
+				<time>2017-11-20T18:59:36Z</time>
+				<extensions>
+					<speed>3.1288061141967773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005713612006703" lon="-84.20607414904681">
+				<ele>932.4574037091807</ele>
+				<time>2017-11-20T18:59:37Z</time>
+				<extensions>
+					<speed>3.9588887691497803</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005684591128738" lon="-84.20610301481153">
+				<ele>932.6426169881597</ele>
+				<time>2017-11-20T18:59:38Z</time>
+				<extensions>
+					<speed>4.724725246429443</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005654275917781" lon="-84.20614024335212">
+				<ele>932.7495563756675</ele>
+				<time>2017-11-20T18:59:39Z</time>
+				<extensions>
+					<speed>5.25413179397583</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005618750094897" lon="-84.20618523340559">
+				<ele>933.0440614437684</ele>
+				<time>2017-11-20T18:59:40Z</time>
+				<extensions>
+					<speed>6.401269912719727</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005577274514334" lon="-84.2062378894993">
+				<ele>932.8916912283748</ele>
+				<time>2017-11-20T18:59:41Z</time>
+				<extensions>
+					<speed>7.417963981628418</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005532979085604" lon="-84.20629548134798">
+				<ele>932.9830761393532</ele>
+				<time>2017-11-20T18:59:42Z</time>
+				<extensions>
+					<speed>7.950187683105469</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005484002625495" lon="-84.2063571272741">
+				<ele>932.7048582779244</ele>
+				<time>2017-11-20T18:59:43Z</time>
+				<extensions>
+					<speed>8.754961967468262</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005430080088455" lon="-84.20641848607279">
+				<ele>932.6549005834386</ele>
+				<time>2017-11-20T18:59:44Z</time>
+				<extensions>
+					<speed>9.046661376953125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005373475971618" lon="-84.20647958705271">
+				<ele>932.4201226243749</ele>
+				<time>2017-11-20T18:59:45Z</time>
+				<extensions>
+					<speed>9.138493537902832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005310735757352" lon="-84.20653953093566">
+				<ele>932.4560771500692</ele>
+				<time>2017-11-20T18:59:46Z</time>
+				<extensions>
+					<speed>9.55473804473877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005243122438356" lon="-84.20659748442093">
+				<ele>931.7265625810251</ele>
+				<time>2017-11-20T18:59:47Z</time>
+				<extensions>
+					<speed>9.290325164794922</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005178066647998" lon="-84.2066464413563">
+				<ele>930.0143058598042</ele>
+				<time>2017-11-20T18:59:48Z</time>
+				<extensions>
+					<speed>8.342514991760254</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005122101781277" lon="-84.20669450895197">
+				<ele>929.4196339342743</ele>
+				<time>2017-11-20T18:59:49Z</time>
+				<extensions>
+					<speed>7.603950023651123</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005074252008118" lon="-84.20673308558425">
+				<ele>928.6903228927404</ele>
+				<time>2017-11-20T18:59:50Z</time>
+				<extensions>
+					<speed>5.829078674316406</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005037841365587" lon="-84.20676604497879">
+				<ele>928.3264731625095</ele>
+				<time>2017-11-20T18:59:51Z</time>
+				<extensions>
+					<speed>4.725052356719971</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0050110204599" lon="-84.20679245476299">
+				<ele>928.145826395601</ele>
+				<time>2017-11-20T18:59:52Z</time>
+				<extensions>
+					<speed>3.3817670345306396</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004990409728107" lon="-84.20681189878675">
+				<ele>927.7401995565742</ele>
+				<time>2017-11-20T18:59:53Z</time>
+				<extensions>
+					<speed>2.4291625022888184</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00497523205677" lon="-84.20681664555772">
+				<ele>927.0325535777956</ele>
+				<time>2017-11-20T18:59:54Z</time>
+				<extensions>
+					<speed>0.9637638926506042</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00496970897543" lon="-84.2068141597943">
+				<ele>926.6108860550448</ele>
+				<time>2017-11-20T18:59:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00496970897543" lon="-84.2068141597943">
+				<ele>926.6108860550448</ele>
+				<time>2017-11-20T18:59:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00496970897543" lon="-84.2068141597943">
+				<ele>926.6108860550448</ele>
+				<time>2017-11-20T18:59:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004964229777762" lon="-84.20681019505241">
+				<ele>926.8051298838109</ele>
+				<time>2017-11-20T18:59:58Z</time>
+				<extensions>
+					<speed>0.8994516134262085</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004949532190517" lon="-84.20680752521385">
+				<ele>926.9549867901951</ele>
+				<time>2017-11-20T18:59:59Z</time>
+				<extensions>
+					<speed>2.0184051990509033</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004927006402857" lon="-84.20680278668648">
+				<ele>927.3266932694241</ele>
+				<time>2017-11-20T19:00:00Z</time>
+				<extensions>
+					<speed>2.9461820125579834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004899625719968" lon="-84.20679307732549">
+				<ele>927.6422330373898</ele>
+				<time>2017-11-20T19:00:01Z</time>
+				<extensions>
+					<speed>3.4800832271575928</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004868316074466" lon="-84.20677676639293">
+				<ele>927.3639182299376</ele>
+				<time>2017-11-20T19:00:02Z</time>
+				<extensions>
+					<speed>4.268568515777588</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004835273025234" lon="-84.20675360057258">
+				<ele>927.1934566944838</ele>
+				<time>2017-11-20T19:00:03Z</time>
+				<extensions>
+					<speed>4.476391315460205</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004803925400761" lon="-84.2067267311321">
+				<ele>927.3410210153088</ele>
+				<time>2017-11-20T19:00:04Z</time>
+				<extensions>
+					<speed>4.5553436279296875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00477619641154" lon="-84.2066980142595">
+				<ele>927.4475964587182</ele>
+				<time>2017-11-20T19:00:05Z</time>
+				<extensions>
+					<speed>4.234081268310547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004754196498826" lon="-84.2066729891698">
+				<ele>927.7708503920585</ele>
+				<time>2017-11-20T19:00:06Z</time>
+				<extensions>
+					<speed>3.014512300491333</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00473817524429" lon="-84.20665875697793">
+				<ele>927.988341756165</ele>
+				<time>2017-11-20T19:00:07Z</time>
+				<extensions>
+					<speed>1.4143085479736328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004730411763223" lon="-84.2066530997675">
+				<ele>928.3106264919043</ele>
+				<time>2017-11-20T19:00:08Z</time>
+				<extensions>
+					<speed>0.6848676800727844</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004730411763223" lon="-84.2066530997675">
+				<ele>928.3106264919043</ele>
+				<time>2017-11-20T19:00:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004737006814047" lon="-84.20665189160057">
+				<ele>928.5491783414036</ele>
+				<time>2017-11-20T19:00:10Z</time>
+				<extensions>
+					<speed>0.8317806720733643</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004746661281716" lon="-84.20665269129994">
+				<ele>928.7192677920684</ele>
+				<time>2017-11-20T19:00:11Z</time>
+				<extensions>
+					<speed>1.0130139589309692</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004757847666122" lon="-84.20665348240425">
+				<ele>929.2138894060627</ele>
+				<time>2017-11-20T19:00:12Z</time>
+				<extensions>
+					<speed>1.0793486833572388</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004769963215399" lon="-84.20665264195667">
+				<ele>929.9545946251601</ele>
+				<time>2017-11-20T19:00:13Z</time>
+				<extensions>
+					<speed>0.700715184211731</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004769963215399" lon="-84.20665264195667">
+				<ele>929.9545946251601</ele>
+				<time>2017-11-20T19:00:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004774173289901" lon="-84.20665049391145">
+				<ele>930.3783632535487</ele>
+				<time>2017-11-20T19:00:15Z</time>
+				<extensions>
+					<speed>0.13555732369422913</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004774173289901" lon="-84.20665049391145">
+				<ele>930.3783632535487</ele>
+				<time>2017-11-20T19:00:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004774173289901" lon="-84.20665049391145">
+				<ele>930.3783632535487</ele>
+				<time>2017-11-20T19:00:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004774173289901" lon="-84.20665049391145">
+				<ele>930.3783632535487</ele>
+				<time>2017-11-20T19:00:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004774173289901" lon="-84.20665049391145">
+				<ele>930.3783632535487</ele>
+				<time>2017-11-20T19:00:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004774173289901" lon="-84.20665049391145">
+				<ele>930.3783632535487</ele>
+				<time>2017-11-20T19:00:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004775174263036" lon="-84.20664887835612">
+				<ele>930.4184814356267</ele>
+				<time>2017-11-20T19:00:21Z</time>
+				<extensions>
+					<speed>0.6843904256820679</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004770304313586" lon="-84.20664486298224">
+				<ele>930.4598776176572</ele>
+				<time>2017-11-20T19:00:22Z</time>
+				<extensions>
+					<speed>1.1938693523406982</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004767151444979" lon="-84.20663324597703">
+				<ele>929.9670096691698</ele>
+				<time>2017-11-20T19:00:23Z</time>
+				<extensions>
+					<speed>1.9924194812774658</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004750640468657" lon="-84.2066154643242">
+				<ele>930.4407299933955</ele>
+				<time>2017-11-20T19:00:24Z</time>
+				<extensions>
+					<speed>3.4267685413360596</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004727352057262" lon="-84.20659113063286">
+				<ele>929.4793175226077</ele>
+				<time>2017-11-20T19:00:25Z</time>
+				<extensions>
+					<speed>4.123079776763916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00469656727402" lon="-84.20656346503661">
+				<ele>928.3857387183234</ele>
+				<time>2017-11-20T19:00:26Z</time>
+				<extensions>
+					<speed>4.902039527893066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004656645098008" lon="-84.20652865008006">
+				<ele>926.863355149515</ele>
+				<time>2017-11-20T19:00:27Z</time>
+				<extensions>
+					<speed>6.302556991577148</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004614250983408" lon="-84.20648986422822">
+				<ele>925.2170788440853</ele>
+				<time>2017-11-20T19:00:28Z</time>
+				<extensions>
+					<speed>6.241477012634277</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004570249465646" lon="-84.2064484870335">
+				<ele>924.3289353242144</ele>
+				<time>2017-11-20T19:00:29Z</time>
+				<extensions>
+					<speed>6.443477630615234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004518787239105" lon="-84.20641098315039">
+				<ele>923.9025404853746</ele>
+				<time>2017-11-20T19:00:30Z</time>
+				<extensions>
+					<speed>5.830732345581055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004472188668792" lon="-84.2063773724896">
+				<ele>923.4516962235793</ele>
+				<time>2017-11-20T19:00:31Z</time>
+				<extensions>
+					<speed>5.462827205657959</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004436216266031" lon="-84.20634305318293">
+				<ele>923.4582421416417</ele>
+				<time>2017-11-20T19:00:32Z</time>
+				<extensions>
+					<speed>4.784100532531738</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004415512417467" lon="-84.20630554341841">
+				<ele>923.4736791634932</ele>
+				<time>2017-11-20T19:00:33Z</time>
+				<extensions>
+					<speed>4.5417022705078125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004416054874298" lon="-84.20626402610687">
+				<ele>923.4851180883124</ele>
+				<time>2017-11-20T19:00:34Z</time>
+				<extensions>
+					<speed>4.9506707191467285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004439049305585" lon="-84.20622017544284">
+				<ele>923.6019881349057</ele>
+				<time>2017-11-20T19:00:35Z</time>
+				<extensions>
+					<speed>5.998239517211914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004475110972505" lon="-84.20617742474215">
+				<ele>924.5974031630903</ele>
+				<time>2017-11-20T19:00:36Z</time>
+				<extensions>
+					<speed>6.400598526000977</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004519942008459" lon="-84.2061347436872">
+				<ele>925.1402293890715</ele>
+				<time>2017-11-20T19:00:37Z</time>
+				<extensions>
+					<speed>6.585464000701904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004562757850685" lon="-84.2060918840169">
+				<ele>926.429269653745</ele>
+				<time>2017-11-20T19:00:38Z</time>
+				<extensions>
+					<speed>6.382551193237305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004603368842986" lon="-84.2060504622513">
+				<ele>927.9940187102184</ele>
+				<time>2017-11-20T19:00:39Z</time>
+				<extensions>
+					<speed>5.903874397277832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004640947478563" lon="-84.20601392642932">
+				<ele>928.9724508132786</ele>
+				<time>2017-11-20T19:00:40Z</time>
+				<extensions>
+					<speed>5.461422920227051</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004675864230505" lon="-84.20597671124705">
+				<ele>930.3386797290295</ele>
+				<time>2017-11-20T19:00:41Z</time>
+				<extensions>
+					<speed>5.31141996383667</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004709022814637" lon="-84.20593962601033">
+				<ele>931.2023929171264</ele>
+				<time>2017-11-20T19:00:42Z</time>
+				<extensions>
+					<speed>5.022836208343506</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004740636742307" lon="-84.20590209606304">
+				<ele>931.3616989245638</ele>
+				<time>2017-11-20T19:00:43Z</time>
+				<extensions>
+					<speed>5.224264144897461</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004773031469748" lon="-84.20586558672495">
+				<ele>931.401141172275</ele>
+				<time>2017-11-20T19:00:44Z</time>
+				<extensions>
+					<speed>5.232389450073242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004806939955389" lon="-84.20582419169388">
+				<ele>932.2287830375135</ele>
+				<time>2017-11-20T19:00:45Z</time>
+				<extensions>
+					<speed>5.8514556884765625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004841182538815" lon="-84.20577917347812">
+				<ele>932.4798148898408</ele>
+				<time>2017-11-20T19:00:46Z</time>
+				<extensions>
+					<speed>6.128425121307373</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004875939062218" lon="-84.20573422196244">
+				<ele>932.0281744152308</ele>
+				<time>2017-11-20T19:00:47Z</time>
+				<extensions>
+					<speed>6.023355960845947</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004908954760056" lon="-84.2056909762574">
+				<ele>931.95857342612</ele>
+				<time>2017-11-20T19:00:48Z</time>
+				<extensions>
+					<speed>5.675097465515137</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004943525761242" lon="-84.20565101126728">
+				<ele>932.2051955070347</ele>
+				<time>2017-11-20T19:00:49Z</time>
+				<extensions>
+					<speed>5.887928009033203</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004981669431412" lon="-84.20560723671542">
+				<ele>932.4064614614472</ele>
+				<time>2017-11-20T19:00:50Z</time>
+				<extensions>
+					<speed>6.636164665222168</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005023824345916" lon="-84.2055633223088">
+				<ele>932.6799938799813</ele>
+				<time>2017-11-20T19:00:51Z</time>
+				<extensions>
+					<speed>6.794122695922852</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00506864158477" lon="-84.20551870325927">
+				<ele>932.9311576178297</ele>
+				<time>2017-11-20T19:00:52Z</time>
+				<extensions>
+					<speed>6.898072719573975</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005111942467389" lon="-84.20547542726908">
+				<ele>933.113148542121</ele>
+				<time>2017-11-20T19:00:53Z</time>
+				<extensions>
+					<speed>6.441741466522217</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005150814007193" lon="-84.20543320706346">
+				<ele>933.461485539563</ele>
+				<time>2017-11-20T19:00:54Z</time>
+				<extensions>
+					<speed>6.0134077072143555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005184141292622" lon="-84.205392159709">
+				<ele>933.6224457714707</ele>
+				<time>2017-11-20T19:00:55Z</time>
+				<extensions>
+					<speed>5.399084091186523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005210187621996" lon="-84.20535493011828">
+				<ele>934.1543899755925</ele>
+				<time>2017-11-20T19:00:56Z</time>
+				<extensions>
+					<speed>4.272451400756836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005228368126488" lon="-84.20532608845218">
+				<ele>934.2882838556543</ele>
+				<time>2017-11-20T19:00:57Z</time>
+				<extensions>
+					<speed>3.3344531059265137</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005243226505218" lon="-84.20530351188506">
+				<ele>934.0692538721487</ele>
+				<time>2017-11-20T19:00:58Z</time>
+				<extensions>
+					<speed>2.7112317085266113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005254177521968" lon="-84.20528456938854">
+				<ele>933.9061137400568</ele>
+				<time>2017-11-20T19:00:59Z</time>
+				<extensions>
+					<speed>1.921816110610962</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005259895365429" lon="-84.20527069103723">
+				<ele>933.7383718937635</ele>
+				<time>2017-11-20T19:01:00Z</time>
+				<extensions>
+					<speed>1.2471537590026855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005264594619243" lon="-84.20526041225573">
+				<ele>933.8543298896402</ele>
+				<time>2017-11-20T19:01:01Z</time>
+				<extensions>
+					<speed>1.02392578125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005267506738889" lon="-84.20525397183683">
+				<ele>934.3186027267948</ele>
+				<time>2017-11-20T19:01:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005271171228774" lon="-84.20524865470244">
+				<ele>934.3115542782471</ele>
+				<time>2017-11-20T19:01:23Z</time>
+				<extensions>
+					<speed>0.6267626881599426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00527860985352" lon="-84.20523966289196">
+				<ele>934.1928455214947</ele>
+				<time>2017-11-20T19:01:24Z</time>
+				<extensions>
+					<speed>1.3595762252807617</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005288238400306" lon="-84.20522570762074">
+				<ele>933.9273168863729</ele>
+				<time>2017-11-20T19:01:25Z</time>
+				<extensions>
+					<speed>1.5144766569137573</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297120747453" lon="-84.20521176859668">
+				<ele>933.6165997199714</ele>
+				<time>2017-11-20T19:01:26Z</time>
+				<extensions>
+					<speed>1.4145920276641846</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005303319653216" lon="-84.20519663610655">
+				<ele>933.3537727436051</ele>
+				<time>2017-11-20T19:01:27Z</time>
+				<extensions>
+					<speed>1.6441468000411987</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005309146548713" lon="-84.205179856921">
+				<ele>933.0945238983259</ele>
+				<time>2017-11-20T19:01:28Z</time>
+				<extensions>
+					<speed>1.4489294290542603</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005314173516734" lon="-84.20516506408299">
+				<ele>932.8605415290222</ele>
+				<time>2017-11-20T19:01:29Z</time>
+				<extensions>
+					<speed>1.2010657787322998</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005319072984225" lon="-84.20515425907108">
+				<ele>933.0987732764333</ele>
+				<time>2017-11-20T19:01:30Z</time>
+				<extensions>
+					<speed>0.8334288001060486</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005325258871498" lon="-84.20514445730775">
+				<ele>933.4686888027936</ele>
+				<time>2017-11-20T19:01:31Z</time>
+				<extensions>
+					<speed>0.8629564642906189</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005331153057538" lon="-84.20513722562063">
+				<ele>933.7849123422056</ele>
+				<time>2017-11-20T19:01:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005334446813677" lon="-84.20513374005675">
+				<ele>934.0676531465724</ele>
+				<time>2017-11-20T19:01:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005338643136582" lon="-84.20512815921532">
+				<ele>934.2746173813939</ele>
+				<time>2017-11-20T19:01:34Z</time>
+				<extensions>
+					<speed>0.722412109375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0053463054085" lon="-84.20511602329898">
+				<ele>934.1527715297416</ele>
+				<time>2017-11-20T19:01:35Z</time>
+				<extensions>
+					<speed>1.6188478469848633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005359030030178" lon="-84.20509852171025">
+				<ele>934.032314516604</ele>
+				<time>2017-11-20T19:01:36Z</time>
+				<extensions>
+					<speed>2.3194618225097656</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00537331889834" lon="-84.20507635543616">
+				<ele>933.746150993742</ele>
+				<time>2017-11-20T19:01:37Z</time>
+				<extensions>
+					<speed>2.626708745956421</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005391156661261" lon="-84.20505518492428">
+				<ele>933.2597834914923</ele>
+				<time>2017-11-20T19:01:38Z</time>
+				<extensions>
+					<speed>2.6156320571899414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005411091146327" lon="-84.20503340042204">
+				<ele>932.9505023965612</ele>
+				<time>2017-11-20T19:01:39Z</time>
+				<extensions>
+					<speed>2.8924543857574463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005432377771458" lon="-84.20501129016499">
+				<ele>932.6479114731774</ele>
+				<time>2017-11-20T19:01:40Z</time>
+				<extensions>
+					<speed>2.9683399200439453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005454086846827" lon="-84.20498920925138">
+				<ele>932.6510459445417</ele>
+				<time>2017-11-20T19:01:41Z</time>
+				<extensions>
+					<speed>3.398280143737793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005477812955887" lon="-84.20496625488016">
+				<ele>932.7497541932389</ele>
+				<time>2017-11-20T19:01:42Z</time>
+				<extensions>
+					<speed>3.6958224773406982</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005501638754284" lon="-84.20494439022715">
+				<ele>932.8542468464002</ele>
+				<time>2017-11-20T19:01:43Z</time>
+				<extensions>
+					<speed>3.3374977111816406</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005521028555375" lon="-84.20492751580038">
+				<ele>932.8079855618998</ele>
+				<time>2017-11-20T19:01:44Z</time>
+				<extensions>
+					<speed>2.314026355743408</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00553448351833" lon="-84.20491523272482">
+				<ele>932.8599207140505</ele>
+				<time>2017-11-20T19:01:45Z</time>
+				<extensions>
+					<speed>1.611483097076416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005544734573913" lon="-84.2049063380839">
+				<ele>932.7937276409939</ele>
+				<time>2017-11-20T19:01:46Z</time>
+				<extensions>
+					<speed>1.2082523107528687</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005550863755564" lon="-84.20490102344633">
+				<ele>932.9254480255768</ele>
+				<time>2017-11-20T19:01:47Z</time>
+				<extensions>
+					<speed>0.5600362420082092</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005550863755564" lon="-84.20490102344633">
+				<ele>932.9254480255768</ele>
+				<time>2017-11-20T19:01:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005551713291313" lon="-84.2049018680736">
+				<ele>933.2305045118555</ele>
+				<time>2017-11-20T19:01:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005551713291313" lon="-84.2049018680736">
+				<ele>933.2305045118555</ele>
+				<time>2017-11-20T19:01:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005551713291313" lon="-84.2049018680736">
+				<ele>933.2305045118555</ele>
+				<time>2017-11-20T19:01:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005551713291313" lon="-84.2049018680736">
+				<ele>933.2305045118555</ele>
+				<time>2017-11-20T19:01:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005549434351932" lon="-84.20490128569394">
+				<ele>933.6025598710403</ele>
+				<time>2017-11-20T19:01:53Z</time>
+				<extensions>
+					<speed>0.6380544304847717</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005551713291313" lon="-84.2049018680736">
+				<ele>933.2305045118555</ele>
+				<time>2017-11-20T19:01:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005551713291313" lon="-84.2049018680736">
+				<ele>933.2305045118555</ele>
+				<time>2017-11-20T19:01:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005551713291313" lon="-84.2049018680736">
+				<ele>933.2305045118555</ele>
+				<time>2017-11-20T19:01:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005551713291313" lon="-84.2049018680736">
+				<ele>933.2305045118555</ele>
+				<time>2017-11-20T19:01:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005551713291313" lon="-84.2049018680736">
+				<ele>933.2305045118555</ele>
+				<time>2017-11-20T19:01:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005556660267418" lon="-84.20489603462465">
+				<ele>933.2608531750739</ele>
+				<time>2017-11-20T19:01:59Z</time>
+				<extensions>
+					<speed>0.8805393576622009</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005551713291313" lon="-84.2049018680736">
+				<ele>933.2305045118555</ele>
+				<time>2017-11-20T19:02:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005551713291313" lon="-84.2049018680736">
+				<ele>933.2305045118555</ele>
+				<time>2017-11-20T19:02:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005551713291313" lon="-84.2049018680736">
+				<ele>933.2305045118555</ele>
+				<time>2017-11-20T19:02:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005551713291313" lon="-84.2049018680736">
+				<ele>933.2305045118555</ele>
+				<time>2017-11-20T19:02:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005554463541465" lon="-84.20489575304393">
+				<ele>933.6856026174501</ele>
+				<time>2017-11-20T19:02:04Z</time>
+				<extensions>
+					<speed>0.9355617761611938</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005560927236358" lon="-84.20488404110642">
+				<ele>934.0234526572749</ele>
+				<time>2017-11-20T19:02:05Z</time>
+				<extensions>
+					<speed>1.312746524810791</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005570072439022" lon="-84.20487006093789">
+				<ele>934.2325425939634</ele>
+				<time>2017-11-20T19:02:06Z</time>
+				<extensions>
+					<speed>1.8801904916763306</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005583219142462" lon="-84.20485318600176">
+				<ele>934.3938358314335</ele>
+				<time>2017-11-20T19:02:07Z</time>
+				<extensions>
+					<speed>2.3515682220458984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005598744794652" lon="-84.20483294999518">
+				<ele>934.7187295323238</ele>
+				<time>2017-11-20T19:02:08Z</time>
+				<extensions>
+					<speed>2.7853996753692627</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005612415372322" lon="-84.2048097974574">
+				<ele>934.9419764913619</ele>
+				<time>2017-11-20T19:02:09Z</time>
+				<extensions>
+					<speed>2.8757340908050537</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005624355325024" lon="-84.2047860202125">
+				<ele>935.5017455928028</ele>
+				<time>2017-11-20T19:02:10Z</time>
+				<extensions>
+					<speed>2.702157974243164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005639412080454" lon="-84.2047644256909">
+				<ele>935.9074852336198</ele>
+				<time>2017-11-20T19:02:11Z</time>
+				<extensions>
+					<speed>2.895695209503174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005655943431858" lon="-84.2047452999872">
+				<ele>936.0767543427646</ele>
+				<time>2017-11-20T19:02:12Z</time>
+				<extensions>
+					<speed>2.7292490005493164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005673401035377" lon="-84.20472486372293">
+				<ele>936.1003480777144</ele>
+				<time>2017-11-20T19:02:13Z</time>
+				<extensions>
+					<speed>2.8845481872558594</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005690810177628" lon="-84.20470495406946">
+				<ele>936.3319460423663</ele>
+				<time>2017-11-20T19:02:14Z</time>
+				<extensions>
+					<speed>2.684373140335083</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0057085718481" lon="-84.20468281372789">
+				<ele>936.9931280687451</ele>
+				<time>2017-11-20T19:02:15Z</time>
+				<extensions>
+					<speed>2.8633663654327393</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005729977848192" lon="-84.20465284869817">
+				<ele>937.694334898144</ele>
+				<time>2017-11-20T19:02:16Z</time>
+				<extensions>
+					<speed>3.5688529014587402</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005755543198863" lon="-84.2046248578683">
+				<ele>938.3611211255193</ele>
+				<time>2017-11-20T19:02:17Z</time>
+				<extensions>
+					<speed>3.684718608856201</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005785279673903" lon="-84.20459477092318">
+				<ele>938.9380745170638</ele>
+				<time>2017-11-20T19:02:18Z</time>
+				<extensions>
+					<speed>4.280074119567871</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005816390264162" lon="-84.20456145206617">
+				<ele>939.288109513931</ele>
+				<time>2017-11-20T19:02:19Z</time>
+				<extensions>
+					<speed>4.638410568237305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005849197610207" lon="-84.20452458737441">
+				<ele>939.3937894012779</ele>
+				<time>2017-11-20T19:02:20Z</time>
+				<extensions>
+					<speed>4.924147605895996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005879809094738" lon="-84.2044863191628">
+				<ele>939.9212527666241</ele>
+				<time>2017-11-20T19:02:21Z</time>
+				<extensions>
+					<speed>4.524618148803711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00590939214462" lon="-84.20445228544322">
+				<ele>940.1733346348628</ele>
+				<time>2017-11-20T19:02:22Z</time>
+				<extensions>
+					<speed>4.385469436645508</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005937067078376" lon="-84.20442241272309">
+				<ele>940.3610311876982</ele>
+				<time>2017-11-20T19:02:23Z</time>
+				<extensions>
+					<speed>4.0964508056640625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005960676382026" lon="-84.20439638802257">
+				<ele>940.4952972494066</ele>
+				<time>2017-11-20T19:02:24Z</time>
+				<extensions>
+					<speed>3.26489520072937</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005978815606497" lon="-84.2043777301866">
+				<ele>941.4485253058374</ele>
+				<time>2017-11-20T19:02:25Z</time>
+				<extensions>
+					<speed>2.1935524940490723</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005990480973134" lon="-84.20436588814762">
+				<ele>943.045931997709</ele>
+				<time>2017-11-20T19:02:26Z</time>
+				<extensions>
+					<speed>0.7380263209342957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005994891774371" lon="-84.20436345769018">
+				<ele>943.9550567800179</ele>
+				<time>2017-11-20T19:02:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005994891774371" lon="-84.20436345769018">
+				<ele>943.9550567800179</ele>
+				<time>2017-11-20T19:02:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005994303944327" lon="-84.20436344797298">
+				<ele>944.2403809363022</ele>
+				<time>2017-11-20T19:02:29Z</time>
+				<extensions>
+					<speed>0.781842827796936</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005994303944327" lon="-84.20436344797298">
+				<ele>944.2403809363022</ele>
+				<time>2017-11-20T19:02:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005994345259575" lon="-84.20436229231574">
+				<ele>944.263673861511</ele>
+				<time>2017-11-20T19:02:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005994345259575" lon="-84.20436229231574">
+				<ele>944.263673861511</ele>
+				<time>2017-11-20T19:02:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005994345259575" lon="-84.20436229231574">
+				<ele>944.263673861511</ele>
+				<time>2017-11-20T19:02:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005994345259575" lon="-84.20436229231574">
+				<ele>944.263673861511</ele>
+				<time>2017-11-20T19:02:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005994345259575" lon="-84.20436229231574">
+				<ele>944.263673861511</ele>
+				<time>2017-11-20T19:02:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005994345259575" lon="-84.20436229231574">
+				<ele>944.263673861511</ele>
+				<time>2017-11-20T19:02:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005994345259575" lon="-84.20436229231574">
+				<ele>944.263673861511</ele>
+				<time>2017-11-20T19:02:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005994345259575" lon="-84.20436229231574">
+				<ele>944.263673861511</ele>
+				<time>2017-11-20T19:02:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005994345259575" lon="-84.20436229231574">
+				<ele>944.263673861511</ele>
+				<time>2017-11-20T19:02:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005994345259575" lon="-84.20436229231574">
+				<ele>944.263673861511</ele>
+				<time>2017-11-20T19:02:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005994345259575" lon="-84.20436229231574">
+				<ele>944.263673861511</ele>
+				<time>2017-11-20T19:02:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005994345259575" lon="-84.20436229231574">
+				<ele>944.263673861511</ele>
+				<time>2017-11-20T19:02:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005994345259575" lon="-84.20436229231574">
+				<ele>944.263673861511</ele>
+				<time>2017-11-20T19:02:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005994345259575" lon="-84.20436229231574">
+				<ele>944.263673861511</ele>
+				<time>2017-11-20T19:02:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00600040997375" lon="-84.20435852456113">
+				<ele>944.2344946423545</ele>
+				<time>2017-11-20T19:02:45Z</time>
+				<extensions>
+					<speed>0.7441115379333496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006008996747456" lon="-84.20435172713186">
+				<ele>944.387358924374</ele>
+				<time>2017-11-20T19:02:46Z</time>
+				<extensions>
+					<speed>1.1720784902572632</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006018957860869" lon="-84.20434226848259">
+				<ele>944.2044845689088</ele>
+				<time>2017-11-20T19:02:47Z</time>
+				<extensions>
+					<speed>1.729828953742981</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006034436170113" lon="-84.20432837226906">
+				<ele>944.1808877587318</ele>
+				<time>2017-11-20T19:02:48Z</time>
+				<extensions>
+					<speed>2.349919319152832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006052606235793" lon="-84.20430952950312">
+				<ele>943.8091626390815</ele>
+				<time>2017-11-20T19:02:49Z</time>
+				<extensions>
+					<speed>2.779780387878418</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006068212042106" lon="-84.20428853986526">
+				<ele>943.5367858223617</ele>
+				<time>2017-11-20T19:02:50Z</time>
+				<extensions>
+					<speed>2.603827476501465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006083058455518" lon="-84.2042655761814">
+				<ele>943.5922245802358</ele>
+				<time>2017-11-20T19:02:51Z</time>
+				<extensions>
+					<speed>2.830608606338501</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006100004278546" lon="-84.20424134368581">
+				<ele>943.4707762626931</ele>
+				<time>2017-11-20T19:02:52Z</time>
+				<extensions>
+					<speed>2.875591993331909</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006118865569453" lon="-84.20421484283433">
+				<ele>943.3042952278629</ele>
+				<time>2017-11-20T19:02:53Z</time>
+				<extensions>
+					<speed>3.1006953716278076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006137615049536" lon="-84.20418895790912">
+				<ele>943.3190077291802</ele>
+				<time>2017-11-20T19:02:54Z</time>
+				<extensions>
+					<speed>3.239644765853882</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006156313150944" lon="-84.20416272368684">
+				<ele>943.3720153896138</ele>
+				<time>2017-11-20T19:02:55Z</time>
+				<extensions>
+					<speed>3.353130578994751</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006176466027215" lon="-84.2041360084003">
+				<ele>943.1589381117374</ele>
+				<time>2017-11-20T19:02:56Z</time>
+				<extensions>
+					<speed>3.468519926071167</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006196833417441" lon="-84.20410973351619">
+				<ele>943.2334113428369</ele>
+				<time>2017-11-20T19:02:57Z</time>
+				<extensions>
+					<speed>3.374856948852539</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00621638208632" lon="-84.20408776615395">
+				<ele>943.3099290402606</ele>
+				<time>2017-11-20T19:02:58Z</time>
+				<extensions>
+					<speed>2.8515799045562744</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006232107924546" lon="-84.20407104035219">
+				<ele>943.2885591154918</ele>
+				<time>2017-11-20T19:02:59Z</time>
+				<extensions>
+					<speed>2.1503424644470215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006244516186" lon="-84.20405808626188">
+				<ele>943.3142390614375</ele>
+				<time>2017-11-20T19:03:00Z</time>
+				<extensions>
+					<speed>1.557080864906311</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006257440354055" lon="-84.2040466586101">
+				<ele>943.459726546891</ele>
+				<time>2017-11-20T19:03:01Z</time>
+				<extensions>
+					<speed>1.7444937229156494</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006274402410888" lon="-84.20404196281928">
+				<ele>943.6752776410431</ele>
+				<time>2017-11-20T19:03:02Z</time>
+				<extensions>
+					<speed>1.8267326354980469</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006296529361526" lon="-84.2040422767577">
+				<ele>943.8602825663984</ele>
+				<time>2017-11-20T19:03:03Z</time>
+				<extensions>
+					<speed>2.4643852710723877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006324399523455" lon="-84.20404839083942">
+				<ele>944.0417274329811</ele>
+				<time>2017-11-20T19:03:04Z</time>
+				<extensions>
+					<speed>3.4965100288391113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006358932938175" lon="-84.20406302101074">
+				<ele>944.1535691032186</ele>
+				<time>2017-11-20T19:03:05Z</time>
+				<extensions>
+					<speed>4.428722381591797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006395636160237" lon="-84.20408651262662">
+				<ele>944.7171427337453</ele>
+				<time>2017-11-20T19:03:06Z</time>
+				<extensions>
+					<speed>5.040942192077637</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006436443264533" lon="-84.204121039847">
+				<ele>945.2816918119788</ele>
+				<time>2017-11-20T19:03:07Z</time>
+				<extensions>
+					<speed>6.211338520050049</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006481321582413" lon="-84.20416244092554">
+				<ele>945.5159720135853</ele>
+				<time>2017-11-20T19:03:08Z</time>
+				<extensions>
+					<speed>6.870536804199219</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006532474247614" lon="-84.20421034820097">
+				<ele>945.8770047063008</ele>
+				<time>2017-11-20T19:03:09Z</time>
+				<extensions>
+					<speed>7.811193466186523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006586594287786" lon="-84.2042636637616">
+				<ele>946.0385415079072</ele>
+				<time>2017-11-20T19:03:10Z</time>
+				<extensions>
+					<speed>8.435173988342285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006643835037496" lon="-84.20431827974295">
+				<ele>946.2829371001571</ele>
+				<time>2017-11-20T19:03:11Z</time>
+				<extensions>
+					<speed>8.797717094421387</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006704614254346" lon="-84.20437505659997">
+				<ele>946.550031548366</ele>
+				<time>2017-11-20T19:03:12Z</time>
+				<extensions>
+					<speed>9.294631004333496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00676902085361" lon="-84.204431854201">
+				<ele>946.5847065346316</ele>
+				<time>2017-11-20T19:03:13Z</time>
+				<extensions>
+					<speed>9.516318321228027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006834801707033" lon="-84.2044873284177">
+				<ele>946.661287474446</ele>
+				<time>2017-11-20T19:03:14Z</time>
+				<extensions>
+					<speed>9.361345291137695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006896551572877" lon="-84.204543507832">
+				<ele>946.7073333002627</ele>
+				<time>2017-11-20T19:03:15Z</time>
+				<extensions>
+					<speed>9.178656578063965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006958184927305" lon="-84.20459829052461">
+				<ele>946.814426981844</ele>
+				<time>2017-11-20T19:03:16Z</time>
+				<extensions>
+					<speed>9.20355224609375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0070156872624" lon="-84.20464914162115">
+				<ele>947.1229098383337</ele>
+				<time>2017-11-20T19:03:17Z</time>
+				<extensions>
+					<speed>8.198404312133789</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007065584390718" lon="-84.20469419020039">
+				<ele>946.88324341923</ele>
+				<time>2017-11-20T19:03:18Z</time>
+				<extensions>
+					<speed>6.765849590301514</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0071097264778" lon="-84.20472753076939">
+				<ele>946.8504472682253</ele>
+				<time>2017-11-20T19:03:19Z</time>
+				<extensions>
+					<speed>5.36037015914917</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007145942523996" lon="-84.20474684090621">
+				<ele>946.9835862983018</ele>
+				<time>2017-11-20T19:03:20Z</time>
+				<extensions>
+					<speed>3.846029043197632</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007177037415243" lon="-84.20474976012972">
+				<ele>947.3640186674893</ele>
+				<time>2017-11-20T19:03:21Z</time>
+				<extensions>
+					<speed>2.881370782852173</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007199506672116" lon="-84.2047430761913">
+				<ele>947.5668844478205</ele>
+				<time>2017-11-20T19:03:22Z</time>
+				<extensions>
+					<speed>1.543617606163025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007210099075184" lon="-84.20473103603719">
+				<ele>948.1444758065045</ele>
+				<time>2017-11-20T19:03:23Z</time>
+				<extensions>
+					<speed>0.8681303262710571</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00721249236353" lon="-84.20471747513406">
+				<ele>948.7080272510648</ele>
+				<time>2017-11-20T19:03:24Z</time>
+				<extensions>
+					<speed>1.3600064516067505</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00721289453889" lon="-84.2047042943256">
+				<ele>949.1101140035316</ele>
+				<time>2017-11-20T19:03:25Z</time>
+				<extensions>
+					<speed>0.8692657351493835</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00721289453889" lon="-84.2047042943256">
+				<ele>949.1101140035316</ele>
+				<time>2017-11-20T19:03:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00722181237819" lon="-84.204692868486">
+				<ele>948.9162273090333</ele>
+				<time>2017-11-20T19:03:27Z</time>
+				<extensions>
+					<speed>1.0121656656265259</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007230134028973" lon="-84.2046795624472">
+				<ele>948.9436025461182</ele>
+				<time>2017-11-20T19:03:28Z</time>
+				<extensions>
+					<speed>1.5272296667099</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00724767989987" lon="-84.20465675833624">
+				<ele>948.1110585490242</ele>
+				<time>2017-11-20T19:03:29Z</time>
+				<extensions>
+					<speed>2.8954782485961914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007270128714454" lon="-84.20463114569249">
+				<ele>947.9780854610726</ele>
+				<time>2017-11-20T19:03:30Z</time>
+				<extensions>
+					<speed>3.733410596847534</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007300006842122" lon="-84.20460614753539">
+				<ele>948.0244141472504</ele>
+				<time>2017-11-20T19:03:31Z</time>
+				<extensions>
+					<speed>4.0393500328063965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007329990214245" lon="-84.20458165331677">
+				<ele>947.906407000497</ele>
+				<time>2017-11-20T19:03:32Z</time>
+				<extensions>
+					<speed>3.8655683994293213</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007353844738631" lon="-84.20456133712443">
+				<ele>947.8402688866481</ele>
+				<time>2017-11-20T19:03:33Z</time>
+				<extensions>
+					<speed>2.482661485671997</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007367595037612" lon="-84.20454898355736">
+				<ele>947.8960783192888</ele>
+				<time>2017-11-20T19:03:34Z</time>
+				<extensions>
+					<speed>0.8696730136871338</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007380631085965" lon="-84.20454414100386">
+				<ele>948.5131155038252</ele>
+				<time>2017-11-20T19:03:35Z</time>
+				<extensions>
+					<speed>0.29095327854156494</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007380631085965" lon="-84.20454414100386">
+				<ele>948.5131155038252</ele>
+				<time>2017-11-20T19:03:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007380587585352" lon="-84.20455009809676">
+				<ele>948.4535327721387</ele>
+				<time>2017-11-20T19:03:37Z</time>
+				<extensions>
+					<speed>0.6093405485153198</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007380587585352" lon="-84.20455009809676">
+				<ele>948.4535327721387</ele>
+				<time>2017-11-20T19:03:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007378364840246" lon="-84.20455343916387">
+				<ele>948.24370081909</ele>
+				<time>2017-11-20T19:03:39Z</time>
+				<extensions>
+					<speed>0.7284786701202393</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007378364840246" lon="-84.20455343916387">
+				<ele>948.24370081909</ele>
+				<time>2017-11-20T19:03:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007375608597064" lon="-84.20455705692693">
+				<ele>947.9905623132363</ele>
+				<time>2017-11-20T19:03:41Z</time>
+				<extensions>
+					<speed>0.1180172935128212</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007375608597064" lon="-84.20455705692693">
+				<ele>947.9905623132363</ele>
+				<time>2017-11-20T19:03:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007375608597064" lon="-84.20455705692693">
+				<ele>947.9905623132363</ele>
+				<time>2017-11-20T19:03:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007375608597064" lon="-84.20455705692693">
+				<ele>947.9905623132363</ele>
+				<time>2017-11-20T19:03:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007375608597064" lon="-84.20455705692693">
+				<ele>947.9905623132363</ele>
+				<time>2017-11-20T19:03:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007379745944364" lon="-84.20455104734198">
+				<ele>947.9435068424791</ele>
+				<time>2017-11-20T19:03:46Z</time>
+				<extensions>
+					<speed>0.9798030257225037</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007390455698946" lon="-84.20454272678494">
+				<ele>947.6661596847698</ele>
+				<time>2017-11-20T19:03:47Z</time>
+				<extensions>
+					<speed>1.7687695026397705</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007408009780711" lon="-84.204529369888">
+				<ele>947.4248209008947</ele>
+				<time>2017-11-20T19:03:48Z</time>
+				<extensions>
+					<speed>2.991084575653076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007431467770127" lon="-84.20450935959914">
+				<ele>947.1915931403637</ele>
+				<time>2017-11-20T19:03:49Z</time>
+				<extensions>
+					<speed>3.972064971923828</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007462525645696" lon="-84.2044863895637">
+				<ele>947.0495634935796</ele>
+				<time>2017-11-20T19:03:50Z</time>
+				<extensions>
+					<speed>4.760035991668701</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007501155821688" lon="-84.20445886304185">
+				<ele>946.8637638809159</ele>
+				<time>2017-11-20T19:03:51Z</time>
+				<extensions>
+					<speed>5.5475311279296875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007542695163474" lon="-84.20442478809386">
+				<ele>946.5452551087365</ele>
+				<time>2017-11-20T19:03:52Z</time>
+				<extensions>
+					<speed>5.887815475463867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007586716884964" lon="-84.20438613322918">
+				<ele>946.1444751098752</ele>
+				<time>2017-11-20T19:03:53Z</time>
+				<extensions>
+					<speed>6.520890235900879</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00763282735913" lon="-84.20434334820241">
+				<ele>945.971422332339</ele>
+				<time>2017-11-20T19:03:54Z</time>
+				<extensions>
+					<speed>7.151167392730713</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00768303136627" lon="-84.20429530274835">
+				<ele>945.7908186241984</ele>
+				<time>2017-11-20T19:03:55Z</time>
+				<extensions>
+					<speed>7.4287214279174805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007733940392095" lon="-84.2042477967713">
+				<ele>945.774888291955</ele>
+				<time>2017-11-20T19:03:56Z</time>
+				<extensions>
+					<speed>7.4552903175354</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00778424137223" lon="-84.20420292135705">
+				<ele>945.8246200149879</ele>
+				<time>2017-11-20T19:03:57Z</time>
+				<extensions>
+					<speed>7.1986260414123535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007831259208395" lon="-84.20415751618711">
+				<ele>945.8239862369373</ele>
+				<time>2017-11-20T19:03:58Z</time>
+				<extensions>
+					<speed>7.025451183319092</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007875510408748" lon="-84.20411250077642">
+				<ele>946.28488097433</ele>
+				<time>2017-11-20T19:03:59Z</time>
+				<extensions>
+					<speed>6.6899943351745605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007922632911544" lon="-84.2040661818869">
+				<ele>945.8502419916913</ele>
+				<time>2017-11-20T19:04:00Z</time>
+				<extensions>
+					<speed>7.174034118652344</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007971350406201" lon="-84.20402024328298">
+				<ele>945.3004476604983</ele>
+				<time>2017-11-20T19:04:01Z</time>
+				<extensions>
+					<speed>6.961545944213867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008018591413425" lon="-84.20397897023568">
+				<ele>945.0329320896417</ele>
+				<time>2017-11-20T19:04:02Z</time>
+				<extensions>
+					<speed>6.733469009399414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008064866982304" lon="-84.20393989997926">
+				<ele>944.8544295113534</ele>
+				<time>2017-11-20T19:04:03Z</time>
+				<extensions>
+					<speed>6.545007705688477</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008112671168112" lon="-84.20390262297067">
+				<ele>944.8665277576074</ele>
+				<time>2017-11-20T19:04:04Z</time>
+				<extensions>
+					<speed>6.71505069732666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008160113979553" lon="-84.203864402213">
+				<ele>944.7481894325465</ele>
+				<time>2017-11-20T19:04:05Z</time>
+				<extensions>
+					<speed>6.646596431732178</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008205767691289" lon="-84.20382284187173">
+				<ele>944.9808124070987</ele>
+				<time>2017-11-20T19:04:06Z</time>
+				<extensions>
+					<speed>6.832712650299072</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008256400492431" lon="-84.20377879354359">
+				<ele>945.7199557116255</ele>
+				<time>2017-11-20T19:04:07Z</time>
+				<extensions>
+					<speed>7.575843334197998</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008309678334166" lon="-84.20373517474802">
+				<ele>946.0233451491222</ele>
+				<time>2017-11-20T19:04:08Z</time>
+				<extensions>
+					<speed>7.624218463897705</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008361268752157" lon="-84.20369182446032">
+				<ele>946.0392616400495</ele>
+				<time>2017-11-20T19:04:09Z</time>
+				<extensions>
+					<speed>7.537364482879639</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008410534056472" lon="-84.20365098851954">
+				<ele>946.5666351411492</ele>
+				<time>2017-11-20T19:04:10Z</time>
+				<extensions>
+					<speed>6.94966459274292</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0084550759903" lon="-84.20361590625578">
+				<ele>946.9229191541672</ele>
+				<time>2017-11-20T19:04:11Z</time>
+				<extensions>
+					<speed>5.745021820068359</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008485238852552" lon="-84.20358695362872">
+				<ele>946.5400943243876</ele>
+				<time>2017-11-20T19:04:12Z</time>
+				<extensions>
+					<speed>3.6105334758758545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008501981942933" lon="-84.20356795454292">
+				<ele>946.0917253391817</ele>
+				<time>2017-11-20T19:04:13Z</time>
+				<extensions>
+					<speed>1.827694296836853</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008511317051628" lon="-84.20355999258148">
+				<ele>945.709541159682</ele>
+				<time>2017-11-20T19:04:14Z</time>
+				<extensions>
+					<speed>1.0648465156555176</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008517456094264" lon="-84.20355460516316">
+				<ele>945.5620874129236</ele>
+				<time>2017-11-20T19:04:15Z</time>
+				<extensions>
+					<speed>0.7093883752822876</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008517456094264" lon="-84.20355460516316">
+				<ele>945.5620874129236</ele>
+				<time>2017-11-20T19:04:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008524846982798" lon="-84.20354810955436">
+				<ele>946.0942258192226</ele>
+				<time>2017-11-20T19:04:17Z</time>
+				<extensions>
+					<speed>1.0540214776992798</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008536332943951" lon="-84.20353941934995">
+				<ele>946.0666917031631</ele>
+				<time>2017-11-20T19:04:18Z</time>
+				<extensions>
+					<speed>2.165578603744507</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00855270064137" lon="-84.20352666963723">
+				<ele>945.6618357468396</ele>
+				<time>2017-11-20T19:04:19Z</time>
+				<extensions>
+					<speed>2.710681438446045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008573553618495" lon="-84.20350997362598">
+				<ele>945.7592014102265</ele>
+				<time>2017-11-20T19:04:20Z</time>
+				<extensions>
+					<speed>3.588724374771118</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008602264928403" lon="-84.20348621233342">
+				<ele>946.0155704692006</ele>
+				<time>2017-11-20T19:04:21Z</time>
+				<extensions>
+					<speed>4.5643415451049805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00863703084609" lon="-84.2034553456705">
+				<ele>946.1378579214215</ele>
+				<time>2017-11-20T19:04:22Z</time>
+				<extensions>
+					<speed>5.3665771484375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008676761812014" lon="-84.20341863089087">
+				<ele>945.908313382417</ele>
+				<time>2017-11-20T19:04:23Z</time>
+				<extensions>
+					<speed>6.077874660491943</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008721601593422" lon="-84.20338142385624">
+				<ele>946.1520160445943</ele>
+				<time>2017-11-20T19:04:24Z</time>
+				<extensions>
+					<speed>6.58890962600708</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00876859057863" lon="-84.20333767094063">
+				<ele>946.0854488443583</ele>
+				<time>2017-11-20T19:04:25Z</time>
+				<extensions>
+					<speed>7.108234405517578</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00881984834882" lon="-84.20329364869231">
+				<ele>946.0372345969081</ele>
+				<time>2017-11-20T19:04:26Z</time>
+				<extensions>
+					<speed>7.403320789337158</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008869771220994" lon="-84.20325085705925">
+				<ele>946.3550865855068</ele>
+				<time>2017-11-20T19:04:27Z</time>
+				<extensions>
+					<speed>6.872954845428467</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008912135581188" lon="-84.20321284965445">
+				<ele>946.2586531927809</ele>
+				<time>2017-11-20T19:04:28Z</time>
+				<extensions>
+					<speed>5.312024116516113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008943237178949" lon="-84.203186099287">
+				<ele>945.8986694011837</ele>
+				<time>2017-11-20T19:04:29Z</time>
+				<extensions>
+					<speed>3.029447078704834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008960410095963" lon="-84.20317690197605">
+				<ele>944.4548267871141</ele>
+				<time>2017-11-20T19:04:30Z</time>
+				<extensions>
+					<speed>0.7380576729774475</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008964289299612" lon="-84.20317898984413">
+				<ele>943.669817911461</ele>
+				<time>2017-11-20T19:04:31Z</time>
+				<extensions>
+					<speed>0.6536037921905518</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008958075375622" lon="-84.20318651090669">
+				<ele>943.9194647818804</ele>
+				<time>2017-11-20T19:04:32Z</time>
+				<extensions>
+					<speed>1.3441195487976074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00894576220282" lon="-84.20319626432597">
+				<ele>944.877835678868</ele>
+				<time>2017-11-20T19:04:33Z</time>
+				<extensions>
+					<speed>1.6017909049987793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008935836204762" lon="-84.2032048486888">
+				<ele>945.1287617692724</ele>
+				<time>2017-11-20T19:04:34Z</time>
+				<extensions>
+					<speed>1.0997142791748047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008929432377853" lon="-84.20321151609194">
+				<ele>945.5240893140435</ele>
+				<time>2017-11-20T19:04:35Z</time>
+				<extensions>
+					<speed>0.4921313226222992</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008929432377853" lon="-84.20321151609194">
+				<ele>945.5240893140435</ele>
+				<time>2017-11-20T19:04:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008934529071743" lon="-84.20320619505642">
+				<ele>946.0695678256452</ele>
+				<time>2017-11-20T19:04:37Z</time>
+				<extensions>
+					<speed>1.5124202966690063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008949851481916" lon="-84.20319461944497">
+				<ele>946.5945028075948</ele>
+				<time>2017-11-20T19:04:38Z</time>
+				<extensions>
+					<speed>2.531754732131958</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008974663335652" lon="-84.2031756410385">
+				<ele>946.4937952402979</ele>
+				<time>2017-11-20T19:04:39Z</time>
+				<extensions>
+					<speed>3.6090340614318848</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009008155964372" lon="-84.20314805370329">
+				<ele>947.0600584028289</ele>
+				<time>2017-11-20T19:04:40Z</time>
+				<extensions>
+					<speed>4.899070739746094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009048910501605" lon="-84.2031152486048">
+				<ele>947.1209601070732</ele>
+				<time>2017-11-20T19:04:41Z</time>
+				<extensions>
+					<speed>5.599759578704834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00909324551564" lon="-84.20308148464575">
+				<ele>947.1475453516468</ele>
+				<time>2017-11-20T19:04:42Z</time>
+				<extensions>
+					<speed>5.707460880279541</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009133214527678" lon="-84.20304945001371">
+				<ele>947.6457218900323</ele>
+				<time>2017-11-20T19:04:43Z</time>
+				<extensions>
+					<speed>5.093770503997803</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009164868484715" lon="-84.20302356058734">
+				<ele>948.3934780415148</ele>
+				<time>2017-11-20T19:04:44Z</time>
+				<extensions>
+					<speed>3.70855450630188</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0091876973391" lon="-84.2030056557352">
+				<ele>948.9459432829171</ele>
+				<time>2017-11-20T19:04:45Z</time>
+				<extensions>
+					<speed>2.2495555877685547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009202796722123" lon="-84.20299580433945">
+				<ele>949.0364501988515</ele>
+				<time>2017-11-20T19:04:46Z</time>
+				<extensions>
+					<speed>1.3130792379379272</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009214147276989" lon="-84.2029879935755">
+				<ele>948.9630462313071</ele>
+				<time>2017-11-20T19:04:47Z</time>
+				<extensions>
+					<speed>1.2241390943527222</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009222819293939" lon="-84.20297950881086">
+				<ele>948.4717511348426</ele>
+				<time>2017-11-20T19:04:48Z</time>
+				<extensions>
+					<speed>1.0165538787841797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00923462980592" lon="-84.20296846315323">
+				<ele>947.8088167021051</ele>
+				<time>2017-11-20T19:04:49Z</time>
+				<extensions>
+					<speed>1.7573597431182861</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009250620550425" lon="-84.20294971400406">
+				<ele>947.3954608188942</ele>
+				<time>2017-11-20T19:04:50Z</time>
+				<extensions>
+					<speed>3.166025161743164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009272877079848" lon="-84.2029242318743">
+				<ele>947.0510346023366</ele>
+				<time>2017-11-20T19:04:51Z</time>
+				<extensions>
+					<speed>3.7419686317443848</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009300959271817" lon="-84.20289490000737">
+				<ele>946.4824090031907</ele>
+				<time>2017-11-20T19:04:52Z</time>
+				<extensions>
+					<speed>4.503434658050537</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009335898870315" lon="-84.20285979280916">
+				<ele>945.8191152308136</ele>
+				<time>2017-11-20T19:04:53Z</time>
+				<extensions>
+					<speed>5.642056941986084</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009373621818458" lon="-84.20281793913115">
+				<ele>945.3637568550184</ele>
+				<time>2017-11-20T19:04:54Z</time>
+				<extensions>
+					<speed>6.299030780792236</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009417624617452" lon="-84.2027745839723">
+				<ele>945.3499582400545</ele>
+				<time>2017-11-20T19:04:55Z</time>
+				<extensions>
+					<speed>6.7138352394104</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009470852533576" lon="-84.20272977393391">
+				<ele>946.1249930961058</ele>
+				<time>2017-11-20T19:04:56Z</time>
+				<extensions>
+					<speed>7.772186756134033</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00953153837923" lon="-84.2026836895602">
+				<ele>946.3794706147164</ele>
+				<time>2017-11-20T19:04:57Z</time>
+				<extensions>
+					<speed>8.453089714050293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009596313595619" lon="-84.20263381071712">
+				<ele>946.7875320566818</ele>
+				<time>2017-11-20T19:04:58Z</time>
+				<extensions>
+					<speed>8.979687690734863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009665225780795" lon="-84.20258379653305">
+				<ele>946.5890679471195</ele>
+				<time>2017-11-20T19:04:59Z</time>
+				<extensions>
+					<speed>9.050004005432129</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009732681793576" lon="-84.202532265702">
+				<ele>946.861667169258</ele>
+				<time>2017-11-20T19:05:00Z</time>
+				<extensions>
+					<speed>9.119976043701172</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009797514709135" lon="-84.20248098748584">
+				<ele>946.9718588721007</ele>
+				<time>2017-11-20T19:05:01Z</time>
+				<extensions>
+					<speed>9.055558204650879</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009861558947676" lon="-84.20242928181807">
+				<ele>947.0665151029825</ele>
+				<time>2017-11-20T19:05:02Z</time>
+				<extensions>
+					<speed>8.862298011779785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009924581038911" lon="-84.20237649790171">
+				<ele>947.0344561105594</ele>
+				<time>2017-11-20T19:05:03Z</time>
+				<extensions>
+					<speed>8.769248962402344</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009988947070173" lon="-84.20232386751452">
+				<ele>947.1913754679263</ele>
+				<time>2017-11-20T19:05:04Z</time>
+				<extensions>
+					<speed>8.696443557739258</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010053026508983" lon="-84.20227526011664">
+				<ele>947.2888411842287</ele>
+				<time>2017-11-20T19:05:05Z</time>
+				<extensions>
+					<speed>8.658280372619629</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010113308653246" lon="-84.20223009953287">
+				<ele>947.7409552587196</ele>
+				<time>2017-11-20T19:05:06Z</time>
+				<extensions>
+					<speed>7.876902103424072</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01016566869837" lon="-84.20219279388141">
+				<ele>948.0079618804157</ele>
+				<time>2017-11-20T19:05:07Z</time>
+				<extensions>
+					<speed>6.319315433502197</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010204972318007" lon="-84.20216316307533">
+				<ele>948.7265186822042</ele>
+				<time>2017-11-20T19:05:08Z</time>
+				<extensions>
+					<speed>4.695796489715576</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010232012920186" lon="-84.20214016214882">
+				<ele>949.2160504264757</ele>
+				<time>2017-11-20T19:05:09Z</time>
+				<extensions>
+					<speed>3.248992919921875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010246426340009" lon="-84.2021304056072">
+				<ele>949.3538887742907</ele>
+				<time>2017-11-20T19:05:10Z</time>
+				<extensions>
+					<speed>1.1792081594467163</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010247776828226" lon="-84.20213095592285">
+				<ele>949.4786967122927</ele>
+				<time>2017-11-20T19:05:11Z</time>
+				<extensions>
+					<speed>0.04239431768655777</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010247776828226" lon="-84.20213095592285">
+				<ele>949.4786967122927</ele>
+				<time>2017-11-20T19:05:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01023912366093" lon="-84.20213715901714">
+				<ele>949.4439774565399</ele>
+				<time>2017-11-20T19:05:13Z</time>
+				<extensions>
+					<speed>1.1888017654418945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010225431224676" lon="-84.20214443750412">
+				<ele>949.6999835539609</ele>
+				<time>2017-11-20T19:05:14Z</time>
+				<extensions>
+					<speed>1.4101033210754395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010211415174634" lon="-84.20214821010254">
+				<ele>949.9972905702889</ele>
+				<time>2017-11-20T19:05:15Z</time>
+				<extensions>
+					<speed>1.1166738271713257</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010197627634112" lon="-84.20215214980952">
+				<ele>949.9708926789463</ele>
+				<time>2017-11-20T19:05:16Z</time>
+				<extensions>
+					<speed>1.3796898126602173</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010185526357303" lon="-84.2021541602572">
+				<ele>949.9858867591247</ele>
+				<time>2017-11-20T19:05:17Z</time>
+				<extensions>
+					<speed>0.9348602294921875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010185526357303" lon="-84.2021541602572">
+				<ele>949.9858867591247</ele>
+				<time>2017-11-20T19:05:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010182100769285" lon="-84.20215213471258">
+				<ele>950.9201492834836</ele>
+				<time>2017-11-20T19:05:19Z</time>
+				<extensions>
+					<speed>0.323749303817749</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010182100769285" lon="-84.20215213471258">
+				<ele>950.9201492834836</ele>
+				<time>2017-11-20T19:05:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010182100769285" lon="-84.20215213471258">
+				<ele>950.9201492834836</ele>
+				<time>2017-11-20T19:05:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010182100769285" lon="-84.20215213471258">
+				<ele>950.9201492834836</ele>
+				<time>2017-11-20T19:05:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010182100769285" lon="-84.20215213471258">
+				<ele>950.9201492834836</ele>
+				<time>2017-11-20T19:05:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010182100769285" lon="-84.20215213471258">
+				<ele>950.9201492834836</ele>
+				<time>2017-11-20T19:05:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010182100769285" lon="-84.20215213471258">
+				<ele>950.9201492834836</ele>
+				<time>2017-11-20T19:05:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010182100769285" lon="-84.20215213471258">
+				<ele>950.9201492834836</ele>
+				<time>2017-11-20T19:05:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010182100769285" lon="-84.20215213471258">
+				<ele>950.9201492834836</ele>
+				<time>2017-11-20T19:05:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010182100769285" lon="-84.20215213471258">
+				<ele>950.9201492834836</ele>
+				<time>2017-11-20T19:05:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010182100769285" lon="-84.20215213471258">
+				<ele>950.9201492834836</ele>
+				<time>2017-11-20T19:05:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01019264104662" lon="-84.20214776157391">
+				<ele>951.0170468492433</ele>
+				<time>2017-11-20T19:05:30Z</time>
+				<extensions>
+					<speed>1.2075484991073608</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010207975884102" lon="-84.20213760222549">
+				<ele>951.3450132729486</ele>
+				<time>2017-11-20T19:05:31Z</time>
+				<extensions>
+					<speed>1.7291698455810547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01022805722556" lon="-84.202124438576">
+				<ele>951.5717373574153</ele>
+				<time>2017-11-20T19:05:32Z</time>
+				<extensions>
+					<speed>2.598801851272583</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010255924961799" lon="-84.20210752702769">
+				<ele>951.3524696193635</ele>
+				<time>2017-11-20T19:05:33Z</time>
+				<extensions>
+					<speed>3.481590986251831</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010288668397394" lon="-84.20208608871474">
+				<ele>951.3792348420247</ele>
+				<time>2017-11-20T19:05:34Z</time>
+				<extensions>
+					<speed>4.1993865966796875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010325408266699" lon="-84.20206272183839">
+				<ele>951.3654433069751</ele>
+				<time>2017-11-20T19:05:35Z</time>
+				<extensions>
+					<speed>4.904280185699463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010367967711769" lon="-84.20203735062202">
+				<ele>952.6542031094432</ele>
+				<time>2017-11-20T19:05:36Z</time>
+				<extensions>
+					<speed>5.348170280456543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010415490027844" lon="-84.202010281938">
+				<ele>953.1558671072125</ele>
+				<time>2017-11-20T19:05:37Z</time>
+				<extensions>
+					<speed>5.9734320640563965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010470061408649" lon="-84.20198034696611">
+				<ele>953.3307175505906</ele>
+				<time>2017-11-20T19:05:38Z</time>
+				<extensions>
+					<speed>6.737588405609131</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010528093577578" lon="-84.20194970437859">
+				<ele>953.02160440851</ele>
+				<time>2017-11-20T19:05:39Z</time>
+				<extensions>
+					<speed>7.076314926147461</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010588324197295" lon="-84.20191702651422">
+				<ele>953.2954874364659</ele>
+				<time>2017-11-20T19:05:40Z</time>
+				<extensions>
+					<speed>7.5364460945129395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010649127291021" lon="-84.20188168791148">
+				<ele>953.5701478598639</ele>
+				<time>2017-11-20T19:05:41Z</time>
+				<extensions>
+					<speed>7.699316024780273</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010711085080311" lon="-84.20184648986772">
+				<ele>953.7817389015108</ele>
+				<time>2017-11-20T19:05:42Z</time>
+				<extensions>
+					<speed>7.7963032722473145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010773431390838" lon="-84.2018138907243">
+				<ele>954.2194202346727</ele>
+				<time>2017-11-20T19:05:43Z</time>
+				<extensions>
+					<speed>7.611035346984863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010834415686567" lon="-84.20178290163386">
+				<ele>954.9257115647197</ele>
+				<time>2017-11-20T19:05:44Z</time>
+				<extensions>
+					<speed>7.491419315338135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010895505960246" lon="-84.20175145924152">
+				<ele>955.3567827558145</ele>
+				<time>2017-11-20T19:05:45Z</time>
+				<extensions>
+					<speed>7.623163223266602</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010952952562644" lon="-84.20171920911542">
+				<ele>955.861257802695</ele>
+				<time>2017-11-20T19:05:46Z</time>
+				<extensions>
+					<speed>6.989055633544922</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011004706337738" lon="-84.20169113764015">
+				<ele>956.170386553742</ele>
+				<time>2017-11-20T19:05:47Z</time>
+				<extensions>
+					<speed>6.163156032562256</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011048197879923" lon="-84.20166666425477">
+				<ele>956.5266823368147</ele>
+				<time>2017-11-20T19:05:48Z</time>
+				<extensions>
+					<speed>4.94669246673584</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011077614707128" lon="-84.20165067488149">
+				<ele>956.8829274531454</ele>
+				<time>2017-11-20T19:05:49Z</time>
+				<extensions>
+					<speed>2.5305609703063965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0110945009404" lon="-84.2016430531083">
+				<ele>957.4507394991815</ele>
+				<time>2017-11-20T19:05:50Z</time>
+				<extensions>
+					<speed>1.5283502340316772</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011107730132702" lon="-84.20164011954445">
+				<ele>958.0282982327044</ele>
+				<time>2017-11-20T19:05:51Z</time>
+				<extensions>
+					<speed>1.1079306602478027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011118298546837" lon="-84.20163757252173">
+				<ele>958.6307300627232</ele>
+				<time>2017-11-20T19:05:52Z</time>
+				<extensions>
+					<speed>1.1117295026779175</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011129945096746" lon="-84.20163326565843">
+				<ele>959.0567859020084</ele>
+				<time>2017-11-20T19:05:53Z</time>
+				<extensions>
+					<speed>1.7425169944763184</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011146163987611" lon="-84.20162484862347">
+				<ele>959.6073792660609</ele>
+				<time>2017-11-20T19:05:54Z</time>
+				<extensions>
+					<speed>2.300358295440674</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01116946489463" lon="-84.20161155204612">
+				<ele>960.6747673638165</ele>
+				<time>2017-11-20T19:05:55Z</time>
+				<extensions>
+					<speed>3.456390619277954</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011201152485393" lon="-84.20159213024462">
+				<ele>960.879690496251</ele>
+				<time>2017-11-20T19:05:56Z</time>
+				<extensions>
+					<speed>4.543239116668701</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011237949851438" lon="-84.20156492626421">
+				<ele>961.3037138246</ele>
+				<time>2017-11-20T19:05:57Z</time>
+				<extensions>
+					<speed>5.427562713623047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011287867371491" lon="-84.20153215248286">
+				<ele>961.2287631845102</ele>
+				<time>2017-11-20T19:05:58Z</time>
+				<extensions>
+					<speed>6.839888572692871</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011345197900818" lon="-84.20149944798753">
+				<ele>961.0126030268148</ele>
+				<time>2017-11-20T19:05:59Z</time>
+				<extensions>
+					<speed>7.1069560050964355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011397507829832" lon="-84.20146558040207">
+				<ele>960.2107874266803</ele>
+				<time>2017-11-20T19:06:00Z</time>
+				<extensions>
+					<speed>6.4417548179626465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0114453619901" lon="-84.20144033527782">
+				<ele>960.0666598407552</ele>
+				<time>2017-11-20T19:06:01Z</time>
+				<extensions>
+					<speed>4.836360454559326</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01148093803694" lon="-84.20142389073106">
+				<ele>959.9054108727723</ele>
+				<time>2017-11-20T19:06:02Z</time>
+				<extensions>
+					<speed>3.1223456859588623</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01150195434404" lon="-84.20141647050484">
+				<ele>959.5095208482817</ele>
+				<time>2017-11-20T19:06:03Z</time>
+				<extensions>
+					<speed>0.8734146356582642</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011508069646228" lon="-84.20141430547221">
+				<ele>959.0412280308083</ele>
+				<time>2017-11-20T19:06:04Z</time>
+				<extensions>
+					<speed>0.6274253129959106</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011508069646228" lon="-84.20141430547221">
+				<ele>959.0412280308083</ele>
+				<time>2017-11-20T19:06:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011506871072816" lon="-84.2014111880192">
+				<ele>958.6764110084623</ele>
+				<time>2017-11-20T19:06:06Z</time>
+				<extensions>
+					<speed>0.07606188952922821</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011515295799827" lon="-84.20140607308156">
+				<ele>958.292940903455</ele>
+				<time>2017-11-20T19:06:07Z</time>
+				<extensions>
+					<speed>1.334671139717102</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011535556527416" lon="-84.20139578588075">
+				<ele>958.0379401538521</ele>
+				<time>2017-11-20T19:06:08Z</time>
+				<extensions>
+					<speed>2.902719736099243</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011568013064728" lon="-84.20138130270848">
+				<ele>957.6368152769282</ele>
+				<time>2017-11-20T19:06:09Z</time>
+				<extensions>
+					<speed>4.2761921882629395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011610454954116" lon="-84.20136089016044">
+				<ele>957.6170141398907</ele>
+				<time>2017-11-20T19:06:10Z</time>
+				<extensions>
+					<speed>5.744058609008789</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011666041429363" lon="-84.20133312197505">
+				<ele>957.4077364346012</ele>
+				<time>2017-11-20T19:06:11Z</time>
+				<extensions>
+					<speed>7.377961158752441</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01173247893311" lon="-84.20129596422223">
+				<ele>957.4556101933122</ele>
+				<time>2017-11-20T19:06:12Z</time>
+				<extensions>
+					<speed>8.557249069213867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011805914275234" lon="-84.2012548316017">
+				<ele>958.1879948722199</ele>
+				<time>2017-11-20T19:06:13Z</time>
+				<extensions>
+					<speed>9.072589874267578</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011881908611096" lon="-84.20121439980936">
+				<ele>958.2476688632742</ele>
+				<time>2017-11-20T19:06:14Z</time>
+				<extensions>
+					<speed>8.881404876708984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011952073824045" lon="-84.20117816814476">
+				<ele>958.6176066752523</ele>
+				<time>2017-11-20T19:06:15Z</time>
+				<extensions>
+					<speed>7.782745838165283</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012011975829886" lon="-84.20114366326332">
+				<ele>958.3380083888769</ele>
+				<time>2017-11-20T19:06:16Z</time>
+				<extensions>
+					<speed>6.94097900390625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012063936298235" lon="-84.20111741687333">
+				<ele>957.6587535152212</ele>
+				<time>2017-11-20T19:06:17Z</time>
+				<extensions>
+					<speed>5.180578231811523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01209762492628" lon="-84.20109900709797">
+				<ele>957.9937487160787</ele>
+				<time>2017-11-20T19:06:18Z</time>
+				<extensions>
+					<speed>2.9753289222717285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012112955330714" lon="-84.20108882816058">
+				<ele>958.0054463595152</ele>
+				<time>2017-11-20T19:06:19Z</time>
+				<extensions>
+					<speed>0.987688422203064</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012113427659335" lon="-84.2010851567491">
+				<ele>958.015342572704</ele>
+				<time>2017-11-20T19:06:20Z</time>
+				<extensions>
+					<speed>0.6857019662857056</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012105941330145" lon="-84.2010867252549">
+				<ele>958.0114726424217</ele>
+				<time>2017-11-20T19:06:21Z</time>
+				<extensions>
+					<speed>1.2042362689971924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012094545352005" lon="-84.20108945588487">
+				<ele>958.1781820124015</ele>
+				<time>2017-11-20T19:06:22Z</time>
+				<extensions>
+					<speed>1.4156749248504639</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012084320990823" lon="-84.20109262783264">
+				<ele>958.5830872794613</ele>
+				<time>2017-11-20T19:06:23Z</time>
+				<extensions>
+					<speed>1.052631139755249</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01207832897074" lon="-84.20109434778439">
+				<ele>958.6594885857776</ele>
+				<time>2017-11-20T19:06:24Z</time>
+				<extensions>
+					<speed>0.6704879999160767</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01207832897074" lon="-84.20109434778439">
+				<ele>958.6594885857776</ele>
+				<time>2017-11-20T19:06:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01208213648458" lon="-84.20109876429618">
+				<ele>958.8638332653791</ele>
+				<time>2017-11-20T19:06:26Z</time>
+				<extensions>
+					<speed>0.35842689871788025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01208213648458" lon="-84.20109876429618">
+				<ele>958.8638332653791</ele>
+				<time>2017-11-20T19:06:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0120874445267" lon="-84.20110359535511">
+				<ele>959.5335583370179</ele>
+				<time>2017-11-20T19:06:28Z</time>
+				<extensions>
+					<speed>0.7023637890815735</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0120874445267" lon="-84.20110359535511">
+				<ele>959.5335583370179</ele>
+				<time>2017-11-20T19:06:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012101383077898" lon="-84.20109988726254">
+				<ele>959.7825078051537</ele>
+				<time>2017-11-20T19:06:30Z</time>
+				<extensions>
+					<speed>1.6713229417800903</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01212323134361" lon="-84.20109265456728">
+				<ele>960.1090592397377</ele>
+				<time>2017-11-20T19:06:31Z</time>
+				<extensions>
+					<speed>3.0277693271636963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012153734986544" lon="-84.20107930778669">
+				<ele>959.8057073066011</ele>
+				<time>2017-11-20T19:06:32Z</time>
+				<extensions>
+					<speed>3.6946613788604736</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012187895418991" lon="-84.20106597079673">
+				<ele>959.7456726357341</ele>
+				<time>2017-11-20T19:06:33Z</time>
+				<extensions>
+					<speed>3.319138288497925</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012217216773012" lon="-84.20105523767016">
+				<ele>959.754433109425</ele>
+				<time>2017-11-20T19:06:34Z</time>
+				<extensions>
+					<speed>2.644526958465576</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012240866362042" lon="-84.20104504493987">
+				<ele>959.6863629184663</ele>
+				<time>2017-11-20T19:06:35Z</time>
+				<extensions>
+					<speed>2.5968384742736816</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012263328683932" lon="-84.20103468679622">
+				<ele>959.7430550139397</ele>
+				<time>2017-11-20T19:06:36Z</time>
+				<extensions>
+					<speed>2.4239683151245117</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01228525215091" lon="-84.20102306266223">
+				<ele>959.5793589763343</ele>
+				<time>2017-11-20T19:06:37Z</time>
+				<extensions>
+					<speed>2.7371392250061035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012310709574672" lon="-84.20100745545686">
+				<ele>959.4999626670033</ele>
+				<time>2017-11-20T19:06:38Z</time>
+				<extensions>
+					<speed>3.6193838119506836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012344516573267" lon="-84.20098596907205">
+				<ele>959.7556242467836</ele>
+				<time>2017-11-20T19:06:39Z</time>
+				<extensions>
+					<speed>4.633929252624512</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012387377166695" lon="-84.20096093527397">
+				<ele>959.5500211883336</ele>
+				<time>2017-11-20T19:06:40Z</time>
+				<extensions>
+					<speed>5.474966049194336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012438634497304" lon="-84.20093260668052">
+				<ele>959.3414509128779</ele>
+				<time>2017-11-20T19:06:41Z</time>
+				<extensions>
+					<speed>6.664910793304443</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012500866165288" lon="-84.20090251495432">
+				<ele>959.1953297834843</ele>
+				<time>2017-11-20T19:06:42Z</time>
+				<extensions>
+					<speed>7.8524956703186035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012566644682037" lon="-84.20086968223781">
+				<ele>959.0755539070815</ele>
+				<time>2017-11-20T19:06:43Z</time>
+				<extensions>
+					<speed>8.133551597595215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012633704547731" lon="-84.20083194169116">
+				<ele>959.7308253012598</ele>
+				<time>2017-11-20T19:06:44Z</time>
+				<extensions>
+					<speed>8.43019962310791</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01269494935446" lon="-84.20079387675553">
+				<ele>959.6936763189733</ele>
+				<time>2017-11-20T19:06:45Z</time>
+				<extensions>
+					<speed>7.1436238288879395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012744181421313" lon="-84.20076349517711">
+				<ele>959.5735775521025</ele>
+				<time>2017-11-20T19:06:46Z</time>
+				<extensions>
+					<speed>5.4299211502075195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012777955338708" lon="-84.20074190418988">
+				<ele>959.3671088069677</ele>
+				<time>2017-11-20T19:06:47Z</time>
+				<extensions>
+					<speed>3.449065923690796</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012793883701816" lon="-84.20072968768648">
+				<ele>959.4055737080052</ele>
+				<time>2017-11-20T19:06:48Z</time>
+				<extensions>
+					<speed>1.093125820159912</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01279478608921" lon="-84.20072401019802">
+				<ele>959.2198965596035</ele>
+				<time>2017-11-20T19:06:49Z</time>
+				<extensions>
+					<speed>0.46659016609191895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012785774882472" lon="-84.20072168298566">
+				<ele>959.076713103801</ele>
+				<time>2017-11-20T19:06:50Z</time>
+				<extensions>
+					<speed>1.0065186023712158</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012771681119444" lon="-84.20072351961018">
+				<ele>959.5203142873943</ele>
+				<time>2017-11-20T19:06:51Z</time>
+				<extensions>
+					<speed>1.3643465042114258</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01275953032193" lon="-84.20072589204217">
+				<ele>959.9896649979055</ele>
+				<time>2017-11-20T19:06:52Z</time>
+				<extensions>
+					<speed>1.3104552030563354</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012747680353309" lon="-84.20073172119527">
+				<ele>960.2495879819617</ele>
+				<time>2017-11-20T19:06:53Z</time>
+				<extensions>
+					<speed>1.536728858947754</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012736187415785" lon="-84.20074042050715">
+				<ele>960.4341431278735</ele>
+				<time>2017-11-20T19:06:54Z</time>
+				<extensions>
+					<speed>2.012951612472534</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012732143879488" lon="-84.20074720618616">
+				<ele>961.1495199585333</ele>
+				<time>2017-11-20T19:06:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01273570574142" lon="-84.2007468798256">
+				<ele>961.3571198983118</ele>
+				<time>2017-11-20T19:06:56Z</time>
+				<extensions>
+					<speed>0.5192800760269165</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012747350741066" lon="-84.2007406511103">
+				<ele>961.3166094971821</ele>
+				<time>2017-11-20T19:06:57Z</time>
+				<extensions>
+					<speed>1.8181278705596924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01276439917867" lon="-84.20072949200062">
+				<ele>961.3578600492328</ele>
+				<time>2017-11-20T19:06:58Z</time>
+				<extensions>
+					<speed>3.0043909549713135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012792439081746" lon="-84.20071407758414">
+				<ele>961.1715987846255</ele>
+				<time>2017-11-20T19:06:59Z</time>
+				<extensions>
+					<speed>4.323106288909912</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012828899053705" lon="-84.20069565441224">
+				<ele>961.1718485541642</ele>
+				<time>2017-11-20T19:07:00Z</time>
+				<extensions>
+					<speed>4.948869705200195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012869306296075" lon="-84.2006803087378">
+				<ele>961.1251793559641</ele>
+				<time>2017-11-20T19:07:01Z</time>
+				<extensions>
+					<speed>4.902238845825195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012914241441969" lon="-84.20067137192059">
+				<ele>960.6356226988137</ele>
+				<time>2017-11-20T19:07:02Z</time>
+				<extensions>
+					<speed>5.045177936553955</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012963201417945" lon="-84.200671479371">
+				<ele>960.4036828530952</ele>
+				<time>2017-11-20T19:07:03Z</time>
+				<extensions>
+					<speed>5.511196613311768</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013015013241501" lon="-84.20068390461152">
+				<ele>960.011940295808</ele>
+				<time>2017-11-20T19:07:04Z</time>
+				<extensions>
+					<speed>5.658560276031494</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013066025550389" lon="-84.20071466909934">
+				<ele>959.7945572370663</ele>
+				<time>2017-11-20T19:07:05Z</time>
+				<extensions>
+					<speed>6.780905246734619</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013113022166115" lon="-84.20076893977104">
+				<ele>959.8662305697799</ele>
+				<time>2017-11-20T19:07:06Z</time>
+				<extensions>
+					<speed>8.251812934875488</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013157447062232" lon="-84.20084571881425">
+				<ele>960.048675654456</ele>
+				<time>2017-11-20T19:07:07Z</time>
+				<extensions>
+					<speed>9.471993446350098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013206566303344" lon="-84.20092861754222">
+				<ele>960.1359522053972</ele>
+				<time>2017-11-20T19:07:08Z</time>
+				<extensions>
+					<speed>10.561118125915527</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013258042881562" lon="-84.20101744526141">
+				<ele>960.0331404516473</ele>
+				<time>2017-11-20T19:07:09Z</time>
+				<extensions>
+					<speed>11.274477005004883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0133140294333" lon="-84.2011095705053">
+				<ele>959.7205915628001</ele>
+				<time>2017-11-20T19:07:10Z</time>
+				<extensions>
+					<speed>11.382216453552246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01336744376193" lon="-84.20120110514989">
+				<ele>959.4931708341464</ele>
+				<time>2017-11-20T19:07:11Z</time>
+				<extensions>
+					<speed>11.082540512084961</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013417858825424" lon="-84.20128280249222">
+				<ele>959.0866412492469</ele>
+				<time>2017-11-20T19:07:12Z</time>
+				<extensions>
+					<speed>9.988729476928711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013471056012431" lon="-84.20135318394203">
+				<ele>958.8902896894142</ele>
+				<time>2017-11-20T19:07:13Z</time>
+				<extensions>
+					<speed>9.396950721740723</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013529144872706" lon="-84.20140428703377">
+				<ele>957.8225831892341</ele>
+				<time>2017-11-20T19:07:14Z</time>
+				<extensions>
+					<speed>7.188430309295654</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013573441849239" lon="-84.20145104936044">
+				<ele>957.5056629870087</ele>
+				<time>2017-11-20T19:07:15Z</time>
+				<extensions>
+					<speed>6.38684606552124</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013614295975954" lon="-84.20149269567244">
+				<ele>957.1145675815642</ele>
+				<time>2017-11-20T19:07:16Z</time>
+				<extensions>
+					<speed>5.700963973999023</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01364576197992" lon="-84.20153056713887">
+				<ele>956.8364906981587</ele>
+				<time>2017-11-20T19:07:17Z</time>
+				<extensions>
+					<speed>4.807162761688232</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01366579359435" lon="-84.20156091111477">
+				<ele>956.9646566482261</ele>
+				<time>2017-11-20T19:07:18Z</time>
+				<extensions>
+					<speed>3.4672627449035645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013675566788995" lon="-84.20158361484906">
+				<ele>956.9663450708613</ele>
+				<time>2017-11-20T19:07:19Z</time>
+				<extensions>
+					<speed>2.348477840423584</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01367608898181" lon="-84.20159987064622">
+				<ele>956.8193830065429</ele>
+				<time>2017-11-20T19:07:20Z</time>
+				<extensions>
+					<speed>1.0717905759811401</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013672912178903" lon="-84.20160350254939">
+				<ele>956.9103825604543</ele>
+				<time>2017-11-20T19:07:21Z</time>
+				<extensions>
+					<speed>0.26309067010879517</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013672912178903" lon="-84.20160350254939">
+				<ele>956.9103825604543</ele>
+				<time>2017-11-20T19:07:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013665353557451" lon="-84.20159538045527">
+				<ele>956.9868573034182</ele>
+				<time>2017-11-20T19:07:23Z</time>
+				<extensions>
+					<speed>0.7165519595146179</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013672912178903" lon="-84.20160350254939">
+				<ele>956.9103825604543</ele>
+				<time>2017-11-20T19:07:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013674901620517" lon="-84.20161499341506">
+				<ele>957.3693915316835</ele>
+				<time>2017-11-20T19:07:25Z</time>
+				<extensions>
+					<speed>1.9756349325180054</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013687149137228" lon="-84.20163935336714">
+				<ele>957.7366446079686</ele>
+				<time>2017-11-20T19:07:26Z</time>
+				<extensions>
+					<speed>3.7250139713287354</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013709428502558" lon="-84.2016773164468">
+				<ele>958.1587996119633</ele>
+				<time>2017-11-20T19:07:27Z</time>
+				<extensions>
+					<speed>5.614469528198242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0137423723006" lon="-84.20173235488065">
+				<ele>958.552208064124</ele>
+				<time>2017-11-20T19:07:28Z</time>
+				<extensions>
+					<speed>7.729377746582031</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013783378002318" lon="-84.20180026494191">
+				<ele>959.1165007837117</ele>
+				<time>2017-11-20T19:07:29Z</time>
+				<extensions>
+					<speed>9.500551223754883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013828987845502" lon="-84.20188148319455">
+				<ele>959.6710569011047</ele>
+				<time>2017-11-20T19:07:30Z</time>
+				<extensions>
+					<speed>10.673569679260254</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013879274080033" lon="-84.20197359745485">
+				<ele>959.9544275607914</ele>
+				<time>2017-11-20T19:07:31Z</time>
+				<extensions>
+					<speed>11.493332862854004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013925990587556" lon="-84.20206751098328">
+				<ele>960.2698430335149</ele>
+				<time>2017-11-20T19:07:32Z</time>
+				<extensions>
+					<speed>11.281078338623047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013975757962976" lon="-84.20216469937418">
+				<ele>960.3437014827505</ele>
+				<time>2017-11-20T19:07:33Z</time>
+				<extensions>
+					<speed>11.690670013427734</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014026243326532" lon="-84.20225890136635">
+				<ele>960.7390821594745</ele>
+				<time>2017-11-20T19:07:34Z</time>
+				<extensions>
+					<speed>11.610185623168945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01407311666453" lon="-84.20234602267226">
+				<ele>960.8534132558852</ele>
+				<time>2017-11-20T19:07:35Z</time>
+				<extensions>
+					<speed>10.85489559173584</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014118001482212" lon="-84.20242319527073">
+				<ele>960.7210461162031</ele>
+				<time>2017-11-20T19:07:36Z</time>
+				<extensions>
+					<speed>9.441608428955078</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01414828372507" lon="-84.20249227109562">
+				<ele>960.8177513424307</ele>
+				<time>2017-11-20T19:07:37Z</time>
+				<extensions>
+					<speed>7.927534103393555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014175342299595" lon="-84.20255028079336">
+				<ele>960.6176744261757</ele>
+				<time>2017-11-20T19:07:38Z</time>
+				<extensions>
+					<speed>6.3240532875061035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014199166880573" lon="-84.2025916463994">
+				<ele>961.1309398887679</ele>
+				<time>2017-11-20T19:07:39Z</time>
+				<extensions>
+					<speed>4.600908279418945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014223725525605" lon="-84.20260754660232">
+				<ele>960.7642243728042</ele>
+				<time>2017-11-20T19:07:40Z</time>
+				<extensions>
+					<speed>3.364739179611206</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014261215895212" lon="-84.20260139583047">
+				<ele>959.8417078396305</ele>
+				<time>2017-11-20T19:07:41Z</time>
+				<extensions>
+					<speed>4.717604160308838</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014306405764865" lon="-84.20257725887161">
+				<ele>959.5312165562063</ele>
+				<time>2017-11-20T19:07:42Z</time>
+				<extensions>
+					<speed>6.0767974853515625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014357127282091" lon="-84.20253603910356">
+				<ele>959.5078970035538</ele>
+				<time>2017-11-20T19:07:43Z</time>
+				<extensions>
+					<speed>6.815606594085693</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014409253756247" lon="-84.2024911366777">
+				<ele>959.4306181073189</ele>
+				<time>2017-11-20T19:07:44Z</time>
+				<extensions>
+					<speed>7.375232696533203</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0144635346768" lon="-84.20243810087906">
+				<ele>959.7774811945856</ele>
+				<time>2017-11-20T19:07:45Z</time>
+				<extensions>
+					<speed>7.426619052886963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014516884837931" lon="-84.20238885885269">
+				<ele>959.924396305345</ele>
+				<time>2017-11-20T19:07:46Z</time>
+				<extensions>
+					<speed>7.181424617767334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014572203713213" lon="-84.20234242825121">
+				<ele>960.0677279513329</ele>
+				<time>2017-11-20T19:07:47Z</time>
+				<extensions>
+					<speed>7.140351295471191</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014626954072432" lon="-84.2022969863612">
+				<ele>960.0827625328675</ele>
+				<time>2017-11-20T19:07:48Z</time>
+				<extensions>
+					<speed>7.267302513122559</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014687820564538" lon="-84.20225359691274">
+				<ele>960.0992356464267</ele>
+				<time>2017-11-20T19:07:49Z</time>
+				<extensions>
+					<speed>7.426651477813721</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014752796791802" lon="-84.20221140046475">
+				<ele>960.0724296513945</ele>
+				<time>2017-11-20T19:07:50Z</time>
+				<extensions>
+					<speed>7.852258205413818</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014843189083255" lon="-84.20218177220417">
+				<ele>959.6306387512013</ele>
+				<time>2017-11-20T19:07:51Z</time>
+				<extensions>
+					<speed>8.618620872497559</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014920657282929" lon="-84.2021412456682">
+				<ele>959.1846880298108</ele>
+				<time>2017-11-20T19:07:52Z</time>
+				<extensions>
+					<speed>8.758112907409668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014994190686883" lon="-84.20210412764058">
+				<ele>959.2994387084618</ele>
+				<time>2017-11-20T19:07:53Z</time>
+				<extensions>
+					<speed>8.72925853729248</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01506590997765" lon="-84.20206632137186">
+				<ele>959.4149391734973</ele>
+				<time>2017-11-20T19:07:54Z</time>
+				<extensions>
+					<speed>8.780080795288086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015137217046734" lon="-84.20202948915909">
+				<ele>959.3821635041386</ele>
+				<time>2017-11-20T19:07:55Z</time>
+				<extensions>
+					<speed>8.676264762878418</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015211239544675" lon="-84.20199403416115">
+				<ele>960.0033156843856</ele>
+				<time>2017-11-20T19:07:56Z</time>
+				<extensions>
+					<speed>8.150029182434082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015269348139567" lon="-84.20195989089576">
+				<ele>960.2086119586602</ele>
+				<time>2017-11-20T19:07:57Z</time>
+				<extensions>
+					<speed>6.565832614898682</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015309331347439" lon="-84.20192876080883">
+				<ele>960.303021620959</ele>
+				<time>2017-11-20T19:07:58Z</time>
+				<extensions>
+					<speed>4.7183918952941895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015333109435423" lon="-84.20190292453239">
+				<ele>960.2941835522652</ele>
+				<time>2017-11-20T19:07:59Z</time>
+				<extensions>
+					<speed>3.1890006065368652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015346529972188" lon="-84.20188418006924">
+				<ele>960.4204556243494</ele>
+				<time>2017-11-20T19:08:00Z</time>
+				<extensions>
+					<speed>2.084836006164551</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015347513113172" lon="-84.20188170016786">
+				<ele>960.4822858348489</ele>
+				<time>2017-11-20T19:08:01Z</time>
+				<extensions>
+					<speed>0.26966139674186707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015342607005685" lon="-84.20188315617249">
+				<ele>960.7050322778523</ele>
+				<time>2017-11-20T19:08:02Z</time>
+				<extensions>
+					<speed>0.9234157800674438</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01533345183152" lon="-84.20189308439396">
+				<ele>960.8648707382381</ele>
+				<time>2017-11-20T19:08:03Z</time>
+				<extensions>
+					<speed>1.5198975801467896</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015325604503632" lon="-84.20190185022228">
+				<ele>961.0859444830567</ele>
+				<time>2017-11-20T19:08:04Z</time>
+				<extensions>
+					<speed>1.3701105117797852</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015316996609457" lon="-84.20190730384003">
+				<ele>961.4610429564491</ele>
+				<time>2017-11-20T19:08:05Z</time>
+				<extensions>
+					<speed>1.294550895690918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015317209429824" lon="-84.20190881759045">
+				<ele>961.6127784820274</ele>
+				<time>2017-11-20T19:08:06Z</time>
+				<extensions>
+					<speed>0.8679778575897217</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015317209429824" lon="-84.20190881759045">
+				<ele>961.6127784820274</ele>
+				<time>2017-11-20T19:08:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015319365892886" lon="-84.20190873854378">
+				<ele>961.7829181747511</ele>
+				<time>2017-11-20T19:08:08Z</time>
+				<extensions>
+					<speed>0.025734834372997284</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015319365892886" lon="-84.20190873854378">
+				<ele>961.7829181747511</ele>
+				<time>2017-11-20T19:08:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015319365892886" lon="-84.20190873854378">
+				<ele>961.7829181747511</ele>
+				<time>2017-11-20T19:08:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015319365892886" lon="-84.20190873854378">
+				<ele>961.7829181747511</ele>
+				<time>2017-11-20T19:08:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015319365892886" lon="-84.20190873854378">
+				<ele>961.7829181747511</ele>
+				<time>2017-11-20T19:08:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015319365892886" lon="-84.20190873854378">
+				<ele>961.7829181747511</ele>
+				<time>2017-11-20T19:08:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015323353939722" lon="-84.20190800685916">
+				<ele>961.5206017447636</ele>
+				<time>2017-11-20T19:08:14Z</time>
+				<extensions>
+					<speed>0.7817617654800415</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01532716396866" lon="-84.2019007817466">
+				<ele>960.9940135590732</ele>
+				<time>2017-11-20T19:08:15Z</time>
+				<extensions>
+					<speed>1.0579421520233154</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332583381705" lon="-84.2018958695569">
+				<ele>960.4130179639906</ele>
+				<time>2017-11-20T19:08:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01533712939886" lon="-84.20189185892573">
+				<ele>959.9979550018907</ele>
+				<time>2017-11-20T19:08:17Z</time>
+				<extensions>
+					<speed>1.1014328002929688</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015344093943988" lon="-84.20188352233313">
+				<ele>959.6387675283477</ele>
+				<time>2017-11-20T19:08:18Z</time>
+				<extensions>
+					<speed>0.9724379181861877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01535300980129" lon="-84.2018710769254">
+				<ele>958.8535467004403</ele>
+				<time>2017-11-20T19:08:19Z</time>
+				<extensions>
+					<speed>1.1110731363296509</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01536543897474" lon="-84.20186442367849">
+				<ele>958.6095401095226</ele>
+				<time>2017-11-20T19:08:20Z</time>
+				<extensions>
+					<speed>1.2011250257492065</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015398942468734" lon="-84.20187217721768">
+				<ele>959.5180035661906</ele>
+				<time>2017-11-20T19:08:21Z</time>
+				<extensions>
+					<speed>1.407334327697754</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01539603162242" lon="-84.20185731279469">
+				<ele>958.0372797064483</ele>
+				<time>2017-11-20T19:08:22Z</time>
+				<extensions>
+					<speed>1.20767343044281</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015398523553042" lon="-84.20184650358672">
+				<ele>957.2123743835837</ele>
+				<time>2017-11-20T19:08:23Z</time>
+				<extensions>
+					<speed>1.15218186378479</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015415564635656" lon="-84.20184253553657">
+				<ele>957.1923500876874</ele>
+				<time>2017-11-20T19:08:24Z</time>
+				<extensions>
+					<speed>1.6754915714263916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015428796949069" lon="-84.20183951893617">
+				<ele>956.8560548964888</ele>
+				<time>2017-11-20T19:08:25Z</time>
+				<extensions>
+					<speed>1.1469063758850098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015442996647854" lon="-84.20183366260922">
+				<ele>956.3659377759323</ele>
+				<time>2017-11-20T19:08:26Z</time>
+				<extensions>
+					<speed>1.6058017015457153</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015460309202355" lon="-84.20182389657288">
+				<ele>955.5965352887288</ele>
+				<time>2017-11-20T19:08:27Z</time>
+				<extensions>
+					<speed>2.1428675651550293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015480462218465" lon="-84.20180928287215">
+				<ele>954.9230312863365</ele>
+				<time>2017-11-20T19:08:28Z</time>
+				<extensions>
+					<speed>2.8970205783843994</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01550264629536" lon="-84.20178747056656">
+				<ele>954.5662737200037</ele>
+				<time>2017-11-20T19:08:29Z</time>
+				<extensions>
+					<speed>3.6290652751922607</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01552809850233" lon="-84.20176162612785">
+				<ele>954.2069417126477</ele>
+				<time>2017-11-20T19:08:30Z</time>
+				<extensions>
+					<speed>4.0690717697143555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015556594685187" lon="-84.2017381015439">
+				<ele>953.9329545451328</ele>
+				<time>2017-11-20T19:08:31Z</time>
+				<extensions>
+					<speed>3.8528313636779785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015583251870671" lon="-84.20171709400317">
+				<ele>953.5297933118418</ele>
+				<time>2017-11-20T19:08:32Z</time>
+				<extensions>
+					<speed>3.0435702800750732</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015600523905801" lon="-84.20170443299583">
+				<ele>953.1981697278097</ele>
+				<time>2017-11-20T19:08:33Z</time>
+				<extensions>
+					<speed>2.0857152938842773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015613213640618" lon="-84.20169148039352">
+				<ele>953.2700763540342</ele>
+				<time>2017-11-20T19:08:34Z</time>
+				<extensions>
+					<speed>2.0378544330596924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015625914761861" lon="-84.20167852378923">
+				<ele>954.3609632821754</ele>
+				<time>2017-11-20T19:08:35Z</time>
+				<extensions>
+					<speed>2.0815939903259277</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015638060988309" lon="-84.20166399027283">
+				<ele>953.4500778354704</ele>
+				<time>2017-11-20T19:08:36Z</time>
+				<extensions>
+					<speed>2.4191994667053223</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01565185031183" lon="-84.20164759772058">
+				<ele>952.9270373173058</ele>
+				<time>2017-11-20T19:08:37Z</time>
+				<extensions>
+					<speed>2.8009278774261475</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015670036948888" lon="-84.20162827479328">
+				<ele>952.863269045949</ele>
+				<time>2017-11-20T19:08:38Z</time>
+				<extensions>
+					<speed>3.3349833488464355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015695214189446" lon="-84.20160245531716">
+				<ele>952.6459333943203</ele>
+				<time>2017-11-20T19:08:39Z</time>
+				<extensions>
+					<speed>4.293656349182129</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015727233726313" lon="-84.2015685542868">
+				<ele>951.8060932336375</ele>
+				<time>2017-11-20T19:08:40Z</time>
+				<extensions>
+					<speed>5.156907081604004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015763036045392" lon="-84.20153052171936">
+				<ele>951.308925723657</ele>
+				<time>2017-11-20T19:08:41Z</time>
+				<extensions>
+					<speed>5.9313645362854</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015806191601062" lon="-84.20148559135107">
+				<ele>950.7168430788442</ele>
+				<time>2017-11-20T19:08:42Z</time>
+				<extensions>
+					<speed>6.681554794311523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015850354069531" lon="-84.20144220892979">
+				<ele>950.8945206720382</ele>
+				<time>2017-11-20T19:08:43Z</time>
+				<extensions>
+					<speed>7.191899299621582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015896167889673" lon="-84.2013922070735">
+				<ele>951.0685333656147</ele>
+				<time>2017-11-20T19:08:44Z</time>
+				<extensions>
+					<speed>7.727879524230957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015943921442338" lon="-84.20133808901173">
+				<ele>951.3985129026696</ele>
+				<time>2017-11-20T19:08:45Z</time>
+				<extensions>
+					<speed>7.921468734741211</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015994437053243" lon="-84.20128191682358">
+				<ele>951.4357806034386</ele>
+				<time>2017-11-20T19:08:46Z</time>
+				<extensions>
+					<speed>8.27930736541748</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016046435914257" lon="-84.2012202302714">
+				<ele>952.2790285171941</ele>
+				<time>2017-11-20T19:08:47Z</time>
+				<extensions>
+					<speed>8.262755393981934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016095208219308" lon="-84.20116431052254">
+				<ele>952.3381452625617</ele>
+				<time>2017-11-20T19:08:48Z</time>
+				<extensions>
+					<speed>7.770535469055176</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016135484712775" lon="-84.20111877683674">
+				<ele>951.7663204539567</ele>
+				<time>2017-11-20T19:08:49Z</time>
+				<extensions>
+					<speed>5.490718841552734</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016163826899989" lon="-84.20109108004428">
+				<ele>951.7717813346535</ele>
+				<time>2017-11-20T19:08:50Z</time>
+				<extensions>
+					<speed>3.1383814811706543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01617911260178" lon="-84.20107763756842">
+				<ele>951.9678770042956</ele>
+				<time>2017-11-20T19:08:51Z</time>
+				<extensions>
+					<speed>1.260999321937561</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016184114643199" lon="-84.20107173962113">
+				<ele>951.6347838258371</ele>
+				<time>2017-11-20T19:08:52Z</time>
+				<extensions>
+					<speed>0.6843678951263428</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016185193069806" lon="-84.20106114622072">
+				<ele>951.2726850295439</ele>
+				<time>2017-11-20T19:08:53Z</time>
+				<extensions>
+					<speed>1.205468773841858</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016191008013186" lon="-84.20106217535913">
+				<ele>950.2550065340474</ele>
+				<time>2017-11-20T19:08:54Z</time>
+				<extensions>
+					<speed>1.7790162563323975</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016201374476385" lon="-84.20103989752326">
+				<ele>950.0598576283082</ele>
+				<time>2017-11-20T19:08:55Z</time>
+				<extensions>
+					<speed>2.862793445587158</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016217270463386" lon="-84.20101283903958">
+				<ele>950.8573679691181</ele>
+				<time>2017-11-20T19:08:56Z</time>
+				<extensions>
+					<speed>3.557054042816162</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01623833369188" lon="-84.20098165995478">
+				<ele>951.4133102456108</ele>
+				<time>2017-11-20T19:08:57Z</time>
+				<extensions>
+					<speed>4.300053596496582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01626640809596" lon="-84.20094331579992">
+				<ele>951.6757216341794</ele>
+				<time>2017-11-20T19:08:58Z</time>
+				<extensions>
+					<speed>5.493627071380615</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016301530188587" lon="-84.20089301966165">
+				<ele>952.0406246129423</ele>
+				<time>2017-11-20T19:08:59Z</time>
+				<extensions>
+					<speed>6.96864128112793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016339774752634" lon="-84.20083098781622">
+				<ele>951.9543375512585</ele>
+				<time>2017-11-20T19:09:00Z</time>
+				<extensions>
+					<speed>8.360288619995117</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01637392441431" lon="-84.20075238863107">
+				<ele>952.5034308955073</ele>
+				<time>2017-11-20T19:09:01Z</time>
+				<extensions>
+					<speed>9.575352668762207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016395055573886" lon="-84.20066260847433">
+				<ele>952.8134468412027</ele>
+				<time>2017-11-20T19:09:02Z</time>
+				<extensions>
+					<speed>9.762208938598633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016382535485338" lon="-84.20053803410744">
+				<ele>950.3605435192585</ele>
+				<time>2017-11-20T19:09:03Z</time>
+				<extensions>
+					<speed>10.549492835998535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016382653155022" lon="-84.20041975216694">
+				<ele>949.1695465417579</ele>
+				<time>2017-11-20T19:09:04Z</time>
+				<extensions>
+					<speed>10.856005668640137</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016403090280976" lon="-84.20031754968396">
+				<ele>949.12820040714</ele>
+				<time>2017-11-20T19:09:05Z</time>
+				<extensions>
+					<speed>11.065342903137207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016440872495293" lon="-84.20021514368192">
+				<ele>949.7426662845537</ele>
+				<time>2017-11-20T19:09:06Z</time>
+				<extensions>
+					<speed>11.486143112182617</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016499182723022" lon="-84.20011434394982">
+				<ele>949.7419681567699</ele>
+				<time>2017-11-20T19:09:07Z</time>
+				<extensions>
+					<speed>11.904096603393555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01657076565106" lon="-84.20002415437264">
+				<ele>950.1598005630076</ele>
+				<time>2017-11-20T19:09:08Z</time>
+				<extensions>
+					<speed>11.801473617553711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016651506527566" lon="-84.19994545760457">
+				<ele>950.5694030011073</ele>
+				<time>2017-11-20T19:09:09Z</time>
+				<extensions>
+					<speed>12.140270233154297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016737175511366" lon="-84.1998718742425">
+				<ele>951.0660482952371</ele>
+				<time>2017-11-20T19:09:10Z</time>
+				<extensions>
+					<speed>12.58162784576416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01682852388507" lon="-84.19979803811971">
+				<ele>951.2260965630412</ele>
+				<time>2017-11-20T19:09:11Z</time>
+				<extensions>
+					<speed>13.120158195495605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01692372083802" lon="-84.19971858683367">
+				<ele>951.4271604958922</ele>
+				<time>2017-11-20T19:09:12Z</time>
+				<extensions>
+					<speed>13.355096817016602</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01701544524712" lon="-84.19963448596212">
+				<ele>951.9318051878363</ele>
+				<time>2017-11-20T19:09:13Z</time>
+				<extensions>
+					<speed>13.577842712402344</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017104775953149" lon="-84.19954736067943">
+				<ele>952.3411951428279</ele>
+				<time>2017-11-20T19:09:14Z</time>
+				<extensions>
+					<speed>13.681417465209961</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017189563934481" lon="-84.19945709639347">
+				<ele>952.7720741210505</ele>
+				<time>2017-11-20T19:09:15Z</time>
+				<extensions>
+					<speed>13.491466522216797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01726770110256" lon="-84.19936499116699">
+				<ele>953.0683157946914</ele>
+				<time>2017-11-20T19:09:16Z</time>
+				<extensions>
+					<speed>13.04879093170166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017344695261901" lon="-84.19927091478638">
+				<ele>954.0894573088735</ele>
+				<time>2017-11-20T19:09:17Z</time>
+				<extensions>
+					<speed>12.894156455993652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017412714615698" lon="-84.1991717617901">
+				<ele>955.521696953103</ele>
+				<time>2017-11-20T19:09:18Z</time>
+				<extensions>
+					<speed>12.977803230285645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017468379661723" lon="-84.1990646838843">
+				<ele>956.6868853997439</ele>
+				<time>2017-11-20T19:09:19Z</time>
+				<extensions>
+					<speed>12.528555870056152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017508553546785" lon="-84.19895484634198">
+				<ele>957.5534862363711</ele>
+				<time>2017-11-20T19:09:20Z</time>
+				<extensions>
+					<speed>12.340760231018066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017538936280932" lon="-84.19884390694777">
+				<ele>958.0190642764792</ele>
+				<time>2017-11-20T19:09:21Z</time>
+				<extensions>
+					<speed>12.269798278808594</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017567487493727" lon="-84.1987330930408">
+				<ele>958.8393636858091</ele>
+				<time>2017-11-20T19:09:22Z</time>
+				<extensions>
+					<speed>12.365303993225098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017606385346186" lon="-84.1986247049302">
+				<ele>959.8954909695312</ele>
+				<time>2017-11-20T19:09:23Z</time>
+				<extensions>
+					<speed>12.56751537322998</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01766175045198" lon="-84.19852263208915">
+				<ele>959.8067598761991</ele>
+				<time>2017-11-20T19:09:24Z</time>
+				<extensions>
+					<speed>13.164542198181152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017733688982993" lon="-84.19842655594879">
+				<ele>959.4907296197489</ele>
+				<time>2017-11-20T19:09:25Z</time>
+				<extensions>
+					<speed>13.471003532409668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01781510771903" lon="-84.19833109869839">
+				<ele>958.7146582882851</ele>
+				<time>2017-11-20T19:09:26Z</time>
+				<extensions>
+					<speed>13.928268432617188</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01790073770738" lon="-84.19823547172284">
+				<ele>958.2917560050264</ele>
+				<time>2017-11-20T19:09:27Z</time>
+				<extensions>
+					<speed>14.374635696411133</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01798948568183" lon="-84.19814088620197">
+				<ele>958.0691662235186</ele>
+				<time>2017-11-20T19:09:28Z</time>
+				<extensions>
+					<speed>14.259674072265625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.018077715884393" lon="-84.19804610010236">
+				<ele>957.9218337228522</ele>
+				<time>2017-11-20T19:09:29Z</time>
+				<extensions>
+					<speed>13.902481079101563</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01815940990475" lon="-84.19795644978115">
+				<ele>957.8823365373537</ele>
+				<time>2017-11-20T19:09:30Z</time>
+				<extensions>
+					<speed>12.906493186950684</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.018231687203318" lon="-84.19787395479464">
+				<ele>957.8144998438656</ele>
+				<time>2017-11-20T19:09:31Z</time>
+				<extensions>
+					<speed>11.958420753479004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.018302103729514" lon="-84.19780110351897">
+				<ele>958.1415017358959</ele>
+				<time>2017-11-20T19:09:32Z</time>
+				<extensions>
+					<speed>10.983044624328613</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.018372528196913" lon="-84.19774131657917">
+				<ele>958.4699435625225</ele>
+				<time>2017-11-20T19:09:33Z</time>
+				<extensions>
+					<speed>10.144416809082031</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.018445384260021" lon="-84.19769533205012">
+				<ele>959.0348456706852</ele>
+				<time>2017-11-20T19:09:34Z</time>
+				<extensions>
+					<speed>9.934127807617188</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01852501716157" lon="-84.19766574061804">
+				<ele>959.7105482211336</ele>
+				<time>2017-11-20T19:09:35Z</time>
+				<extensions>
+					<speed>9.54685115814209</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.018606163162373" lon="-84.19765592027358">
+				<ele>960.1045698961243</ele>
+				<time>2017-11-20T19:09:36Z</time>
+				<extensions>
+					<speed>9.030267715454102</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.018691458291322" lon="-84.19766694900103">
+				<ele>960.2837001075968</ele>
+				<time>2017-11-20T19:09:37Z</time>
+				<extensions>
+					<speed>10.046509742736816</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.018776927075596" lon="-84.19769807996094">
+				<ele>960.110995917581</ele>
+				<time>2017-11-20T19:09:38Z</time>
+				<extensions>
+					<speed>10.061894416809082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.018858488936424" lon="-84.19774747289097">
+				<ele>959.924064155668</ele>
+				<time>2017-11-20T19:09:39Z</time>
+				<extensions>
+					<speed>10.543609619140625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.018939870850382" lon="-84.19780307672285">
+				<ele>959.7679302897304</ele>
+				<time>2017-11-20T19:09:40Z</time>
+				<extensions>
+					<speed>10.615767478942871</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019002060012694" lon="-84.19785045314948">
+				<ele>958.6652940800413</ele>
+				<time>2017-11-20T19:09:41Z</time>
+				<extensions>
+					<speed>10.120844841003418</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019077199005997" lon="-84.19790148520943">
+				<ele>958.2934171874076</ele>
+				<time>2017-11-20T19:09:42Z</time>
+				<extensions>
+					<speed>9.473090171813965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019154280088307" lon="-84.1979529990492">
+				<ele>957.8979168860242</ele>
+				<time>2017-11-20T19:09:43Z</time>
+				<extensions>
+					<speed>10.27137565612793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019236923173272" lon="-84.19799829570889">
+				<ele>957.8062222963199</ele>
+				<time>2017-11-20T19:09:44Z</time>
+				<extensions>
+					<speed>10.105842590332031</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019318065224075" lon="-84.19804130210389">
+				<ele>958.6653922023252</ele>
+				<time>2017-11-20T19:09:45Z</time>
+				<extensions>
+					<speed>9.841755867004395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019387222999306" lon="-84.19807259212914">
+				<ele>959.0997958127409</ele>
+				<time>2017-11-20T19:09:46Z</time>
+				<extensions>
+					<speed>8.191252708435059</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019451637836871" lon="-84.19810102980284">
+				<ele>958.9019367638975</ele>
+				<time>2017-11-20T19:09:47Z</time>
+				<extensions>
+					<speed>7.38631010055542</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019498725176778" lon="-84.19811083232138">
+				<ele>958.7587258117273</ele>
+				<time>2017-11-20T19:09:48Z</time>
+				<extensions>
+					<speed>4.880826473236084</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01952739367468" lon="-84.19810649423258">
+				<ele>958.8008060529828</ele>
+				<time>2017-11-20T19:09:49Z</time>
+				<extensions>
+					<speed>2.356693983078003</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019531873465489" lon="-84.19809094352914">
+				<ele>958.8851635474712</ele>
+				<time>2017-11-20T19:09:50Z</time>
+				<extensions>
+					<speed>1.50852370262146</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019521130595068" lon="-84.19807392534253">
+				<ele>959.1974484687671</ele>
+				<time>2017-11-20T19:09:51Z</time>
+				<extensions>
+					<speed>2.0807065963745117</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019505970247392" lon="-84.19805727037554">
+				<ele>959.2850307449698</ele>
+				<time>2017-11-20T19:09:52Z</time>
+				<extensions>
+					<speed>1.979964017868042</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01949066816414" lon="-84.19803883113545">
+				<ele>959.663315503858</ele>
+				<time>2017-11-20T19:09:53Z</time>
+				<extensions>
+					<speed>1.8262192010879517</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01948252333893" lon="-84.19802390135409">
+				<ele>959.9614971708506</ele>
+				<time>2017-11-20T19:09:54Z</time>
+				<extensions>
+					<speed>1.594612956047058</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019480130097948" lon="-84.19800520461536">
+				<ele>960.3216222347692</ele>
+				<time>2017-11-20T19:09:55Z</time>
+				<extensions>
+					<speed>1.5535870790481567</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019475565705905" lon="-84.19797860157021">
+				<ele>960.3300546575338</ele>
+				<time>2017-11-20T19:09:56Z</time>
+				<extensions>
+					<speed>2.451591730117798</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0194763567584" lon="-84.19795266840823">
+				<ele>960.5656846789643</ele>
+				<time>2017-11-20T19:09:57Z</time>
+				<extensions>
+					<speed>3.033546209335327</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019487398630046" lon="-84.19792763150663">
+				<ele>961.5040531046689</ele>
+				<time>2017-11-20T19:09:58Z</time>
+				<extensions>
+					<speed>2.9454002380371094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019497748915493" lon="-84.19790539392578">
+				<ele>962.483568563126</ele>
+				<time>2017-11-20T19:09:59Z</time>
+				<extensions>
+					<speed>2.253465414047241</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019503754977935" lon="-84.1978804129548">
+				<ele>963.377598201856</ele>
+				<time>2017-11-20T19:10:00Z</time>
+				<extensions>
+					<speed>2.2240066528320313</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019506503754997" lon="-84.19784993152042">
+				<ele>963.6576945632696</ele>
+				<time>2017-11-20T19:10:01Z</time>
+				<extensions>
+					<speed>2.7593648433685303</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01950672517172" lon="-84.19781700495722">
+				<ele>963.9178831214085</ele>
+				<time>2017-11-20T19:10:02Z</time>
+				<extensions>
+					<speed>3.2490711212158203</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019512134598822" lon="-84.19777940275445">
+				<ele>964.7631094679236</ele>
+				<time>2017-11-20T19:10:03Z</time>
+				<extensions>
+					<speed>3.944383382797241</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019509673454584" lon="-84.19772465786353">
+				<ele>964.8319252803922</ele>
+				<time>2017-11-20T19:10:04Z</time>
+				<extensions>
+					<speed>4.890933036804199</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019500431123799" lon="-84.1976730332331">
+				<ele>964.9426753381267</ele>
+				<time>2017-11-20T19:10:05Z</time>
+				<extensions>
+					<speed>4.980772495269775</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01947476748134" lon="-84.19762792076347">
+				<ele>965.3747870214283</ele>
+				<time>2017-11-20T19:10:06Z</time>
+				<extensions>
+					<speed>5.565364837646484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019435241843544" lon="-84.19758647475825">
+				<ele>965.863722008653</ele>
+				<time>2017-11-20T19:10:07Z</time>
+				<extensions>
+					<speed>6.616504669189453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019381166635931" lon="-84.19755144469993">
+				<ele>966.5588769866154</ele>
+				<time>2017-11-20T19:10:08Z</time>
+				<extensions>
+					<speed>7.100066661834717</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0193175747028" lon="-84.19752006588634">
+				<ele>967.371655613184</ele>
+				<time>2017-11-20T19:10:09Z</time>
+				<extensions>
+					<speed>8.154838562011719</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019246747257958" lon="-84.19748866265765">
+				<ele>968.0606600893661</ele>
+				<time>2017-11-20T19:10:10Z</time>
+				<extensions>
+					<speed>8.539270401000977</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019171523344253" lon="-84.19745679214489">
+				<ele>968.3673542160541</ele>
+				<time>2017-11-20T19:10:11Z</time>
+				<extensions>
+					<speed>8.83650016784668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019094693868293" lon="-84.19742441847114">
+				<ele>968.6187121318653</ele>
+				<time>2017-11-20T19:10:12Z</time>
+				<extensions>
+					<speed>9.10055923461914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.019017081433677" lon="-84.19738746431732">
+				<ele>968.2699338011444</ele>
+				<time>2017-11-20T19:10:13Z</time>
+				<extensions>
+					<speed>9.470709800720215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.018930019627465" lon="-84.19735562352275">
+				<ele>968.2563173100352</ele>
+				<time>2017-11-20T19:10:14Z</time>
+				<extensions>
+					<speed>10.136693954467773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01884098483296" lon="-84.19732254280855">
+				<ele>968.8769837040454</ele>
+				<time>2017-11-20T19:10:15Z</time>
+				<extensions>
+					<speed>11.165042877197266</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01874260709103" lon="-84.19727806893894">
+				<ele>968.1790389986709</ele>
+				<time>2017-11-20T19:10:16Z</time>
+				<extensions>
+					<speed>10.586164474487305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.018651642305434" lon="-84.19722802926469">
+				<ele>968.0232818722725</ele>
+				<time>2017-11-20T19:10:17Z</time>
+				<extensions>
+					<speed>11.183565139770508</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01855313143445" lon="-84.19718042719357">
+				<ele>967.80585773848</ele>
+				<time>2017-11-20T19:10:18Z</time>
+				<extensions>
+					<speed>11.081223487854004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.018466476970959" lon="-84.19713357722502">
+				<ele>968.1290452051908</ele>
+				<time>2017-11-20T19:10:19Z</time>
+				<extensions>
+					<speed>10.99221134185791</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.018383559519245" lon="-84.19708237286129">
+				<ele>968.642306894064</ele>
+				<time>2017-11-20T19:10:20Z</time>
+				<extensions>
+					<speed>11.229475021362305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01830410161718" lon="-84.1970273029029">
+				<ele>969.4847469339147</ele>
+				<time>2017-11-20T19:10:21Z</time>
+				<extensions>
+					<speed>11.463678359985352</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.018225085089403" lon="-84.19696767304708">
+				<ele>970.4597701365128</ele>
+				<time>2017-11-20T19:10:22Z</time>
+				<extensions>
+					<speed>11.5304536819458</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.018155411454982" lon="-84.19690931988754">
+				<ele>971.857963277027</ele>
+				<time>2017-11-20T19:10:23Z</time>
+				<extensions>
+					<speed>10.12477970123291</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01809314875717" lon="-84.196856315614">
+				<ele>973.7075057802722</ele>
+				<time>2017-11-20T19:10:24Z</time>
+				<extensions>
+					<speed>8.877439498901367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.018039562755428" lon="-84.1967926275891">
+				<ele>975.1306249070913</ele>
+				<time>2017-11-20T19:10:25Z</time>
+				<extensions>
+					<speed>10.072606086730957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017994461370437" lon="-84.19670930793323">
+				<ele>976.1387614654377</ele>
+				<time>2017-11-20T19:10:26Z</time>
+				<extensions>
+					<speed>10.988028526306152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017959650649912" lon="-84.1966175054954">
+				<ele>977.6742468699813</ele>
+				<time>2017-11-20T19:10:27Z</time>
+				<extensions>
+					<speed>10.95382308959961</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017920835736454" lon="-84.19652179887457">
+				<ele>979.8123366096988</ele>
+				<time>2017-11-20T19:10:28Z</time>
+				<extensions>
+					<speed>10.452617645263672</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017892295853493" lon="-84.1964336999975">
+				<ele>980.973072716035</ele>
+				<time>2017-11-20T19:10:29Z</time>
+				<extensions>
+					<speed>9.39909839630127</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017867385931646" lon="-84.19635748466753">
+				<ele>982.1757820360363</ele>
+				<time>2017-11-20T19:10:30Z</time>
+				<extensions>
+					<speed>8.189586639404297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017834416442149" lon="-84.1962968646847">
+				<ele>984.1015833923593</ele>
+				<time>2017-11-20T19:10:31Z</time>
+				<extensions>
+					<speed>7.253050327301025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017797767526702" lon="-84.19624204417993">
+				<ele>985.0860775830224</ele>
+				<time>2017-11-20T19:10:32Z</time>
+				<extensions>
+					<speed>5.976477146148682</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017755881743216" lon="-84.1961956822743">
+				<ele>984.2718320880085</ele>
+				<time>2017-11-20T19:10:33Z</time>
+				<extensions>
+					<speed>5.100873947143555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017720440866444" lon="-84.196163018851">
+				<ele>984.1396343223751</ele>
+				<time>2017-11-20T19:10:34Z</time>
+				<extensions>
+					<speed>4.469939708709717</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017684681905795" lon="-84.1961371594715">
+				<ele>984.4554345402867</ele>
+				<time>2017-11-20T19:10:35Z</time>
+				<extensions>
+					<speed>4.036750316619873</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017654136219104" lon="-84.1961157686581">
+				<ele>985.1448973771185</ele>
+				<time>2017-11-20T19:10:36Z</time>
+				<extensions>
+					<speed>3.5941660404205322</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017627663450984" lon="-84.19609784699172">
+				<ele>985.8830689778551</ele>
+				<time>2017-11-20T19:10:37Z</time>
+				<extensions>
+					<speed>2.9975805282592773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017603255142706" lon="-84.1960814898747">
+				<ele>986.4862194480374</ele>
+				<time>2017-11-20T19:10:38Z</time>
+				<extensions>
+					<speed>2.728968381881714</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017580842668824" lon="-84.1960647211894">
+				<ele>986.942082173191</ele>
+				<time>2017-11-20T19:10:39Z</time>
+				<extensions>
+					<speed>2.4146170616149902</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01756266155427" lon="-84.19604632643019">
+				<ele>986.738906907849</ele>
+				<time>2017-11-20T19:10:40Z</time>
+				<extensions>
+					<speed>2.1344525814056396</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017544452657628" lon="-84.19602770649136">
+				<ele>986.3969182213768</ele>
+				<time>2017-11-20T19:10:41Z</time>
+				<extensions>
+					<speed>2.0499377250671387</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017527991573603" lon="-84.19601220129847">
+				<ele>986.3072900082916</ele>
+				<time>2017-11-20T19:10:42Z</time>
+				<extensions>
+					<speed>1.8465044498443604</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017511249539341" lon="-84.19599731518">
+				<ele>985.9065667176619</ele>
+				<time>2017-11-20T19:10:43Z</time>
+				<extensions>
+					<speed>1.9218231439590454</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017490411609032" lon="-84.19598339102536">
+				<ele>985.1149136675522</ele>
+				<time>2017-11-20T19:10:44Z</time>
+				<extensions>
+					<speed>1.9268821477890015</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017472201862521" lon="-84.19597083287935">
+				<ele>985.3451897036284</ele>
+				<time>2017-11-20T19:10:45Z</time>
+				<extensions>
+					<speed>2.100029468536377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017452942994165" lon="-84.1959609966682">
+				<ele>985.7285403022543</ele>
+				<time>2017-11-20T19:10:46Z</time>
+				<extensions>
+					<speed>2.4177188873291016</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01743056031788" lon="-84.19595523561956">
+				<ele>986.1412161784247</ele>
+				<time>2017-11-20T19:10:47Z</time>
+				<extensions>
+					<speed>2.3807287216186523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017403778193176" lon="-84.19595811979195">
+				<ele>986.2087098825723</ele>
+				<time>2017-11-20T19:10:48Z</time>
+				<extensions>
+					<speed>3.463700771331787</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017366315762162" lon="-84.19596990759896">
+				<ele>986.2508727898821</ele>
+				<time>2017-11-20T19:10:49Z</time>
+				<extensions>
+					<speed>5.026919841766357</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01732362631616" lon="-84.1959898884693">
+				<ele>986.3624550085515</ele>
+				<time>2017-11-20T19:10:50Z</time>
+				<extensions>
+					<speed>5.552120685577393</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017277981253432" lon="-84.19601421732932">
+				<ele>986.6815713383257</ele>
+				<time>2017-11-20T19:10:51Z</time>
+				<extensions>
+					<speed>5.5210280418396</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017233576430598" lon="-84.19603155639294">
+				<ele>987.0641844244674</ele>
+				<time>2017-11-20T19:10:52Z</time>
+				<extensions>
+					<speed>4.731141567230225</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017196349935054" lon="-84.19603952541993">
+				<ele>988.2885403903201</ele>
+				<time>2017-11-20T19:10:53Z</time>
+				<extensions>
+					<speed>3.8653404712677</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017168883691804" lon="-84.19604766597355">
+				<ele>988.5876173172146</ele>
+				<time>2017-11-20T19:10:54Z</time>
+				<extensions>
+					<speed>2.5932209491729736</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017151309296025" lon="-84.19605478677587">
+				<ele>988.7503418987617</ele>
+				<time>2017-11-20T19:10:55Z</time>
+				<extensions>
+					<speed>1.6282472610473633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017142358718807" lon="-84.19605913330544">
+				<ele>988.7113077333197</ele>
+				<time>2017-11-20T19:10:56Z</time>
+				<extensions>
+					<speed>0.6546990871429443</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01714690970288" lon="-84.19606678730892">
+				<ele>986.4333600504324</ele>
+				<time>2017-11-20T19:10:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01714690970288" lon="-84.19606678730892">
+				<ele>986.4333600504324</ele>
+				<time>2017-11-20T19:10:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017149692874122" lon="-84.19605903284263">
+				<ele>985.8758017774671</ele>
+				<time>2017-11-20T19:10:59Z</time>
+				<extensions>
+					<speed>0.654321014881134</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017149692874122" lon="-84.19605903284263">
+				<ele>985.8758017774671</ele>
+				<time>2017-11-20T19:11:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017151011477468" lon="-84.1960610069286">
+				<ele>985.6221977137029</ele>
+				<time>2017-11-20T19:11:01Z</time>
+				<extensions>
+					<speed>0.2297862023115158</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017151011477468" lon="-84.1960610069286">
+				<ele>985.6221977137029</ele>
+				<time>2017-11-20T19:11:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017151011477468" lon="-84.1960610069286">
+				<ele>985.6221977137029</ele>
+				<time>2017-11-20T19:11:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+		</trkseg>
+	</trk>
+</gpx>

--- a/bus_alajuela-targuases/asistentes/fran_2017_11_20_repo.gpx
+++ b/bus_alajuela-targuases/asistentes/fran_2017_11_20_repo.gpx
@@ -1,0 +1,12841 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="OSMTracker for Android™ - https://github.com/nguillaumin/osmtracker-android" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd ">
+	<wpt lat="10.015283525502308" lon="-84.21332273883895">
+		<ele>945.4678052756935</ele>
+		<time>2017-11-20T20:09:31Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015293393427982" lon="-84.21333362477047">
+		<ele>945.6231339210644</ele>
+		<time>2017-11-20T20:09:32Z</time>
+		<name><![CDATA[3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015739951645187" lon="-84.21190913879657">
+		<ele>955.4692996935919</ele>
+		<time>2017-11-20T20:11:08Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015732784858947" lon="-84.21191640313322">
+		<ele>955.3820689534768</ele>
+		<time>2017-11-20T20:11:09Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.010179364480896" lon="-84.21299499669895">
+		<ele>946.984489204362</ele>
+		<time>2017-11-20T20:15:29Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.010179364480896" lon="-84.21299499669895">
+		<ele>946.984489204362</ele>
+		<time>2017-11-20T20:15:30Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008677658612408" lon="-84.21026161916728">
+		<ele>935.3992691067979</ele>
+		<time>2017-11-20T20:16:32Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008671067521004" lon="-84.21022814184911">
+		<ele>935.528134512715</ele>
+		<time>2017-11-20T20:16:33Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.005775563565875" lon="-84.20587615863813">
+		<ele>927.4906055442989</ele>
+		<time>2017-11-20T20:19:22Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.005737604838611" lon="-84.20591196003632">
+		<ele>927.6365197319537</ele>
+		<time>2017-11-20T20:19:23Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.004747909852904" lon="-84.20654861843312">
+		<ele>931.5157094830647</ele>
+		<time>2017-11-20T20:20:14Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.00477246637479" lon="-84.2065261720645">
+		<ele>929.4004470296204</ele>
+		<time>2017-11-20T20:20:15Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.005887017734507" lon="-84.20452294675758">
+		<ele>934.55851814989</ele>
+		<time>2017-11-20T20:23:39Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.005909027358332" lon="-84.2044967417471">
+		<ele>934.9363594166934</ele>
+		<time>2017-11-20T20:23:40Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.007386498586788" lon="-84.20459805745608">
+		<ele>943.1628719493747</ele>
+		<time>2017-11-20T20:25:01Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.007386498586788" lon="-84.20459805745608">
+		<ele>943.1628719493747</ele>
+		<time>2017-11-20T20:25:01Z</time>
+		<name><![CDATA[3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008972179365857" lon="-84.2031921758312">
+		<ele>951.8765381230041</ele>
+		<time>2017-11-20T20:25:54Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.008956074748383" lon="-84.20321556417616">
+		<ele>952.3940506707877</ele>
+		<time>2017-11-20T20:25:57Z</time>
+		<name><![CDATA[3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.010220322276439" lon="-84.20214754186975">
+		<ele>942.1584898866713</ele>
+		<time>2017-11-20T20:26:46Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.01021293760805" lon="-84.2021522812243">
+		<ele>942.0687048798427</ele>
+		<time>2017-11-20T20:26:47Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.011491559641607" lon="-84.20148974670605">
+		<ele>953.070958815515</ele>
+		<time>2017-11-20T20:27:37Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.011491559641607" lon="-84.20148974670605">
+		<ele>953.070958815515</ele>
+		<time>2017-11-20T20:27:38Z</time>
+		<name><![CDATA[3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.01272983801093" lon="-84.2007917863322">
+		<ele>953.3038161611184</ele>
+		<time>2017-11-20T20:29:02Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.0127343040754" lon="-84.20078972431905">
+		<ele>952.7381139872596</ele>
+		<time>2017-11-20T20:29:03Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.013129836012698" lon="-84.20096959274743">
+		<ele>957.1121038608253</ele>
+		<time>2017-11-20T20:29:37Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.013129836012698" lon="-84.20096959274743">
+		<ele>957.1121038608253</ele>
+		<time>2017-11-20T20:29:40Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.014031686248876" lon="-84.20211261362029">
+		<ele>944.5633470257744</ele>
+		<time>2017-11-20T20:30:06Z</time>
+		<name><![CDATA[Grabación de voz]]></name>
+		<link href="2017-11-20_14-30-13.3gpp">
+			<text>2017-11-20_14-30-13.3gpp</text>
+		</link>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.016474803386423" lon="-84.19672917895988">
+		<ele>973.034937415272</ele>
+		<time>2017-11-20T20:34:20Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.016474803386423" lon="-84.19672917895988">
+		<ele>973.034937415272</ele>
+		<time>2017-11-20T20:34:20Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<trk>
+		<name><![CDATA[Trazado con OSMTracker para Android™]]></name>
+		<trkseg>
+			<trkpt lat="10.014140657262312" lon="-84.21682380377024">
+				<ele>960.9342310484499</ele>
+				<time>2017-11-20T20:05:11Z</time>
+				<extensions>
+					<speed>2.6955697536468506</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014403049561095" lon="-84.21686872774889">
+				<ele>961.3790343319997</ele>
+				<time>2017-11-20T20:05:15Z</time>
+				<extensions>
+					<speed>1.0149996280670166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014649820833975" lon="-84.21686834143864">
+				<ele>961.3147618547082</ele>
+				<time>2017-11-20T20:05:16Z</time>
+				<extensions>
+					<speed>0.2819209694862366</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014512837050853" lon="-84.21681340122991">
+				<ele>961.2248058505356</ele>
+				<time>2017-11-20T20:05:17Z</time>
+				<extensions>
+					<speed>0.46089041233062744</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014638643199795" lon="-84.21681694918894">
+				<ele>961.2372244261205</ele>
+				<time>2017-11-20T20:05:19Z</time>
+				<extensions>
+					<speed>0.5632554292678833</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014548649862054" lon="-84.21685141785375">
+				<ele>961.3189594512805</ele>
+				<time>2017-11-20T20:05:20Z</time>
+				<extensions>
+					<speed>0.4038102924823761</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014403051837936" lon="-84.21682000211412">
+				<ele>975.8573253592476</ele>
+				<time>2017-11-20T20:05:21Z</time>
+				<extensions>
+					<speed>0.535968542098999</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014425865316735" lon="-84.21682617307555">
+				<ele>969.4469898510724</ele>
+				<time>2017-11-20T20:05:22Z</time>
+				<extensions>
+					<speed>0.5741347074508667</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014406840622486" lon="-84.21679756419368">
+				<ele>964.1891636261716</ele>
+				<time>2017-11-20T20:05:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014388896206494" lon="-84.2167771239918">
+				<ele>963.5303989341483</ele>
+				<time>2017-11-20T20:05:24Z</time>
+				<extensions>
+					<speed>0.9132627248764038</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014437890118682" lon="-84.21679340529809">
+				<ele>965.2978562498465</ele>
+				<time>2017-11-20T20:05:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:26Z</time>
+				<extensions>
+					<speed>0.3648652136325836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:05:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:06:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:06:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:06:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:06:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:06:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:06:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:06:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445306358413" lon="-84.21679575359906">
+				<ele>966.0722328228876</ele>
+				<time>2017-11-20T20:06:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014447887525112" lon="-84.21679720736469">
+				<ele>964.5984163945541</ele>
+				<time>2017-11-20T20:06:08Z</time>
+				<extensions>
+					<speed>0.8025249242782593</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014443660131823" lon="-84.21679319307685">
+				<ele>963.722839506343</ele>
+				<time>2017-11-20T20:06:09Z</time>
+				<extensions>
+					<speed>1.1777068376541138</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014447605346653" lon="-84.21678703723494">
+				<ele>962.8504382381216</ele>
+				<time>2017-11-20T20:06:10Z</time>
+				<extensions>
+					<speed>1.4614238739013672</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014455581309653" lon="-84.21677901952533">
+				<ele>962.158727793023</ele>
+				<time>2017-11-20T20:06:11Z</time>
+				<extensions>
+					<speed>2.0170063972473145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014466313678467" lon="-84.21676705015062">
+				<ele>960.6336192730814</ele>
+				<time>2017-11-20T20:06:12Z</time>
+				<extensions>
+					<speed>2.699617624282837</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01447593254199" lon="-84.21675295228522">
+				<ele>959.1107481289655</ele>
+				<time>2017-11-20T20:06:13Z</time>
+				<extensions>
+					<speed>2.889065980911255</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014480636049386" lon="-84.21673392424584">
+				<ele>957.2012788914144</ele>
+				<time>2017-11-20T20:06:14Z</time>
+				<extensions>
+					<speed>2.709303140640259</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014485190358839" lon="-84.21671442876612">
+				<ele>955.7395219132304</ele>
+				<time>2017-11-20T20:06:15Z</time>
+				<extensions>
+					<speed>2.3525733947753906</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01448978064984" lon="-84.21669822388115">
+				<ele>954.4678294872865</ele>
+				<time>2017-11-20T20:06:16Z</time>
+				<extensions>
+					<speed>2.0865871906280518</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014497863455778" lon="-84.21668467494314">
+				<ele>953.4021420041099</ele>
+				<time>2017-11-20T20:06:17Z</time>
+				<extensions>
+					<speed>1.96376371383667</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01450404209199" lon="-84.21667121552045">
+				<ele>952.6422112705186</ele>
+				<time>2017-11-20T20:06:18Z</time>
+				<extensions>
+					<speed>1.9569647312164307</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014511358205135" lon="-84.21665662206257">
+				<ele>951.9186238823459</ele>
+				<time>2017-11-20T20:06:19Z</time>
+				<extensions>
+					<speed>1.8966223001480103</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014503160905058" lon="-84.21663753706564">
+				<ele>951.2712696585804</ele>
+				<time>2017-11-20T20:06:20Z</time>
+				<extensions>
+					<speed>1.6306267976760864</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014508133988512" lon="-84.21662707304088">
+				<ele>950.4204754820094</ele>
+				<time>2017-11-20T20:06:21Z</time>
+				<extensions>
+					<speed>1.41563880443573</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014509592944288" lon="-84.21661784655832">
+				<ele>949.2384029589593</ele>
+				<time>2017-11-20T20:06:22Z</time>
+				<extensions>
+					<speed>0.9752230048179626</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014510691822696" lon="-84.21661270029549">
+				<ele>947.7007009880617</ele>
+				<time>2017-11-20T20:06:23Z</time>
+				<extensions>
+					<speed>0.9324021339416504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014512193807683" lon="-84.21660943133922">
+				<ele>946.5849028006196</ele>
+				<time>2017-11-20T20:06:24Z</time>
+				<extensions>
+					<speed>0.7907022833824158</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0145169380345" lon="-84.21660560692519">
+				<ele>946.1790584335104</ele>
+				<time>2017-11-20T20:06:25Z</time>
+				<extensions>
+					<speed>0.8108508586883545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014521145098385" lon="-84.2165976575755">
+				<ele>946.012345707044</ele>
+				<time>2017-11-20T20:06:26Z</time>
+				<extensions>
+					<speed>1.2784039974212646</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014523470317654" lon="-84.2165850503195">
+				<ele>945.5381598062813</ele>
+				<time>2017-11-20T20:06:27Z</time>
+				<extensions>
+					<speed>1.6382083892822266</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014526328033217" lon="-84.21656780316489">
+				<ele>944.9301840914413</ele>
+				<time>2017-11-20T20:06:28Z</time>
+				<extensions>
+					<speed>2.153390884399414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014529139079196" lon="-84.21654985886593">
+				<ele>944.2522762911394</ele>
+				<time>2017-11-20T20:06:29Z</time>
+				<extensions>
+					<speed>1.940157175064087</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014531408796042" lon="-84.21653477146995">
+				<ele>943.8277160301805</ele>
+				<time>2017-11-20T20:06:30Z</time>
+				<extensions>
+					<speed>1.5860177278518677</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014533142429455" lon="-84.21652475592687">
+				<ele>943.6749874046072</ele>
+				<time>2017-11-20T20:06:31Z</time>
+				<extensions>
+					<speed>1.1355760097503662</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014537140893234" lon="-84.21651678671165">
+				<ele>943.7401040121913</ele>
+				<time>2017-11-20T20:06:32Z</time>
+				<extensions>
+					<speed>1.0998246669769287</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014545245269924" lon="-84.21651025885939">
+				<ele>944.0167772090062</ele>
+				<time>2017-11-20T20:06:33Z</time>
+				<extensions>
+					<speed>1.027820348739624</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014553840287805" lon="-84.21650113473501">
+				<ele>945.032138469629</ele>
+				<time>2017-11-20T20:06:34Z</time>
+				<extensions>
+					<speed>1.5950418710708618</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01456315223804" lon="-84.21648573639186">
+				<ele>945.8937768032774</ele>
+				<time>2017-11-20T20:06:35Z</time>
+				<extensions>
+					<speed>2.3090596199035645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014570481718623" lon="-84.21646465350022">
+				<ele>946.9742920715362</ele>
+				<time>2017-11-20T20:06:36Z</time>
+				<extensions>
+					<speed>2.717061996459961</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014575624894068" lon="-84.21643635921313">
+				<ele>947.1312405811623</ele>
+				<time>2017-11-20T20:06:37Z</time>
+				<extensions>
+					<speed>3.52541184425354</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014579093658718" lon="-84.21640120636087">
+				<ele>947.3991745132953</ele>
+				<time>2017-11-20T20:06:38Z</time>
+				<extensions>
+					<speed>4.368052959442139</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014585272552527" lon="-84.21636007446861">
+				<ele>946.9863603161648</ele>
+				<time>2017-11-20T20:06:39Z</time>
+				<extensions>
+					<speed>4.654883861541748</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01459349159643" lon="-84.21631707935204">
+				<ele>946.5055641261861</ele>
+				<time>2017-11-20T20:06:40Z</time>
+				<extensions>
+					<speed>4.778782367706299</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014601936290296" lon="-84.2162736365291">
+				<ele>945.5434385463595</ele>
+				<time>2017-11-20T20:06:41Z</time>
+				<extensions>
+					<speed>4.8382720947265625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014611318839389" lon="-84.21623233263638">
+				<ele>944.8340503796935</ele>
+				<time>2017-11-20T20:06:42Z</time>
+				<extensions>
+					<speed>4.333571910858154</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014622603579907" lon="-84.21619385873073">
+				<ele>944.1645765136927</ele>
+				<time>2017-11-20T20:06:43Z</time>
+				<extensions>
+					<speed>4.256330966949463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014633020825611" lon="-84.21615817188525">
+				<ele>943.1420545317233</ele>
+				<time>2017-11-20T20:06:44Z</time>
+				<extensions>
+					<speed>3.6179287433624268</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014641586293093" lon="-84.21612763482713">
+				<ele>942.5035643605515</ele>
+				<time>2017-11-20T20:06:45Z</time>
+				<extensions>
+					<speed>2.9558188915252686</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014647521705474" lon="-84.21610682393309">
+				<ele>941.7059268383309</ele>
+				<time>2017-11-20T20:06:46Z</time>
+				<extensions>
+					<speed>1.9506171941757202</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014650944304394" lon="-84.21608777159467">
+				<ele>940.6403680508956</ele>
+				<time>2017-11-20T20:06:47Z</time>
+				<extensions>
+					<speed>1.7056396007537842</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014655250865342" lon="-84.21606800954703">
+				<ele>939.716003828682</ele>
+				<time>2017-11-20T20:06:48Z</time>
+				<extensions>
+					<speed>1.9157949686050415</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014658785619913" lon="-84.21604603040146">
+				<ele>939.4516335530207</ele>
+				<time>2017-11-20T20:06:49Z</time>
+				<extensions>
+					<speed>2.46915340423584</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01466321256378" lon="-84.21602038268625">
+				<ele>939.6457745051011</ele>
+				<time>2017-11-20T20:06:50Z</time>
+				<extensions>
+					<speed>3.050647497177124</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014671181320267" lon="-84.2159871037334">
+				<ele>939.8253941275179</ele>
+				<time>2017-11-20T20:06:51Z</time>
+				<extensions>
+					<speed>3.8377201557159424</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0146800889263" lon="-84.21595045421812">
+				<ele>938.8589662835002</ele>
+				<time>2017-11-20T20:06:52Z</time>
+				<extensions>
+					<speed>4.031429290771484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014688160582349" lon="-84.21591575745916">
+				<ele>937.9577275365591</ele>
+				<time>2017-11-20T20:06:53Z</time>
+				<extensions>
+					<speed>3.588554620742798</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014695070376318" lon="-84.2158841537503">
+				<ele>937.3053004527465</ele>
+				<time>2017-11-20T20:06:54Z</time>
+				<extensions>
+					<speed>3.443472146987915</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01470169337776" lon="-84.21585219359694">
+				<ele>936.7041915552691</ele>
+				<time>2017-11-20T20:06:55Z</time>
+				<extensions>
+					<speed>3.4031498432159424</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708615277685" lon="-84.21582288334122">
+				<ele>936.192512200214</ele>
+				<time>2017-11-20T20:06:56Z</time>
+				<extensions>
+					<speed>3.1758882999420166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014716512354651" lon="-84.21579600013429">
+				<ele>935.9193279836327</ele>
+				<time>2017-11-20T20:06:57Z</time>
+				<extensions>
+					<speed>2.8133721351623535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014722065033887" lon="-84.2157742101472">
+				<ele>935.8009439175949</ele>
+				<time>2017-11-20T20:06:58Z</time>
+				<extensions>
+					<speed>2.3300862312316895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014720751484422" lon="-84.21575781528334">
+				<ele>935.5362189318985</ele>
+				<time>2017-11-20T20:06:59Z</time>
+				<extensions>
+					<speed>1.5327603816986084</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01471842252773" lon="-84.21574796406101">
+				<ele>935.4196432512254</ele>
+				<time>2017-11-20T20:07:00Z</time>
+				<extensions>
+					<speed>0.6299975514411926</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014716965365752" lon="-84.21574880036692">
+				<ele>935.2982575912029</ele>
+				<time>2017-11-20T20:07:01Z</time>
+				<extensions>
+					<speed>0.5260776877403259</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014716965365752" lon="-84.21574880036692">
+				<ele>935.2982575912029</ele>
+				<time>2017-11-20T20:07:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014715329630844" lon="-84.21575581844053">
+				<ele>935.4300031354651</ele>
+				<time>2017-11-20T20:07:03Z</time>
+				<extensions>
+					<speed>0.6844795346260071</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014715329630844" lon="-84.21575581844053">
+				<ele>935.4300031354651</ele>
+				<time>2017-11-20T20:07:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014713628373483" lon="-84.21575999691674">
+				<ele>935.4747723676264</ele>
+				<time>2017-11-20T20:07:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01471142570479" lon="-84.21574903306178">
+				<ele>936.1889531007037</ele>
+				<time>2017-11-20T20:07:29Z</time>
+				<extensions>
+					<speed>1.0978213548660278</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708710735382" lon="-84.21573141655988">
+				<ele>936.6755954828113</ele>
+				<time>2017-11-20T20:07:30Z</time>
+				<extensions>
+					<speed>1.980809211730957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014712892017956" lon="-84.2157074152865">
+				<ele>936.5394085347652</ele>
+				<time>2017-11-20T20:07:31Z</time>
+				<extensions>
+					<speed>2.7085726261138916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014717730902355" lon="-84.21567721153455">
+				<ele>936.6163849169388</ele>
+				<time>2017-11-20T20:07:32Z</time>
+				<extensions>
+					<speed>3.3909716606140137</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0147261729631" lon="-84.2156410535861">
+				<ele>936.9819390932098</ele>
+				<time>2017-11-20T20:07:33Z</time>
+				<extensions>
+					<speed>4.101563453674316</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014735527975878" lon="-84.21559940161781">
+				<ele>937.5564624825493</ele>
+				<time>2017-11-20T20:07:34Z</time>
+				<extensions>
+					<speed>4.774742126464844</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014745444940267" lon="-84.21555019667169">
+				<ele>937.8381823282689</ele>
+				<time>2017-11-20T20:07:35Z</time>
+				<extensions>
+					<speed>5.316930294036865</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014753466553973" lon="-84.21549569715563">
+				<ele>937.9171701259911</ele>
+				<time>2017-11-20T20:07:36Z</time>
+				<extensions>
+					<speed>5.66740608215332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01476040671054" lon="-84.21543948838212">
+				<ele>938.0500268861651</ele>
+				<time>2017-11-20T20:07:37Z</time>
+				<extensions>
+					<speed>5.848972797393799</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014771638727668" lon="-84.21538705319702">
+				<ele>938.0606298930943</ele>
+				<time>2017-11-20T20:07:38Z</time>
+				<extensions>
+					<speed>5.814581871032715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014782150980832" lon="-84.21533807053949">
+				<ele>938.0496363900602</ele>
+				<time>2017-11-20T20:07:39Z</time>
+				<extensions>
+					<speed>5.484453201293945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01479202966359" lon="-84.21530171774553">
+				<ele>937.8841920886189</ele>
+				<time>2017-11-20T20:07:40Z</time>
+				<extensions>
+					<speed>4.283227920532227</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014799807283644" lon="-84.21527472234106">
+				<ele>937.8678757390007</ele>
+				<time>2017-11-20T20:07:41Z</time>
+				<extensions>
+					<speed>2.5971879959106445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014807426247971" lon="-84.21525508968043">
+				<ele>937.8418166320771</ele>
+				<time>2017-11-20T20:07:42Z</time>
+				<extensions>
+					<speed>2.012028932571411</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01481676660018" lon="-84.21523676719018">
+				<ele>938.0934880683199</ele>
+				<time>2017-11-20T20:07:43Z</time>
+				<extensions>
+					<speed>2.018512010574341</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014821344385648" lon="-84.21521568903374">
+				<ele>938.4108580658212</ele>
+				<time>2017-11-20T20:07:44Z</time>
+				<extensions>
+					<speed>2.06540584564209</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014823666141956" lon="-84.21519466137708">
+				<ele>938.6205654172227</ele>
+				<time>2017-11-20T20:07:45Z</time>
+				<extensions>
+					<speed>2.252819299697876</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825642701206" lon="-84.21517220110523">
+				<ele>938.6684732344002</ele>
+				<time>2017-11-20T20:07:46Z</time>
+				<extensions>
+					<speed>2.3427677154541016</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014820664324846" lon="-84.21514556599386">
+				<ele>938.5784165253863</ele>
+				<time>2017-11-20T20:07:47Z</time>
+				<extensions>
+					<speed>2.4385323524475098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014814578829707" lon="-84.215117448498">
+				<ele>938.530658329837</ele>
+				<time>2017-11-20T20:07:48Z</time>
+				<extensions>
+					<speed>2.541971445083618</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014819169666499" lon="-84.21508110741621">
+				<ele>938.4835540754721</ele>
+				<time>2017-11-20T20:07:49Z</time>
+				<extensions>
+					<speed>2.94775390625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014829607931658" lon="-84.21504829514232">
+				<ele>938.6093787448481</ele>
+				<time>2017-11-20T20:07:50Z</time>
+				<extensions>
+					<speed>3.043458938598633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014838531490309" lon="-84.21501935478737">
+				<ele>938.5763117931783</ele>
+				<time>2017-11-20T20:07:51Z</time>
+				<extensions>
+					<speed>2.7562897205352783</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014845773791084" lon="-84.21499844204298">
+				<ele>938.6061339518055</ele>
+				<time>2017-11-20T20:07:52Z</time>
+				<extensions>
+					<speed>2.5216064453125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01484904610608" lon="-84.21498628617643">
+				<ele>938.6869491375983</ele>
+				<time>2017-11-20T20:07:53Z</time>
+				<extensions>
+					<speed>1.9038469791412354</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01485204942693" lon="-84.21497885706304">
+				<ele>938.635633260943</ele>
+				<time>2017-11-20T20:07:54Z</time>
+				<extensions>
+					<speed>1.1271030902862549</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014845124064609" lon="-84.21497686162307">
+				<ele>938.802045578137</ele>
+				<time>2017-11-20T20:07:55Z</time>
+				<extensions>
+					<speed>0.4365800619125366</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014845124064609" lon="-84.21497686162307">
+				<ele>938.802045578137</ele>
+				<time>2017-11-20T20:07:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014842101983216" lon="-84.21496915509002">
+				<ele>938.759572846815</ele>
+				<time>2017-11-20T20:07:57Z</time>
+				<extensions>
+					<speed>0.18741832673549652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014842101983216" lon="-84.21496915509002">
+				<ele>938.759572846815</ele>
+				<time>2017-11-20T20:07:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014842101983216" lon="-84.21496915509002">
+				<ele>938.759572846815</ele>
+				<time>2017-11-20T20:07:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01483154015977" lon="-84.21494652409541">
+				<ele>938.7397634536028</ele>
+				<time>2017-11-20T20:08:00Z</time>
+				<extensions>
+					<speed>0.6740785837173462</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014842101983216" lon="-84.21496915509002">
+				<ele>938.759572846815</ele>
+				<time>2017-11-20T20:08:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014833381346401" lon="-84.21494506223888">
+				<ele>938.6264269072562</ele>
+				<time>2017-11-20T20:08:02Z</time>
+				<extensions>
+					<speed>0.8583239316940308</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014842101983216" lon="-84.21496915509002">
+				<ele>938.759572846815</ele>
+				<time>2017-11-20T20:08:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014827753267786" lon="-84.2149445906339">
+				<ele>938.6041699172929</ele>
+				<time>2017-11-20T20:08:04Z</time>
+				<extensions>
+					<speed>0.8818870186805725</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014818913186229" lon="-84.21491396592197">
+				<ele>938.4851245898753</ele>
+				<time>2017-11-20T20:08:05Z</time>
+				<extensions>
+					<speed>1.1088604927062988</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825762119905" lon="-84.214886668705">
+				<ele>938.2362345159054</ele>
+				<time>2017-11-20T20:08:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825762119905" lon="-84.214886668705">
+				<ele>938.2362345159054</ele>
+				<time>2017-11-20T20:08:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825762119905" lon="-84.214886668705">
+				<ele>938.2362345159054</ele>
+				<time>2017-11-20T20:08:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825762119905" lon="-84.214886668705">
+				<ele>938.2362345159054</ele>
+				<time>2017-11-20T20:08:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825762119905" lon="-84.214886668705">
+				<ele>938.2362345159054</ele>
+				<time>2017-11-20T20:08:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825762119905" lon="-84.214886668705">
+				<ele>938.2362345159054</ele>
+				<time>2017-11-20T20:08:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825762119905" lon="-84.214886668705">
+				<ele>938.2362345159054</ele>
+				<time>2017-11-20T20:08:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825762119905" lon="-84.214886668705">
+				<ele>938.2362345159054</ele>
+				<time>2017-11-20T20:08:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825762119905" lon="-84.214886668705">
+				<ele>938.2362345159054</ele>
+				<time>2017-11-20T20:08:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825762119905" lon="-84.214886668705">
+				<ele>938.2362345159054</ele>
+				<time>2017-11-20T20:08:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825762119905" lon="-84.214886668705">
+				<ele>938.2362345159054</ele>
+				<time>2017-11-20T20:08:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825762119905" lon="-84.214886668705">
+				<ele>938.2362345159054</ele>
+				<time>2017-11-20T20:08:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825762119905" lon="-84.214886668705">
+				<ele>938.2362345159054</ele>
+				<time>2017-11-20T20:08:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825762119905" lon="-84.214886668705">
+				<ele>938.2362345159054</ele>
+				<time>2017-11-20T20:08:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825762119905" lon="-84.214886668705">
+				<ele>938.2362345159054</ele>
+				<time>2017-11-20T20:08:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825762119905" lon="-84.214886668705">
+				<ele>938.2362345159054</ele>
+				<time>2017-11-20T20:08:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014825762119905" lon="-84.214886668705">
+				<ele>938.2362345159054</ele>
+				<time>2017-11-20T20:08:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014833175511674" lon="-84.2148611384459">
+				<ele>938.6216188408434</ele>
+				<time>2017-11-20T20:08:23Z</time>
+				<extensions>
+					<speed>0.9453462958335876</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014844940652406" lon="-84.21482503615772">
+				<ele>939.0724760685116</ele>
+				<time>2017-11-20T20:08:24Z</time>
+				<extensions>
+					<speed>1.7579020261764526</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014862296616995" lon="-84.21479557701312">
+				<ele>939.7628107750788</ele>
+				<time>2017-11-20T20:08:25Z</time>
+				<extensions>
+					<speed>2.2271625995635986</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014885694168948" lon="-84.21477319762529">
+				<ele>940.6077753873542</ele>
+				<time>2017-11-20T20:08:26Z</time>
+				<extensions>
+					<speed>2.3054964542388916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014901739002696" lon="-84.21475941336696">
+				<ele>940.8755431855097</ele>
+				<time>2017-11-20T20:08:27Z</time>
+				<extensions>
+					<speed>2.051823854446411</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014910503060372" lon="-84.21474855015036">
+				<ele>940.7003276282921</ele>
+				<time>2017-11-20T20:08:28Z</time>
+				<extensions>
+					<speed>2.47399640083313</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014918701794501" lon="-84.21473240449541">
+				<ele>940.7825438641012</ele>
+				<time>2017-11-20T20:08:29Z</time>
+				<extensions>
+					<speed>3.011014461517334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014930786536933" lon="-84.21470139200997">
+				<ele>940.9141932576895</ele>
+				<time>2017-11-20T20:08:30Z</time>
+				<extensions>
+					<speed>3.556530714035034</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01494524969611" lon="-84.21466400488485">
+				<ele>941.1705589834601</ele>
+				<time>2017-11-20T20:08:31Z</time>
+				<extensions>
+					<speed>4.0081377029418945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014956727091187" lon="-84.21460952175245">
+				<ele>941.5462290719151</ele>
+				<time>2017-11-20T20:08:32Z</time>
+				<extensions>
+					<speed>4.770063400268555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014969733131508" lon="-84.2145588540869">
+				<ele>942.072638197802</ele>
+				<time>2017-11-20T20:08:33Z</time>
+				<extensions>
+					<speed>5.088879108428955</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0149795143613" lon="-84.21451488103033">
+				<ele>942.5055525209755</ele>
+				<time>2017-11-20T20:08:34Z</time>
+				<extensions>
+					<speed>4.937868118286133</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014979351021621" lon="-84.21445530023439">
+				<ele>943.7538235811517</ele>
+				<time>2017-11-20T20:08:35Z</time>
+				<extensions>
+					<speed>5.138428211212158</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01498518085786" lon="-84.21440219294585">
+				<ele>944.2661823695526</ele>
+				<time>2017-11-20T20:08:36Z</time>
+				<extensions>
+					<speed>5.164417266845703</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014982214640176" lon="-84.21435671134793">
+				<ele>944.5323603134602</ele>
+				<time>2017-11-20T20:08:37Z</time>
+				<extensions>
+					<speed>4.850417137145996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014988936332262" lon="-84.21430982452404">
+				<ele>944.6172407865524</ele>
+				<time>2017-11-20T20:08:38Z</time>
+				<extensions>
+					<speed>4.700077533721924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01499002106704" lon="-84.21426853439846">
+				<ele>944.7940996354446</ele>
+				<time>2017-11-20T20:08:39Z</time>
+				<extensions>
+					<speed>4.376981258392334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014995251764589" lon="-84.21423230449204">
+				<ele>944.9202588610351</ele>
+				<time>2017-11-20T20:08:40Z</time>
+				<extensions>
+					<speed>4.0912981033325195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01499484310502" lon="-84.21419454578589">
+				<ele>944.8961867503822</ele>
+				<time>2017-11-20T20:08:41Z</time>
+				<extensions>
+					<speed>3.9236338138580322</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014995091444366" lon="-84.2141555266588">
+				<ele>944.6952630020678</ele>
+				<time>2017-11-20T20:08:42Z</time>
+				<extensions>
+					<speed>3.7867586612701416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015007183539659" lon="-84.2141181497897">
+				<ele>944.7637639315799</ele>
+				<time>2017-11-20T20:08:43Z</time>
+				<extensions>
+					<speed>3.5698177814483643</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015015341698458" lon="-84.21409440632992">
+				<ele>944.6854393640533</ele>
+				<time>2017-11-20T20:08:44Z</time>
+				<extensions>
+					<speed>3.3578128814697266</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01501998904185" lon="-84.21408312607738">
+				<ele>944.7484715515748</ele>
+				<time>2017-11-20T20:08:45Z</time>
+				<extensions>
+					<speed>2.726959705352783</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015030432060133" lon="-84.21408137673355">
+				<ele>945.2413244405761</ele>
+				<time>2017-11-20T20:08:46Z</time>
+				<extensions>
+					<speed>2.216949939727783</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015031385943978" lon="-84.21408895815782">
+				<ele>945.2992320051417</ele>
+				<time>2017-11-20T20:08:47Z</time>
+				<extensions>
+					<speed>1.4075663089752197</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015031537708504" lon="-84.21409570235396">
+				<ele>945.5099846851081</ele>
+				<time>2017-11-20T20:08:48Z</time>
+				<extensions>
+					<speed>0.6511370539665222</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015031537708504" lon="-84.21409570235396">
+				<ele>945.5099846851081</ele>
+				<time>2017-11-20T20:08:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:08:50Z</time>
+				<extensions>
+					<speed>0.30385810136795044</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:08:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:08:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:08:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:08:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:08:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:08:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:08:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:08:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:08:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:09:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:09:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:09:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:09:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:09:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:09:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:09:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:09:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:09:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:09:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:09:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:09:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:09:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:09:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:09:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:09:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015037394917229" lon="-84.2140917780759">
+				<ele>945.6992480708286</ele>
+				<time>2017-11-20T20:09:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015041008951751" lon="-84.21405955883367">
+				<ele>945.2176290601492</ele>
+				<time>2017-11-20T20:09:17Z</time>
+				<extensions>
+					<speed>1.0653154850006104</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015040999528551" lon="-84.21402364527658">
+				<ele>944.575664492324</ele>
+				<time>2017-11-20T20:09:18Z</time>
+				<extensions>
+					<speed>1.555860161781311</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015073803261034" lon="-84.21399878874277">
+				<ele>944.1577095435932</ele>
+				<time>2017-11-20T20:09:19Z</time>
+				<extensions>
+					<speed>2.1082754135131836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015097547080714" lon="-84.21396387680026">
+				<ele>944.1515941768885</ele>
+				<time>2017-11-20T20:09:20Z</time>
+				<extensions>
+					<speed>2.745147943496704</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015115162573222" lon="-84.21391877102813">
+				<ele>944.0201270002872</ele>
+				<time>2017-11-20T20:09:21Z</time>
+				<extensions>
+					<speed>3.4086527824401855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01513768309099" lon="-84.21385302151744">
+				<ele>943.9842483457178</ele>
+				<time>2017-11-20T20:09:22Z</time>
+				<extensions>
+					<speed>4.473414897918701</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01517663867327" lon="-84.21376348849635">
+				<ele>944.5058315116912</ele>
+				<time>2017-11-20T20:09:23Z</time>
+				<extensions>
+					<speed>6.62558126449585</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01520094652356" lon="-84.21369180654085">
+				<ele>944.4351663729176</ele>
+				<time>2017-11-20T20:09:24Z</time>
+				<extensions>
+					<speed>7.201146602630615</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015221306396308" lon="-84.21363156671384">
+				<ele>943.8191404528916</ele>
+				<time>2017-11-20T20:09:25Z</time>
+				<extensions>
+					<speed>6.8649749755859375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015229196674506" lon="-84.21355879424947">
+				<ele>943.8850833149627</ele>
+				<time>2017-11-20T20:09:26Z</time>
+				<extensions>
+					<speed>7.046697616577148</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01523543241727" lon="-84.21348339304839">
+				<ele>944.2503481749445</ele>
+				<time>2017-11-20T20:09:27Z</time>
+				<extensions>
+					<speed>7.4095377922058105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015244902356109" lon="-84.2134207968119">
+				<ele>944.4953617174178</ele>
+				<time>2017-11-20T20:09:28Z</time>
+				<extensions>
+					<speed>6.6945085525512695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015256207689896" lon="-84.21336838604054">
+				<ele>944.5641255071387</ele>
+				<time>2017-11-20T20:09:29Z</time>
+				<extensions>
+					<speed>5.9449896812438965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01527065152314" lon="-84.21333287468232">
+				<ele>944.6669738302007</ele>
+				<time>2017-11-20T20:09:30Z</time>
+				<extensions>
+					<speed>4.33974552154541</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015283525502308" lon="-84.21332273883895">
+				<ele>945.4678052756935</ele>
+				<time>2017-11-20T20:09:31Z</time>
+				<extensions>
+					<speed>0.6081811785697937</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015293393427982" lon="-84.21333362477047">
+				<ele>945.6231339210644</ele>
+				<time>2017-11-20T20:09:32Z</time>
+				<extensions>
+					<speed>1.190777063369751</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015300316916276" lon="-84.21334975803629">
+				<ele>945.6067347303033</ele>
+				<time>2017-11-20T20:09:33Z</time>
+				<extensions>
+					<speed>1.376861572265625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015304457241331" lon="-84.21336021137475">
+				<ele>945.6610669372603</ele>
+				<time>2017-11-20T20:09:34Z</time>
+				<extensions>
+					<speed>1.157481074333191</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015312595780683" lon="-84.21336292570854">
+				<ele>945.1881930781528</ele>
+				<time>2017-11-20T20:09:35Z</time>
+				<extensions>
+					<speed>0.8582339286804199</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015312595780683" lon="-84.21336292570854">
+				<ele>945.1881930781528</ele>
+				<time>2017-11-20T20:09:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015324946212278" lon="-84.21336716673738">
+				<ele>945.0684052417055</ele>
+				<time>2017-11-20T20:09:37Z</time>
+				<extensions>
+					<speed>0.493971586227417</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015324946212278" lon="-84.21336716673738">
+				<ele>945.0684052417055</ele>
+				<time>2017-11-20T20:09:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:09:39Z</time>
+				<extensions>
+					<speed>0.19001980125904083</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:09:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:09:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:09:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:09:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:09:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:09:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:09:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:09:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:09:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:09:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:09:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:09:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:09:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:09:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:09:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:09:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:09:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:09:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:09:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015340932079436" lon="-84.21339080829935">
+				<ele>946.0011183489114</ele>
+				<time>2017-11-20T20:09:59Z</time>
+				<extensions>
+					<speed>0.7171444892883301</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:10:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:10:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:10:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:10:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:10:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:10:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:10:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:10:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:10:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:10:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:10:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:10:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:10:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015332110573963" lon="-84.21337067354138">
+				<ele>945.409061149694</ele>
+				<time>2017-11-20T20:10:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015339742680252" lon="-84.21337867405853">
+				<ele>945.5653640255332</ele>
+				<time>2017-11-20T20:10:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015339742680252" lon="-84.21337867405853">
+				<ele>945.5653640255332</ele>
+				<time>2017-11-20T20:10:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015339742680252" lon="-84.21337867405853">
+				<ele>945.5653640255332</ele>
+				<time>2017-11-20T20:10:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015339742680252" lon="-84.21337867405853">
+				<ele>945.5653640255332</ele>
+				<time>2017-11-20T20:10:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015339742680252" lon="-84.21337867405853">
+				<ele>945.5653640255332</ele>
+				<time>2017-11-20T20:10:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015339742680252" lon="-84.21337867405853">
+				<ele>945.5653640255332</ele>
+				<time>2017-11-20T20:10:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015339742680252" lon="-84.21337867405853">
+				<ele>945.5653640255332</ele>
+				<time>2017-11-20T20:10:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015339742680252" lon="-84.21337867405853">
+				<ele>945.5653640255332</ele>
+				<time>2017-11-20T20:10:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015339742680252" lon="-84.21337867405853">
+				<ele>945.5653640255332</ele>
+				<time>2017-11-20T20:10:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015339742680252" lon="-84.21337867405853">
+				<ele>945.5653640255332</ele>
+				<time>2017-11-20T20:10:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015339742680252" lon="-84.21337867405853">
+				<ele>945.5653640255332</ele>
+				<time>2017-11-20T20:10:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015339742680252" lon="-84.21337867405853">
+				<ele>945.5653640255332</ele>
+				<time>2017-11-20T20:10:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015339742680252" lon="-84.21337867405853">
+				<ele>945.5653640255332</ele>
+				<time>2017-11-20T20:10:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015339742680252" lon="-84.21337867405853">
+				<ele>945.5653640255332</ele>
+				<time>2017-11-20T20:10:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015339742680252" lon="-84.21337867405853">
+				<ele>945.5653640255332</ele>
+				<time>2017-11-20T20:10:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015338398120933" lon="-84.2133690095777">
+				<ele>945.5971748800948</ele>
+				<time>2017-11-20T20:10:29Z</time>
+				<extensions>
+					<speed>0.9205771684646606</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015339888326844" lon="-84.2133625598227">
+				<ele>945.6766700521111</ele>
+				<time>2017-11-20T20:10:30Z</time>
+				<extensions>
+					<speed>1.1840848922729492</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01534335446849" lon="-84.2133570102703">
+				<ele>945.9906230149791</ele>
+				<time>2017-11-20T20:10:31Z</time>
+				<extensions>
+					<speed>1.2396981716156006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015358339057144" lon="-84.21335689641785">
+				<ele>947.3773639090359</ele>
+				<time>2017-11-20T20:10:32Z</time>
+				<extensions>
+					<speed>1.1351019144058228</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015370678909841" lon="-84.21335493673054">
+				<ele>948.7959857340902</ele>
+				<time>2017-11-20T20:10:33Z</time>
+				<extensions>
+					<speed>1.2011970281600952</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01538086160612" lon="-84.2133425442566">
+				<ele>949.7588392542675</ele>
+				<time>2017-11-20T20:10:34Z</time>
+				<extensions>
+					<speed>1.7298316955566406</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015390640823792" lon="-84.2133237952106">
+				<ele>950.3967758202925</ele>
+				<time>2017-11-20T20:10:35Z</time>
+				<extensions>
+					<speed>2.303715705871582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015397974810462" lon="-84.21330337959154">
+				<ele>950.8871151339263</ele>
+				<time>2017-11-20T20:10:36Z</time>
+				<extensions>
+					<speed>2.4840173721313477</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01540074207835" lon="-84.21327922623007">
+				<ele>950.9546126499772</ele>
+				<time>2017-11-20T20:10:37Z</time>
+				<extensions>
+					<speed>2.639557123184204</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015405388985984" lon="-84.21325188978948">
+				<ele>950.9284996949136</ele>
+				<time>2017-11-20T20:10:38Z</time>
+				<extensions>
+					<speed>2.808042049407959</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015405773309784" lon="-84.21321684016829">
+				<ele>950.6341408779845</ele>
+				<time>2017-11-20T20:10:39Z</time>
+				<extensions>
+					<speed>3.014308452606201</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015419204133604" lon="-84.2131631103904">
+				<ele>950.0678432006389</ele>
+				<time>2017-11-20T20:10:40Z</time>
+				<extensions>
+					<speed>3.7503507137298584</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01544607235563" lon="-84.21312409804598">
+				<ele>949.9038564283401</ele>
+				<time>2017-11-20T20:10:41Z</time>
+				<extensions>
+					<speed>3.7957582473754883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01545242600056" lon="-84.21309524042307">
+				<ele>949.969537503086</ele>
+				<time>2017-11-20T20:10:42Z</time>
+				<extensions>
+					<speed>3.3453269004821777</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015449651852887" lon="-84.2130685465086">
+				<ele>950.4218249265105</ele>
+				<time>2017-11-20T20:10:43Z</time>
+				<extensions>
+					<speed>3.0319125652313232</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015445731975422" lon="-84.21305206464932">
+				<ele>950.5101341754198</ele>
+				<time>2017-11-20T20:10:44Z</time>
+				<extensions>
+					<speed>2.4683732986450195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015448899328462" lon="-84.21303227519279">
+				<ele>950.9490164145827</ele>
+				<time>2017-11-20T20:10:45Z</time>
+				<extensions>
+					<speed>2.1167004108428955</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015450640871803" lon="-84.2129979895794">
+				<ele>950.6734576141462</ele>
+				<time>2017-11-20T20:10:46Z</time>
+				<extensions>
+					<speed>2.2209513187408447</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015454646214947" lon="-84.21297064855895">
+				<ele>950.9733874388039</ele>
+				<time>2017-11-20T20:10:47Z</time>
+				<extensions>
+					<speed>2.383040428161621</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015458604740296" lon="-84.21293619480453">
+				<ele>951.7645257776603</ele>
+				<time>2017-11-20T20:10:48Z</time>
+				<extensions>
+					<speed>3.0386340618133545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015462804717457" lon="-84.2128845326472">
+				<ele>952.0822325292975</ele>
+				<time>2017-11-20T20:10:49Z</time>
+				<extensions>
+					<speed>3.9333078861236572</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01546784927447" lon="-84.21283407378664">
+				<ele>951.7319161426276</ele>
+				<time>2017-11-20T20:10:50Z</time>
+				<extensions>
+					<speed>4.325966835021973</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015474942626907" lon="-84.21278009300914">
+				<ele>951.7843347070739</ele>
+				<time>2017-11-20T20:10:51Z</time>
+				<extensions>
+					<speed>5.0912909507751465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015479876684099" lon="-84.21272059995626">
+				<ele>951.9240070283413</ele>
+				<time>2017-11-20T20:10:52Z</time>
+				<extensions>
+					<speed>5.450981616973877</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015482536550719" lon="-84.21265011918113">
+				<ele>952.2509581046179</ele>
+				<time>2017-11-20T20:10:53Z</time>
+				<extensions>
+					<speed>6.166314601898193</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015485540591774" lon="-84.21258769687945">
+				<ele>952.5870381360874</ele>
+				<time>2017-11-20T20:10:54Z</time>
+				<extensions>
+					<speed>6.273984432220459</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015501333578092" lon="-84.21251970979151">
+				<ele>952.7181886322796</ele>
+				<time>2017-11-20T20:10:55Z</time>
+				<extensions>
+					<speed>6.578470706939697</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015513525934745" lon="-84.21245498412624">
+				<ele>952.917736611329</ele>
+				<time>2017-11-20T20:10:56Z</time>
+				<extensions>
+					<speed>6.769125461578369</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015532280993039" lon="-84.21239086291062">
+				<ele>953.0352733023465</ele>
+				<time>2017-11-20T20:10:57Z</time>
+				<extensions>
+					<speed>6.938830852508545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015550599200555" lon="-84.21232685046418">
+				<ele>953.2235268456861</ele>
+				<time>2017-11-20T20:10:58Z</time>
+				<extensions>
+					<speed>7.022578716278076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015569309589548" lon="-84.21226629242757">
+				<ele>953.114017225802</ele>
+				<time>2017-11-20T20:10:59Z</time>
+				<extensions>
+					<speed>7.002150058746338</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015594526797091" lon="-84.21220730710787">
+				<ele>953.1506522018462</ele>
+				<time>2017-11-20T20:11:00Z</time>
+				<extensions>
+					<speed>7.085696220397949</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015610173729328" lon="-84.2121404739756">
+				<ele>953.1544746784493</ele>
+				<time>2017-11-20T20:11:01Z</time>
+				<extensions>
+					<speed>7.190235137939453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015626230854235" lon="-84.21207242374822">
+				<ele>953.0652786744758</ele>
+				<time>2017-11-20T20:11:02Z</time>
+				<extensions>
+					<speed>7.226299285888672</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01565231275614" lon="-84.21200343468179">
+				<ele>953.3777071908116</ele>
+				<time>2017-11-20T20:11:03Z</time>
+				<extensions>
+					<speed>7.103341579437256</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015681588568853" lon="-84.2119505341221">
+				<ele>953.7207282138988</ele>
+				<time>2017-11-20T20:11:04Z</time>
+				<extensions>
+					<speed>6.666754245758057</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015702396216653" lon="-84.21192058646614">
+				<ele>954.5860349927098</ele>
+				<time>2017-11-20T20:11:05Z</time>
+				<extensions>
+					<speed>5.086503028869629</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015733499015226" lon="-84.2119250373215">
+				<ele>955.2394872037694</ele>
+				<time>2017-11-20T20:11:06Z</time>
+				<extensions>
+					<speed>1.5513641834259033</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01574336457052" lon="-84.2119049090025">
+				<ele>955.4144150465727</ele>
+				<time>2017-11-20T20:11:07Z</time>
+				<extensions>
+					<speed>0.40749168395996094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015739951645187" lon="-84.21190913879657">
+				<ele>955.4692996935919</ele>
+				<time>2017-11-20T20:11:08Z</time>
+				<extensions>
+					<speed>1.6253396272659302</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015732784858947" lon="-84.21191640313322">
+				<ele>955.3820689534768</ele>
+				<time>2017-11-20T20:11:09Z</time>
+				<extensions>
+					<speed>1.674462080001831</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015732931679413" lon="-84.21192284204494">
+				<ele>955.4914752170444</ele>
+				<time>2017-11-20T20:11:10Z</time>
+				<extensions>
+					<speed>1.3346047401428223</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015737032885694" lon="-84.2119375261064">
+				<ele>955.8104082876816</ele>
+				<time>2017-11-20T20:11:11Z</time>
+				<extensions>
+					<speed>1.1805000305175781</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015720772032411" lon="-84.2119480889196">
+				<ele>958.4989288412035</ele>
+				<time>2017-11-20T20:11:12Z</time>
+				<extensions>
+					<speed>1.6469415426254272</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01571886636693" lon="-84.21193580739103">
+				<ele>956.8355237357318</ele>
+				<time>2017-11-20T20:11:13Z</time>
+				<extensions>
+					<speed>1.70273756980896</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015709676117254" lon="-84.21193575694778">
+				<ele>957.3056913418695</ele>
+				<time>2017-11-20T20:11:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015717948995265" lon="-84.21194380859579">
+				<ele>958.9812237517908</ele>
+				<time>2017-11-20T20:11:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015717948995265" lon="-84.21194380859579">
+				<ele>958.9812237517908</ele>
+				<time>2017-11-20T20:11:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015717948995265" lon="-84.21194380859579">
+				<ele>958.9812237517908</ele>
+				<time>2017-11-20T20:11:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015717948995265" lon="-84.21194380859579">
+				<ele>958.9812237517908</ele>
+				<time>2017-11-20T20:11:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015717948995265" lon="-84.21194380859579">
+				<ele>958.9812237517908</ele>
+				<time>2017-11-20T20:11:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015717948995265" lon="-84.21194380859579">
+				<ele>958.9812237517908</ele>
+				<time>2017-11-20T20:11:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015717948995265" lon="-84.21194380859579">
+				<ele>958.9812237517908</ele>
+				<time>2017-11-20T20:11:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015717948995265" lon="-84.21194380859579">
+				<ele>958.9812237517908</ele>
+				<time>2017-11-20T20:11:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015717948995265" lon="-84.21194380859579">
+				<ele>958.9812237517908</ele>
+				<time>2017-11-20T20:11:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015717948995265" lon="-84.21194380859579">
+				<ele>958.9812237517908</ele>
+				<time>2017-11-20T20:11:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015717948995265" lon="-84.21194380859579">
+				<ele>958.9812237517908</ele>
+				<time>2017-11-20T20:11:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015714758608231" lon="-84.21193259914807">
+				<ele>958.9032213967294</ele>
+				<time>2017-11-20T20:11:26Z</time>
+				<extensions>
+					<speed>0.6011903882026672</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015717948995265" lon="-84.21194380859579">
+				<ele>958.9812237517908</ele>
+				<time>2017-11-20T20:11:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015717948995265" lon="-84.21194380859579">
+				<ele>958.9812237517908</ele>
+				<time>2017-11-20T20:11:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015717948995265" lon="-84.21194380859579">
+				<ele>958.9812237517908</ele>
+				<time>2017-11-20T20:11:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015717948995265" lon="-84.21194380859579">
+				<ele>958.9812237517908</ele>
+				<time>2017-11-20T20:11:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015717948995265" lon="-84.21194380859579">
+				<ele>958.9812237517908</ele>
+				<time>2017-11-20T20:11:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015717948995265" lon="-84.21194380859579">
+				<ele>958.9812237517908</ele>
+				<time>2017-11-20T20:11:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015727131920478" lon="-84.2119288175257">
+				<ele>958.9953171676025</ele>
+				<time>2017-11-20T20:11:33Z</time>
+				<extensions>
+					<speed>1.1248122453689575</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015735336962237" lon="-84.2119050059705">
+				<ele>959.0379888508469</ele>
+				<time>2017-11-20T20:11:34Z</time>
+				<extensions>
+					<speed>1.9671621322631836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015748792754756" lon="-84.21188642403847">
+				<ele>959.2060954291373</ele>
+				<time>2017-11-20T20:11:35Z</time>
+				<extensions>
+					<speed>2.447472333908081</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015753074429426" lon="-84.2118512684373">
+				<ele>959.5805202294141</ele>
+				<time>2017-11-20T20:11:36Z</time>
+				<extensions>
+					<speed>3.2585222721099854</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015779574831393" lon="-84.21180863280878">
+				<ele>959.7087438628078</ele>
+				<time>2017-11-20T20:11:37Z</time>
+				<extensions>
+					<speed>4.098163604736328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015800051001014" lon="-84.21176904720497">
+				<ele>959.6025458788499</ele>
+				<time>2017-11-20T20:11:38Z</time>
+				<extensions>
+					<speed>4.556602478027344</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01581540914897" lon="-84.21173178715783">
+				<ele>959.7103747194633</ele>
+				<time>2017-11-20T20:11:39Z</time>
+				<extensions>
+					<speed>4.74616813659668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015815117997045" lon="-84.21169103949246">
+				<ele>959.5660460973158</ele>
+				<time>2017-11-20T20:11:40Z</time>
+				<extensions>
+					<speed>4.798073768615723</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015812675513876" lon="-84.21164800873024">
+				<ele>959.8258973555639</ele>
+				<time>2017-11-20T20:11:41Z</time>
+				<extensions>
+					<speed>4.802407741546631</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015812247450699" lon="-84.21161336979418">
+				<ele>960.0957052996382</ele>
+				<time>2017-11-20T20:11:42Z</time>
+				<extensions>
+					<speed>4.6747822761535645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015816563370484" lon="-84.2115757232136">
+				<ele>960.824587430805</ele>
+				<time>2017-11-20T20:11:43Z</time>
+				<extensions>
+					<speed>4.546799182891846</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01582272702346" lon="-84.21151809093708">
+				<ele>961.4344087094069</ele>
+				<time>2017-11-20T20:11:44Z</time>
+				<extensions>
+					<speed>4.749887466430664</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015820630372977" lon="-84.21147271798674">
+				<ele>961.9078216543421</ele>
+				<time>2017-11-20T20:11:45Z</time>
+				<extensions>
+					<speed>4.6692986488342285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015818888527008" lon="-84.21142792633731">
+				<ele>962.4485261915252</ele>
+				<time>2017-11-20T20:11:46Z</time>
+				<extensions>
+					<speed>4.664064884185791</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015818301353109" lon="-84.21139405793086">
+				<ele>962.8256709557027</ele>
+				<time>2017-11-20T20:11:47Z</time>
+				<extensions>
+					<speed>4.463379859924316</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015814187943924" lon="-84.21138134055009">
+				<ele>963.2978003667668</ele>
+				<time>2017-11-20T20:11:48Z</time>
+				<extensions>
+					<speed>3.96297025680542</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015817323208728" lon="-84.21135520861839">
+				<ele>963.7474596919492</ele>
+				<time>2017-11-20T20:11:49Z</time>
+				<extensions>
+					<speed>3.7636923789978027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015801023959265" lon="-84.21135208807486">
+				<ele>963.9936820175499</ele>
+				<time>2017-11-20T20:11:50Z</time>
+				<extensions>
+					<speed>3.235708475112915</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015801800765065" lon="-84.2113177683315">
+				<ele>964.252791620791</ele>
+				<time>2017-11-20T20:11:51Z</time>
+				<extensions>
+					<speed>3.246941089630127</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015804938389175" lon="-84.21131736883702">
+				<ele>964.1925249341875</ele>
+				<time>2017-11-20T20:11:52Z</time>
+				<extensions>
+					<speed>2.8139772415161133</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015788648055375" lon="-84.21132403002098">
+				<ele>963.9730918258429</ele>
+				<time>2017-11-20T20:11:53Z</time>
+				<extensions>
+					<speed>2.2757441997528076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015757246080405" lon="-84.21138213902022">
+				<ele>963.1249646535143</ele>
+				<time>2017-11-20T20:11:54Z</time>
+				<extensions>
+					<speed>1.578930377960205</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015748438742463" lon="-84.21139201091255">
+				<ele>962.8902297401801</ele>
+				<time>2017-11-20T20:11:55Z</time>
+				<extensions>
+					<speed>1.2933380603790283</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01574383365543" lon="-84.2113731698087">
+				<ele>963.0938277924433</ele>
+				<time>2017-11-20T20:11:56Z</time>
+				<extensions>
+					<speed>1.3643121719360352</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01577171439338" lon="-84.21140805685022">
+				<ele>962.9546542745084</ele>
+				<time>2017-11-20T20:11:57Z</time>
+				<extensions>
+					<speed>0.6551459431648254</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015783586160852" lon="-84.2113914997562">
+				<ele>962.4930260377005</ele>
+				<time>2017-11-20T20:11:58Z</time>
+				<extensions>
+					<speed>1.9563623666763306</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015780825863706" lon="-84.21136535446655">
+				<ele>962.6687387181446</ele>
+				<time>2017-11-20T20:11:59Z</time>
+				<extensions>
+					<speed>2.666390895843506</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015761981065511" lon="-84.21134463691041">
+				<ele>963.3353616697714</ele>
+				<time>2017-11-20T20:12:00Z</time>
+				<extensions>
+					<speed>2.811554193496704</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015731589230482" lon="-84.21132495176408">
+				<ele>963.8004115307704</ele>
+				<time>2017-11-20T20:12:01Z</time>
+				<extensions>
+					<speed>3.3461685180664063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015701209995257" lon="-84.2113132468743">
+				<ele>964.2692364593968</ele>
+				<time>2017-11-20T20:12:02Z</time>
+				<extensions>
+					<speed>3.6307144165039063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015668701125929" lon="-84.211304596128">
+				<ele>964.7907562023029</ele>
+				<time>2017-11-20T20:12:03Z</time>
+				<extensions>
+					<speed>3.821690082550049</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015624420560817" lon="-84.21130257556523">
+				<ele>965.3544942243025</ele>
+				<time>2017-11-20T20:12:04Z</time>
+				<extensions>
+					<speed>4.124942779541016</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01555137909881" lon="-84.21130285027348">
+				<ele>965.9708024701104</ele>
+				<time>2017-11-20T20:12:05Z</time>
+				<extensions>
+					<speed>5.272319316864014</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015466992949412" lon="-84.21128391552311">
+				<ele>966.5682975575328</ele>
+				<time>2017-11-20T20:12:06Z</time>
+				<extensions>
+					<speed>6.313649654388428</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015382686792924" lon="-84.21128958952299">
+				<ele>966.7574867364019</ele>
+				<time>2017-11-20T20:12:07Z</time>
+				<extensions>
+					<speed>7.312867164611816</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015298257911713" lon="-84.21127835644862">
+				<ele>967.0734911486506</ele>
+				<time>2017-11-20T20:12:08Z</time>
+				<extensions>
+					<speed>7.841999053955078</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01520113429076" lon="-84.21126254298275">
+				<ele>967.4601501598954</ele>
+				<time>2017-11-20T20:12:09Z</time>
+				<extensions>
+					<speed>8.45881175994873</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015090369597242" lon="-84.21121188656802">
+				<ele>967.8649476310238</ele>
+				<time>2017-11-20T20:12:10Z</time>
+				<extensions>
+					<speed>9.257685661315918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014938223524755" lon="-84.21107836402201">
+				<ele>967.8677593767643</ele>
+				<time>2017-11-20T20:12:11Z</time>
+				<extensions>
+					<speed>10.983148574829102</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014838243406405" lon="-84.21102902921318">
+				<ele>968.5318265222013</ele>
+				<time>2017-11-20T20:12:12Z</time>
+				<extensions>
+					<speed>11.827608108520508</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014721723138555" lon="-84.21099938903632">
+				<ele>969.0358901545405</ele>
+				<time>2017-11-20T20:12:13Z</time>
+				<extensions>
+					<speed>12.305850982666016</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014588769645272" lon="-84.21093074941074">
+				<ele>969.5563687868416</ele>
+				<time>2017-11-20T20:12:14Z</time>
+				<extensions>
+					<speed>12.933785438537598</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014471825386323" lon="-84.21086991830495">
+				<ele>969.851558174938</ele>
+				<time>2017-11-20T20:12:15Z</time>
+				<extensions>
+					<speed>13.143697738647461</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014331629731348" lon="-84.21078149176057">
+				<ele>970.1340881772339</ele>
+				<time>2017-11-20T20:12:16Z</time>
+				<extensions>
+					<speed>13.694271087646484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014215657619847" lon="-84.21070897804078">
+				<ele>970.38229657989</ele>
+				<time>2017-11-20T20:12:17Z</time>
+				<extensions>
+					<speed>13.587257385253906</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014114508770765" lon="-84.21066239845004">
+				<ele>970.6828566016629</ele>
+				<time>2017-11-20T20:12:18Z</time>
+				<extensions>
+					<speed>13.143881797790527</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014018009557756" lon="-84.21060633168112">
+				<ele>971.049690335989</ele>
+				<time>2017-11-20T20:12:19Z</time>
+				<extensions>
+					<speed>12.970268249511719</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013925824065714" lon="-84.21054383467549">
+				<ele>971.1956949643791</ele>
+				<time>2017-11-20T20:12:20Z</time>
+				<extensions>
+					<speed>12.75932502746582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013845254348434" lon="-84.21047546707274">
+				<ele>971.1601285180077</ele>
+				<time>2017-11-20T20:12:21Z</time>
+				<extensions>
+					<speed>12.485689163208008</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013768050807228" lon="-84.21041439852006">
+				<ele>971.3613400040194</ele>
+				<time>2017-11-20T20:12:22Z</time>
+				<extensions>
+					<speed>12.251042366027832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013700217767225" lon="-84.2103712809745">
+				<ele>971.5818070704117</ele>
+				<time>2017-11-20T20:12:23Z</time>
+				<extensions>
+					<speed>11.858399391174316</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013626626679711" lon="-84.2103355939715">
+				<ele>971.5093864630908</ele>
+				<time>2017-11-20T20:12:24Z</time>
+				<extensions>
+					<speed>11.566545486450195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013557238744754" lon="-84.21030931239004">
+				<ele>971.5143832359463</ele>
+				<time>2017-11-20T20:12:25Z</time>
+				<extensions>
+					<speed>11.35351276397705</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013479351132307" lon="-84.21027896486275">
+				<ele>971.171049377881</ele>
+				<time>2017-11-20T20:12:26Z</time>
+				<extensions>
+					<speed>11.415214538574219</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013393779302028" lon="-84.2102399860085">
+				<ele>971.1088595492765</ele>
+				<time>2017-11-20T20:12:27Z</time>
+				<extensions>
+					<speed>11.460282325744629</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013310457348874" lon="-84.21019143548983">
+				<ele>970.9703966574743</ele>
+				<time>2017-11-20T20:12:28Z</time>
+				<extensions>
+					<speed>11.418191909790039</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013229181077634" lon="-84.21015674781279">
+				<ele>971.0827940106392</ele>
+				<time>2017-11-20T20:12:29Z</time>
+				<extensions>
+					<speed>11.30091381072998</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013146308243869" lon="-84.21013167509982">
+				<ele>971.0256313746795</ele>
+				<time>2017-11-20T20:12:30Z</time>
+				<extensions>
+					<speed>11.125143051147461</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013069838639494" lon="-84.21011384458166">
+				<ele>970.6257606791332</ele>
+				<time>2017-11-20T20:12:31Z</time>
+				<extensions>
+					<speed>11.045318603515625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012993501105308" lon="-84.21010012493024">
+				<ele>970.086265523918</ele>
+				<time>2017-11-20T20:12:32Z</time>
+				<extensions>
+					<speed>10.987020492553711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01291339340947" lon="-84.21008188841422">
+				<ele>969.663112796843</ele>
+				<time>2017-11-20T20:12:33Z</time>
+				<extensions>
+					<speed>10.832504272460938</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012836368246171" lon="-84.21006219978867">
+				<ele>968.6528375027701</ele>
+				<time>2017-11-20T20:12:34Z</time>
+				<extensions>
+					<speed>10.604144096374512</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01276100922612" lon="-84.2100423047244">
+				<ele>968.1950034582987</ele>
+				<time>2017-11-20T20:12:35Z</time>
+				<extensions>
+					<speed>10.224959373474121</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012693224519607" lon="-84.21003125431413">
+				<ele>967.9815050261095</ele>
+				<time>2017-11-20T20:12:36Z</time>
+				<extensions>
+					<speed>9.558917045593262</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012628235138717" lon="-84.21003004443311">
+				<ele>967.1814100341871</ele>
+				<time>2017-11-20T20:12:37Z</time>
+				<extensions>
+					<speed>8.958417892456055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012563789142058" lon="-84.21003716904464">
+				<ele>966.4414084367454</ele>
+				<time>2017-11-20T20:12:38Z</time>
+				<extensions>
+					<speed>8.584822654724121</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012510323513773" lon="-84.21003833094592">
+				<ele>965.7399202156812</ele>
+				<time>2017-11-20T20:12:39Z</time>
+				<extensions>
+					<speed>8.159581184387207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012468076925218" lon="-84.21004791454101">
+				<ele>965.3819073932245</ele>
+				<time>2017-11-20T20:12:40Z</time>
+				<extensions>
+					<speed>7.393125534057617</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01243624078473" lon="-84.21006319589361">
+				<ele>964.7189143532887</ele>
+				<time>2017-11-20T20:12:41Z</time>
+				<extensions>
+					<speed>6.6603498458862305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012415310293447" lon="-84.21010630984632">
+				<ele>963.7539632879198</ele>
+				<time>2017-11-20T20:12:42Z</time>
+				<extensions>
+					<speed>5.919034957885742</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012374909154637" lon="-84.2101488668111">
+				<ele>962.5363022014499</ele>
+				<time>2017-11-20T20:12:43Z</time>
+				<extensions>
+					<speed>5.636728286743164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012343969475388" lon="-84.21019095566085">
+				<ele>960.7984577091411</ele>
+				<time>2017-11-20T20:12:44Z</time>
+				<extensions>
+					<speed>5.346487045288086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012317825861352" lon="-84.21024236305584">
+				<ele>959.932043781504</ele>
+				<time>2017-11-20T20:12:45Z</time>
+				<extensions>
+					<speed>5.1332478523254395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012300994926413" lon="-84.21027999310714">
+				<ele>959.8795406287536</ele>
+				<time>2017-11-20T20:12:46Z</time>
+				<extensions>
+					<speed>4.319080352783203</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012269852822541" lon="-84.21032092199046">
+				<ele>959.7198800304905</ele>
+				<time>2017-11-20T20:12:47Z</time>
+				<extensions>
+					<speed>4.3013386726379395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012242859693853" lon="-84.21039476007805">
+				<ele>958.9998418865725</ele>
+				<time>2017-11-20T20:12:48Z</time>
+				<extensions>
+					<speed>4.537370204925537</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012215056869174" lon="-84.21047460549269">
+				<ele>957.9855456165969</ele>
+				<time>2017-11-20T20:12:49Z</time>
+				<extensions>
+					<speed>4.527205944061279</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012188768897241" lon="-84.21052996160587">
+				<ele>957.9893007483333</ele>
+				<time>2017-11-20T20:12:50Z</time>
+				<extensions>
+					<speed>4.577050685882568</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012214084886876" lon="-84.21058904732831">
+				<ele>958.1806062888354</ele>
+				<time>2017-11-20T20:12:51Z</time>
+				<extensions>
+					<speed>4.340204238891602</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012231032760168" lon="-84.21065562252423">
+				<ele>958.4835357423872</ele>
+				<time>2017-11-20T20:12:52Z</time>
+				<extensions>
+					<speed>4.433010578155518</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012279681687831" lon="-84.21072602142965">
+				<ele>958.5706522604451</ele>
+				<time>2017-11-20T20:12:53Z</time>
+				<extensions>
+					<speed>4.515517234802246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012317227750584" lon="-84.2107464191693">
+				<ele>958.3604017533362</ele>
+				<time>2017-11-20T20:12:54Z</time>
+				<extensions>
+					<speed>3.8552277088165283</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012377975836904" lon="-84.21078823891233">
+				<ele>957.6632883623242</ele>
+				<time>2017-11-20T20:12:55Z</time>
+				<extensions>
+					<speed>3.3656718730926514</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012397295991658" lon="-84.21078498179062">
+				<ele>957.1106339460239</ele>
+				<time>2017-11-20T20:12:56Z</time>
+				<extensions>
+					<speed>2.077324628829956</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012408476335917" lon="-84.21077399733265">
+				<ele>956.9461833704263</ele>
+				<time>2017-11-20T20:12:57Z</time>
+				<extensions>
+					<speed>0.998310923576355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012408042413451" lon="-84.21075410321944">
+				<ele>957.1801550881937</ele>
+				<time>2017-11-20T20:12:58Z</time>
+				<extensions>
+					<speed>0.4667735695838928</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012402900255886" lon="-84.210741181837">
+				<ele>957.4850321114063</ele>
+				<time>2017-11-20T20:12:59Z</time>
+				<extensions>
+					<speed>0.2155607044696808</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012393109331994" lon="-84.21071902338964">
+				<ele>958.0845495108515</ele>
+				<time>2017-11-20T20:13:00Z</time>
+				<extensions>
+					<speed>0.2698897123336792</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012393109331994" lon="-84.21071902338964">
+				<ele>958.0845495108515</ele>
+				<time>2017-11-20T20:13:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012393109331994" lon="-84.21071902338964">
+				<ele>958.0845495108515</ele>
+				<time>2017-11-20T20:13:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012387833392783" lon="-84.21071016825432">
+				<ele>958.0046552820131</ele>
+				<time>2017-11-20T20:13:03Z</time>
+				<extensions>
+					<speed>0.7389656901359558</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012376392626653" lon="-84.21070315989961">
+				<ele>957.70674708765</ele>
+				<time>2017-11-20T20:13:04Z</time>
+				<extensions>
+					<speed>1.0357898473739624</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012363239728288" lon="-84.2107144773854">
+				<ele>957.2115857396275</ele>
+				<time>2017-11-20T20:13:05Z</time>
+				<extensions>
+					<speed>1.4690091609954834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01234906548619" lon="-84.21072301217691">
+				<ele>957.0797345936298</ele>
+				<time>2017-11-20T20:13:06Z</time>
+				<extensions>
+					<speed>1.6236584186553955</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012334567246105" lon="-84.21074409006361">
+				<ele>957.0490320809186</ele>
+				<time>2017-11-20T20:13:07Z</time>
+				<extensions>
+					<speed>1.8391528129577637</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012325610271017" lon="-84.21077057503986">
+				<ele>956.8905569752678</ele>
+				<time>2017-11-20T20:13:08Z</time>
+				<extensions>
+					<speed>2.031370162963867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012289453331691" lon="-84.21082452238834">
+				<ele>956.3637686930597</ele>
+				<time>2017-11-20T20:13:09Z</time>
+				<extensions>
+					<speed>2.933476448059082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01223103604349" lon="-84.21092043865299">
+				<ele>955.6333754220977</ele>
+				<time>2017-11-20T20:13:10Z</time>
+				<extensions>
+					<speed>4.6014790534973145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012185442684059" lon="-84.21102372340624">
+				<ele>954.6755391657352</ele>
+				<time>2017-11-20T20:13:11Z</time>
+				<extensions>
+					<speed>6.301459312438965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012149150536633" lon="-84.21117086207136">
+				<ele>953.8341194866225</ele>
+				<time>2017-11-20T20:13:12Z</time>
+				<extensions>
+					<speed>9.05521297454834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012112716166584" lon="-84.2112967808685">
+				<ele>953.6543846689165</ele>
+				<time>2017-11-20T20:13:13Z</time>
+				<extensions>
+					<speed>10.536439895629883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012082118410854" lon="-84.21142904384183">
+				<ele>953.8651445154101</ele>
+				<time>2017-11-20T20:13:14Z</time>
+				<extensions>
+					<speed>11.609413146972656</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012052310479364" lon="-84.21158618393767">
+				<ele>954.4060923056677</ele>
+				<time>2017-11-20T20:13:15Z</time>
+				<extensions>
+					<speed>12.546773910522461</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012024213308774" lon="-84.21173229445597">
+				<ele>954.6934995213524</ele>
+				<time>2017-11-20T20:13:16Z</time>
+				<extensions>
+					<speed>13.031749725341797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011995438994015" lon="-84.21186630633194">
+				<ele>954.7016888437793</ele>
+				<time>2017-11-20T20:13:17Z</time>
+				<extensions>
+					<speed>13.215251922607422</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011965149397671" lon="-84.21200031839554">
+				<ele>954.7537492485717</ele>
+				<time>2017-11-20T20:13:18Z</time>
+				<extensions>
+					<speed>13.341970443725586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011936943570799" lon="-84.21214291169943">
+				<ele>954.8935941569507</ele>
+				<time>2017-11-20T20:13:19Z</time>
+				<extensions>
+					<speed>13.175169944763184</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011925457354234" lon="-84.21226237227613">
+				<ele>954.7658403906971</ele>
+				<time>2017-11-20T20:13:20Z</time>
+				<extensions>
+					<speed>12.724950790405273</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011904289278672" lon="-84.21236591798254">
+				<ele>954.4392500566319</ele>
+				<time>2017-11-20T20:13:21Z</time>
+				<extensions>
+					<speed>12.299306869506836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011880252035859" lon="-84.21245206628058">
+				<ele>953.9773601759225</ele>
+				<time>2017-11-20T20:13:22Z</time>
+				<extensions>
+					<speed>11.746684074401855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011858903348333" lon="-84.21251937194387">
+				<ele>953.522160208784</ele>
+				<time>2017-11-20T20:13:23Z</time>
+				<extensions>
+					<speed>11.000396728515625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011840436641062" lon="-84.21257480698786">
+				<ele>953.5801974488422</ele>
+				<time>2017-11-20T20:13:24Z</time>
+				<extensions>
+					<speed>10.17710018157959</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011823576930087" lon="-84.21260587079644">
+				<ele>953.7080545648932</ele>
+				<time>2017-11-20T20:13:25Z</time>
+				<extensions>
+					<speed>9.061877250671387</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011826003236417" lon="-84.21260819077233">
+				<ele>954.6287854434922</ele>
+				<time>2017-11-20T20:13:26Z</time>
+				<extensions>
+					<speed>7.203524589538574</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011847285921899" lon="-84.2126121907441">
+				<ele>956.3261312954128</ele>
+				<time>2017-11-20T20:13:27Z</time>
+				<extensions>
+					<speed>5.296172618865967</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011856329141564" lon="-84.2125936940025">
+				<ele>957.7890935856849</ele>
+				<time>2017-11-20T20:13:28Z</time>
+				<extensions>
+					<speed>3.1164262294769287</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011872229684197" lon="-84.2125580177012">
+				<ele>958.2332424987108</ele>
+				<time>2017-11-20T20:13:29Z</time>
+				<extensions>
+					<speed>0.9972692131996155</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011879473083033" lon="-84.21252300701718">
+				<ele>958.469113281928</ele>
+				<time>2017-11-20T20:13:30Z</time>
+				<extensions>
+					<speed>0.7014859318733215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01189454685558" lon="-84.21250430708069">
+				<ele>958.6489582583308</ele>
+				<time>2017-11-20T20:13:31Z</time>
+				<extensions>
+					<speed>1.158008337020874</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011904928213761" lon="-84.21249429036386">
+				<ele>958.2755073932931</ele>
+				<time>2017-11-20T20:13:32Z</time>
+				<extensions>
+					<speed>1.1412065029144287</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011911850595206" lon="-84.21248468479193">
+				<ele>958.0904319407418</ele>
+				<time>2017-11-20T20:13:33Z</time>
+				<extensions>
+					<speed>1.0099328756332397</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01192011022395" lon="-84.21247636442105">
+				<ele>957.8887888556346</ele>
+				<time>2017-11-20T20:13:34Z</time>
+				<extensions>
+					<speed>0.9264430999755859</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01192011022395" lon="-84.21247636442105">
+				<ele>957.8887888556346</ele>
+				<time>2017-11-20T20:13:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011924074508357" lon="-84.21247679669025">
+				<ele>957.6972511745989</ele>
+				<time>2017-11-20T20:13:36Z</time>
+				<extensions>
+					<speed>0.4888651371002197</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011924074508357" lon="-84.21247679669025">
+				<ele>957.6972511745989</ele>
+				<time>2017-11-20T20:13:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:38Z</time>
+				<extensions>
+					<speed>0.06142927706241608</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:13:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:14:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:14:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:14:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:14:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:14:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:14:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:14:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:14:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:14:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:14:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:14:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:14:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:14:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:14:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011926218725414" lon="-84.21249218678265">
+				<ele>957.3306796066463</ele>
+				<time>2017-11-20T20:14:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011919989909757" lon="-84.21248106596678">
+				<ele>957.4776672488078</ele>
+				<time>2017-11-20T20:14:15Z</time>
+				<extensions>
+					<speed>0.6139346361160278</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011905957926825" lon="-84.21250267787543">
+				<ele>957.324316249229</ele>
+				<time>2017-11-20T20:14:16Z</time>
+				<extensions>
+					<speed>0.9467500448226929</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011895411048426" lon="-84.2125258196631">
+				<ele>957.188130791299</ele>
+				<time>2017-11-20T20:14:17Z</time>
+				<extensions>
+					<speed>1.17467200756073</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011885132164926" lon="-84.21254028451638">
+				<ele>956.9937784960493</ele>
+				<time>2017-11-20T20:14:18Z</time>
+				<extensions>
+					<speed>1.3151243925094604</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011874718309008" lon="-84.21259258727724">
+				<ele>956.3181587718427</ele>
+				<time>2017-11-20T20:14:19Z</time>
+				<extensions>
+					<speed>1.6836131811141968</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01185927195621" lon="-84.21263414964761">
+				<ele>955.4415918365121</ele>
+				<time>2017-11-20T20:14:20Z</time>
+				<extensions>
+					<speed>2.1259703636169434</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01182755320194" lon="-84.21272875922836">
+				<ele>954.073688108474</ele>
+				<time>2017-11-20T20:14:21Z</time>
+				<extensions>
+					<speed>3.6752662658691406</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011798213194131" lon="-84.21282796932655">
+				<ele>952.7925917329267</ele>
+				<time>2017-11-20T20:14:22Z</time>
+				<extensions>
+					<speed>4.7614426612854</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011775803642076" lon="-84.21289288032082">
+				<ele>951.316308750771</ele>
+				<time>2017-11-20T20:14:23Z</time>
+				<extensions>
+					<speed>5.403386116027832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011764763279224" lon="-84.21301064918154">
+				<ele>950.1306087998673</ele>
+				<time>2017-11-20T20:14:24Z</time>
+				<extensions>
+					<speed>6.547863006591797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01174486737732" lon="-84.21308941237041">
+				<ele>949.9630397502333</ele>
+				<time>2017-11-20T20:14:25Z</time>
+				<extensions>
+					<speed>6.988344669342041</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011719582554393" lon="-84.21317271897762">
+				<ele>949.5943656964228</ele>
+				<time>2017-11-20T20:14:26Z</time>
+				<extensions>
+					<speed>7.522173881530762</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011687864900761" lon="-84.2132653101534">
+				<ele>949.0180774368346</ele>
+				<time>2017-11-20T20:14:27Z</time>
+				<extensions>
+					<speed>8.102228164672852</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011656759992738" lon="-84.21335137677005">
+				<ele>948.4680777806789</ele>
+				<time>2017-11-20T20:14:28Z</time>
+				<extensions>
+					<speed>8.48193645477295</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011630360656266" lon="-84.21344577458817">
+				<ele>948.4353014994413</ele>
+				<time>2017-11-20T20:14:29Z</time>
+				<extensions>
+					<speed>8.784700393676758</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011605260200932" lon="-84.21352739028177">
+				<ele>948.4590888228267</ele>
+				<time>2017-11-20T20:14:30Z</time>
+				<extensions>
+					<speed>8.83467960357666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011583550959596" lon="-84.21361260954039">
+				<ele>948.5056684529409</ele>
+				<time>2017-11-20T20:14:31Z</time>
+				<extensions>
+					<speed>8.92575454711914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011563767302443" lon="-84.21369441487299">
+				<ele>948.5515882018954</ele>
+				<time>2017-11-20T20:14:32Z</time>
+				<extensions>
+					<speed>8.904972076416016</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011540868291485" lon="-84.21377611481245">
+				<ele>948.5511112166569</ele>
+				<time>2017-11-20T20:14:33Z</time>
+				<extensions>
+					<speed>8.890729904174805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011523412351515" lon="-84.21386297773358">
+				<ele>948.6981934038922</ele>
+				<time>2017-11-20T20:14:34Z</time>
+				<extensions>
+					<speed>8.972188949584961</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011515803774985" lon="-84.21391884482699">
+				<ele>948.8783030593768</ele>
+				<time>2017-11-20T20:14:35Z</time>
+				<extensions>
+					<speed>8.597879409790039</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011506628467314" lon="-84.21398037343904">
+				<ele>949.0082523571327</ele>
+				<time>2017-11-20T20:14:36Z</time>
+				<extensions>
+					<speed>8.381467819213867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01150069147692" lon="-84.21401129392929">
+				<ele>949.4302378548309</ele>
+				<time>2017-11-20T20:14:37Z</time>
+				<extensions>
+					<speed>7.763228416442871</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011490763689709" lon="-84.21401161779154">
+				<ele>949.7499173851684</ele>
+				<time>2017-11-20T20:14:38Z</time>
+				<extensions>
+					<speed>6.894104957580566</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011501704993163" lon="-84.21397946445163">
+				<ele>950.2014096193016</ele>
+				<time>2017-11-20T20:14:39Z</time>
+				<extensions>
+					<speed>5.5676350593566895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011495292964057" lon="-84.2139653622192">
+				<ele>950.0058330185711</ele>
+				<time>2017-11-20T20:14:40Z</time>
+				<extensions>
+					<speed>4.724532604217529</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011490200700898" lon="-84.21391366006378">
+				<ele>949.9355838829651</ele>
+				<time>2017-11-20T20:14:41Z</time>
+				<extensions>
+					<speed>3.1906142234802246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011498472064794" lon="-84.21391357535249">
+				<ele>949.8728457698599</ele>
+				<time>2017-11-20T20:14:42Z</time>
+				<extensions>
+					<speed>2.51347017288208</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011524037802687" lon="-84.21391782418544">
+				<ele>949.8413880513981</ele>
+				<time>2017-11-20T20:14:43Z</time>
+				<extensions>
+					<speed>2.0935704708099365</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011517372473397" lon="-84.21389956191794">
+				<ele>949.9284365782514</ele>
+				<time>2017-11-20T20:14:44Z</time>
+				<extensions>
+					<speed>1.573042392730713</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011550215657927" lon="-84.21390946365386">
+				<ele>949.8386806054041</ele>
+				<time>2017-11-20T20:14:45Z</time>
+				<extensions>
+					<speed>1.4876117706298828</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01153618594228" lon="-84.21391306237922">
+				<ele>949.8004098394886</ele>
+				<time>2017-11-20T20:14:46Z</time>
+				<extensions>
+					<speed>1.3088895082473755</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01147932615566" lon="-84.213932637487">
+				<ele>949.8689824268222</ele>
+				<time>2017-11-20T20:14:47Z</time>
+				<extensions>
+					<speed>2.1794657707214355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011409945136231" lon="-84.21396470860508">
+				<ele>950.0836451398209</ele>
+				<time>2017-11-20T20:14:48Z</time>
+				<extensions>
+					<speed>4.681593894958496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011346650234268" lon="-84.21398516737429">
+				<ele>949.9794058687985</ele>
+				<time>2017-11-20T20:14:49Z</time>
+				<extensions>
+					<speed>6.407474517822266</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011246951174959" lon="-84.21397952556391">
+				<ele>949.9982543177903</ele>
+				<time>2017-11-20T20:14:50Z</time>
+				<extensions>
+					<speed>8.547073364257813</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011142417658213" lon="-84.21395824346087">
+				<ele>949.8628191715106</ele>
+				<time>2017-11-20T20:14:51Z</time>
+				<extensions>
+					<speed>9.013973236083984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011049326556602" lon="-84.2139483516586">
+				<ele>949.6708338735625</ele>
+				<time>2017-11-20T20:14:52Z</time>
+				<extensions>
+					<speed>9.279221534729004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01096252212748" lon="-84.21397161255491">
+				<ele>950.0831784019247</ele>
+				<time>2017-11-20T20:14:53Z</time>
+				<extensions>
+					<speed>9.473146438598633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010848007441178" lon="-84.21393266458348">
+				<ele>950.4789158171043</ele>
+				<time>2017-11-20T20:14:54Z</time>
+				<extensions>
+					<speed>10.203927993774414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010738809938434" lon="-84.21387881620178">
+				<ele>950.3656321996823</ele>
+				<time>2017-11-20T20:14:55Z</time>
+				<extensions>
+					<speed>10.593755722045898</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010627304576033" lon="-84.21381485734672">
+				<ele>949.9317226735875</ele>
+				<time>2017-11-20T20:14:56Z</time>
+				<extensions>
+					<speed>10.145451545715332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01052455151615" lon="-84.21377007050233">
+				<ele>949.4083570837975</ele>
+				<time>2017-11-20T20:14:57Z</time>
+				<extensions>
+					<speed>9.910061836242676</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010431269868382" lon="-84.21373710165034">
+				<ele>949.1680936831981</ele>
+				<time>2017-11-20T20:14:58Z</time>
+				<extensions>
+					<speed>9.659119606018066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01034792485225" lon="-84.21370073675838">
+				<ele>949.1654880233109</ele>
+				<time>2017-11-20T20:14:59Z</time>
+				<extensions>
+					<speed>9.51724624633789</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010253379601004" lon="-84.21362879846056">
+				<ele>948.8582844464108</ele>
+				<time>2017-11-20T20:15:00Z</time>
+				<extensions>
+					<speed>9.476338386535645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010168984159066" lon="-84.21354895922283">
+				<ele>948.533032502979</ele>
+				<time>2017-11-20T20:15:01Z</time>
+				<extensions>
+					<speed>9.31623363494873</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010088273610505" lon="-84.2134779898817">
+				<ele>948.1601644624025</ele>
+				<time>2017-11-20T20:15:02Z</time>
+				<extensions>
+					<speed>9.225353240966797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009997406683832" lon="-84.21338391449773">
+				<ele>947.7878838256001</ele>
+				<time>2017-11-20T20:15:03Z</time>
+				<extensions>
+					<speed>9.345067024230957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00992107201279" lon="-84.21331752261712">
+				<ele>947.7351551791653</ele>
+				<time>2017-11-20T20:15:04Z</time>
+				<extensions>
+					<speed>9.298190116882324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00986596655586" lon="-84.213253317679">
+				<ele>947.6393025545403</ele>
+				<time>2017-11-20T20:15:05Z</time>
+				<extensions>
+					<speed>9.067235946655273</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009800001216973" lon="-84.21315574792193">
+				<ele>947.2868942320347</ele>
+				<time>2017-11-20T20:15:06Z</time>
+				<extensions>
+					<speed>9.039661407470703</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009779237316895" lon="-84.21306879070164">
+				<ele>946.7769399974495</ele>
+				<time>2017-11-20T20:15:07Z</time>
+				<extensions>
+					<speed>8.38089656829834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009741097247923" lon="-84.21294281287436">
+				<ele>946.2324676187709</ele>
+				<time>2017-11-20T20:15:08Z</time>
+				<extensions>
+					<speed>8.272364616394043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009746457367681" lon="-84.21284502327433">
+				<ele>945.8597922921181</ele>
+				<time>2017-11-20T20:15:09Z</time>
+				<extensions>
+					<speed>7.812786102294922</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009723413596516" lon="-84.21275738225367">
+				<ele>945.4897969588637</ele>
+				<time>2017-11-20T20:15:10Z</time>
+				<extensions>
+					<speed>7.698293209075928</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009652597492675" lon="-84.2126507973368">
+				<ele>945.3476557452232</ele>
+				<time>2017-11-20T20:15:11Z</time>
+				<extensions>
+					<speed>8.034392356872559</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009802082800846" lon="-84.21265797818646">
+				<ele>945.2322227759287</ele>
+				<time>2017-11-20T20:15:12Z</time>
+				<extensions>
+					<speed>6.325555324554443</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009867365044002" lon="-84.21264948884719">
+				<ele>945.0457315128297</ele>
+				<time>2017-11-20T20:15:13Z</time>
+				<extensions>
+					<speed>5.513372421264648</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010021259159528" lon="-84.2127134802614">
+				<ele>944.6823075506836</ele>
+				<time>2017-11-20T20:15:14Z</time>
+				<extensions>
+					<speed>3.9507052898406982</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010024033373362" lon="-84.21272876908976">
+				<ele>944.4051263472065</ele>
+				<time>2017-11-20T20:15:15Z</time>
+				<extensions>
+					<speed>3.0885391235351563</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010022354995527" lon="-84.21274980747759">
+				<ele>944.2732486082241</ele>
+				<time>2017-11-20T20:15:16Z</time>
+				<extensions>
+					<speed>2.2349283695220947</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010050735855172" lon="-84.21278538362904">
+				<ele>944.0989070823416</ele>
+				<time>2017-11-20T20:15:17Z</time>
+				<extensions>
+					<speed>1.648814082145691</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010076981000987" lon="-84.21280254769015">
+				<ele>944.1531567228958</ele>
+				<time>2017-11-20T20:15:18Z</time>
+				<extensions>
+					<speed>1.6039623022079468</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010096500211752" lon="-84.21282937381675">
+				<ele>944.381529902108</ele>
+				<time>2017-11-20T20:15:19Z</time>
+				<extensions>
+					<speed>1.535569190979004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010109782872743" lon="-84.21285259000224">
+				<ele>944.5448640612885</ele>
+				<time>2017-11-20T20:15:20Z</time>
+				<extensions>
+					<speed>1.5116534233093262</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01011373671421" lon="-84.21287559782114">
+				<ele>944.6809119787067</ele>
+				<time>2017-11-20T20:15:21Z</time>
+				<extensions>
+					<speed>1.5784324407577515</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010115091401603" lon="-84.2128942691829">
+				<ele>944.8512908248231</ele>
+				<time>2017-11-20T20:15:22Z</time>
+				<extensions>
+					<speed>1.7550545930862427</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010117557025547" lon="-84.21292312501623">
+				<ele>945.7298664702103</ele>
+				<time>2017-11-20T20:15:23Z</time>
+				<extensions>
+					<speed>1.7632014751434326</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010081633667033" lon="-84.2129086930986">
+				<ele>948.9057148220018</ele>
+				<time>2017-11-20T20:15:24Z</time>
+				<extensions>
+					<speed>1.8262001276016235</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010134663977597" lon="-84.21299129071333">
+				<ele>947.6191349448636</ele>
+				<time>2017-11-20T20:15:25Z</time>
+				<extensions>
+					<speed>1.5385740995407104</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010177299207273" lon="-84.21301395071082">
+				<ele>946.2047207998112</ele>
+				<time>2017-11-20T20:15:28Z</time>
+				<extensions>
+					<speed>1.0614477396011353</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010179364480896" lon="-84.21299499669895">
+				<ele>946.984489204362</ele>
+				<time>2017-11-20T20:15:29Z</time>
+				<extensions>
+					<speed>0.5525836944580078</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010179364480896" lon="-84.21299499669895">
+				<ele>946.984489204362</ele>
+				<time>2017-11-20T20:15:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010163235956917" lon="-84.2129674768959">
+				<ele>945.8628577338532</ele>
+				<time>2017-11-20T20:15:31Z</time>
+				<extensions>
+					<speed>0.5156787633895874</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010163235956917" lon="-84.2129674768959">
+				<ele>945.8628577338532</ele>
+				<time>2017-11-20T20:15:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010149175735368" lon="-84.2129541735281">
+				<ele>946.5346760852262</ele>
+				<time>2017-11-20T20:15:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010149175735368" lon="-84.2129541735281">
+				<ele>946.5346760852262</ele>
+				<time>2017-11-20T20:15:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010149175735368" lon="-84.2129541735281">
+				<ele>946.5346760852262</ele>
+				<time>2017-11-20T20:15:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010149175735368" lon="-84.2129541735281">
+				<ele>946.5346760852262</ele>
+				<time>2017-11-20T20:15:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010149175735368" lon="-84.2129541735281">
+				<ele>946.5346760852262</ele>
+				<time>2017-11-20T20:15:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010149175735368" lon="-84.2129541735281">
+				<ele>946.5346760852262</ele>
+				<time>2017-11-20T20:15:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01014582024563" lon="-84.21294499966956">
+				<ele>946.537049818784</ele>
+				<time>2017-11-20T20:15:39Z</time>
+				<extensions>
+					<speed>0.7114633917808533</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010138153085132" lon="-84.21292898118217">
+				<ele>946.3075998555869</ele>
+				<time>2017-11-20T20:15:40Z</time>
+				<extensions>
+					<speed>1.2963365316390991</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010123558297765" lon="-84.21290908995408">
+				<ele>946.0664033629</ele>
+				<time>2017-11-20T20:15:41Z</time>
+				<extensions>
+					<speed>1.8348057270050049</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010102037317848" lon="-84.21288759055817">
+				<ele>945.876536142081</ele>
+				<time>2017-11-20T20:15:42Z</time>
+				<extensions>
+					<speed>2.307142496109009</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010081141866207" lon="-84.21286533581838">
+				<ele>945.8642293643206</ele>
+				<time>2017-11-20T20:15:43Z</time>
+				<extensions>
+					<speed>2.6509459018707275</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010047757403148" lon="-84.21283313837858">
+				<ele>945.7934340480715</ele>
+				<time>2017-11-20T20:15:44Z</time>
+				<extensions>
+					<speed>3.247499465942383</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009987677151061" lon="-84.21280697804214">
+				<ele>945.5216687275097</ele>
+				<time>2017-11-20T20:15:45Z</time>
+				<extensions>
+					<speed>4.261322021484375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009929614053673" lon="-84.21275572581224">
+				<ele>945.4452182725072</ele>
+				<time>2017-11-20T20:15:46Z</time>
+				<extensions>
+					<speed>5.658812046051025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009847877359256" lon="-84.21267781702586">
+				<ele>945.4607775136828</ele>
+				<time>2017-11-20T20:15:47Z</time>
+				<extensions>
+					<speed>7.707425594329834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009774370139372" lon="-84.21261878780942">
+				<ele>945.1888010967523</ele>
+				<time>2017-11-20T20:15:48Z</time>
+				<extensions>
+					<speed>8.194112777709961</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009703601456014" lon="-84.2125518244639">
+				<ele>944.8335681837052</ele>
+				<time>2017-11-20T20:15:49Z</time>
+				<extensions>
+					<speed>8.558892250061035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009643189006292" lon="-84.2124948016195">
+				<ele>944.5654805209488</ele>
+				<time>2017-11-20T20:15:50Z</time>
+				<extensions>
+					<speed>8.760893821716309</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009577317371672" lon="-84.21242919215248">
+				<ele>944.5258693099022</ele>
+				<time>2017-11-20T20:15:51Z</time>
+				<extensions>
+					<speed>8.7947998046875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00951261647474" lon="-84.21237078037385">
+				<ele>944.5000449698418</ele>
+				<time>2017-11-20T20:15:52Z</time>
+				<extensions>
+					<speed>8.847026824951172</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00944853232133" lon="-84.21231739449924">
+				<ele>944.5743444561958</ele>
+				<time>2017-11-20T20:15:53Z</time>
+				<extensions>
+					<speed>8.82945442199707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009377429232647" lon="-84.21226030344967">
+				<ele>944.4514204235747</ele>
+				<time>2017-11-20T20:15:54Z</time>
+				<extensions>
+					<speed>8.86489486694336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009317551343072" lon="-84.21222877911016">
+				<ele>944.0174861941487</ele>
+				<time>2017-11-20T20:15:55Z</time>
+				<extensions>
+					<speed>8.142302513122559</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009271638120046" lon="-84.21218011732148">
+				<ele>943.1329245502129</ele>
+				<time>2017-11-20T20:15:56Z</time>
+				<extensions>
+					<speed>6.703183650970459</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009228758286726" lon="-84.21213437375317">
+				<ele>942.7163740033284</ele>
+				<time>2017-11-20T20:15:57Z</time>
+				<extensions>
+					<speed>5.913120269775391</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00920040336991" lon="-84.21210386921665">
+				<ele>942.3607404455543</ele>
+				<time>2017-11-20T20:15:58Z</time>
+				<extensions>
+					<speed>4.931861877441406</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009179022645421" lon="-84.21208205646548">
+				<ele>941.9802419906482</ele>
+				<time>2017-11-20T20:15:59Z</time>
+				<extensions>
+					<speed>4.261749744415283</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009155280945295" lon="-84.21205899335935">
+				<ele>941.7146341353655</ele>
+				<time>2017-11-20T20:16:00Z</time>
+				<extensions>
+					<speed>3.9176480770111084</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009134673016987" lon="-84.21203363117581">
+				<ele>941.6554698348045</ele>
+				<time>2017-11-20T20:16:01Z</time>
+				<extensions>
+					<speed>3.7284648418426514</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00910310685018" lon="-84.21200362186869">
+				<ele>941.2433145325631</ele>
+				<time>2017-11-20T20:16:02Z</time>
+				<extensions>
+					<speed>3.9942195415496826</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009064537613723" lon="-84.2119604084123">
+				<ele>940.5523210791871</ele>
+				<time>2017-11-20T20:16:03Z</time>
+				<extensions>
+					<speed>4.5080132484436035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009021952931327" lon="-84.21190730090588">
+				<ele>939.7977251820266</ele>
+				<time>2017-11-20T20:16:04Z</time>
+				<extensions>
+					<speed>5.2952141761779785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008978225653545" lon="-84.21185751887992">
+				<ele>939.2706050714478</ele>
+				<time>2017-11-20T20:16:05Z</time>
+				<extensions>
+					<speed>6.081573009490967</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008928189702178" lon="-84.21182980064117">
+				<ele>938.7665067091584</ele>
+				<time>2017-11-20T20:16:06Z</time>
+				<extensions>
+					<speed>6.096965312957764</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008887709659929" lon="-84.21179043347065">
+				<ele>938.5181561000645</ele>
+				<time>2017-11-20T20:16:07Z</time>
+				<extensions>
+					<speed>6.264917850494385</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008865229193951" lon="-84.21174164171852">
+				<ele>938.0777704324573</ele>
+				<time>2017-11-20T20:16:08Z</time>
+				<extensions>
+					<speed>6.271198749542236</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008821142016032" lon="-84.21166051164185">
+				<ele>937.6549088582397</ele>
+				<time>2017-11-20T20:16:09Z</time>
+				<extensions>
+					<speed>7.668205261230469</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008775491055417" lon="-84.21156921408311">
+				<ele>937.4657176472247</ele>
+				<time>2017-11-20T20:16:10Z</time>
+				<extensions>
+					<speed>9.648138046264648</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008732024310204" lon="-84.21147312695237">
+				<ele>937.2270021252334</ele>
+				<time>2017-11-20T20:16:11Z</time>
+				<extensions>
+					<speed>9.997017860412598</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00870528476253" lon="-84.2113732858884">
+				<ele>937.2142812432721</ele>
+				<time>2017-11-20T20:16:12Z</time>
+				<extensions>
+					<speed>9.475736618041992</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008682389273874" lon="-84.21128009700357">
+				<ele>937.2770909490064</ele>
+				<time>2017-11-20T20:16:13Z</time>
+				<extensions>
+					<speed>9.082514762878418</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008670675766057" lon="-84.21118389302436">
+				<ele>937.4007682558149</ele>
+				<time>2017-11-20T20:16:14Z</time>
+				<extensions>
+					<speed>8.357597351074219</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008659888706708" lon="-84.21108933790305">
+				<ele>938.8255039760843</ele>
+				<time>2017-11-20T20:16:15Z</time>
+				<extensions>
+					<speed>7.7646565437316895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00865741760859" lon="-84.21099642885909">
+				<ele>940.3148656086996</ele>
+				<time>2017-11-20T20:16:16Z</time>
+				<extensions>
+					<speed>7.100170612335205</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008649990080377" lon="-84.21092733543078">
+				<ele>940.6576705360785</ele>
+				<time>2017-11-20T20:16:17Z</time>
+				<extensions>
+					<speed>6.329370498657227</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00863812982029" lon="-84.21087477509487">
+				<ele>939.7627522516996</ele>
+				<time>2017-11-20T20:16:18Z</time>
+				<extensions>
+					<speed>4.997832775115967</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008642874094226" lon="-84.21086126053373">
+				<ele>938.7354160360992</ele>
+				<time>2017-11-20T20:16:19Z</time>
+				<extensions>
+					<speed>4.475745677947998</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008643627806341" lon="-84.21083036866348">
+				<ele>938.4721796205267</ele>
+				<time>2017-11-20T20:16:20Z</time>
+				<extensions>
+					<speed>4.183531284332275</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008649186642513" lon="-84.21079449254722">
+				<ele>938.1181479822844</ele>
+				<time>2017-11-20T20:16:21Z</time>
+				<extensions>
+					<speed>4.401684761047363</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008654845886765" lon="-84.21075029105602">
+				<ele>937.8405345873907</ele>
+				<time>2017-11-20T20:16:22Z</time>
+				<extensions>
+					<speed>4.776340961456299</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008658278653224" lon="-84.21070206700705">
+				<ele>937.7675188388675</ele>
+				<time>2017-11-20T20:16:23Z</time>
+				<extensions>
+					<speed>5.340733051300049</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008663965223462" lon="-84.21064467805442">
+				<ele>938.3690730994567</ele>
+				<time>2017-11-20T20:16:24Z</time>
+				<extensions>
+					<speed>5.782166004180908</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008675879812312" lon="-84.21058372751038">
+				<ele>937.4919590577483</ele>
+				<time>2017-11-20T20:16:25Z</time>
+				<extensions>
+					<speed>5.791965007781982</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008676609418588" lon="-84.21052843093622">
+				<ele>936.5780782476068</ele>
+				<time>2017-11-20T20:16:26Z</time>
+				<extensions>
+					<speed>5.8695807456970215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008677586168998" lon="-84.21047838333092">
+				<ele>936.4177111405879</ele>
+				<time>2017-11-20T20:16:27Z</time>
+				<extensions>
+					<speed>5.7645416259765625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008675325458258" lon="-84.21043772339077">
+				<ele>935.7159607140347</ele>
+				<time>2017-11-20T20:16:28Z</time>
+				<extensions>
+					<speed>5.510767459869385</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008678658564579" lon="-84.21038921995384">
+				<ele>935.4502352112904</ele>
+				<time>2017-11-20T20:16:29Z</time>
+				<extensions>
+					<speed>5.362138748168945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008681385524014" lon="-84.21034511573318">
+				<ele>935.2776634693146</ele>
+				<time>2017-11-20T20:16:30Z</time>
+				<extensions>
+					<speed>5.207077980041504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00867840023557" lon="-84.2103033655243">
+				<ele>935.3037635134533</ele>
+				<time>2017-11-20T20:16:31Z</time>
+				<extensions>
+					<speed>5.0138773918151855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008677658612408" lon="-84.21026161916728">
+				<ele>935.3992691067979</ele>
+				<time>2017-11-20T20:16:32Z</time>
+				<extensions>
+					<speed>4.225931167602539</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008671067521004" lon="-84.21022814184911">
+				<ele>935.528134512715</ele>
+				<time>2017-11-20T20:16:33Z</time>
+				<extensions>
+					<speed>3.072901725769043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008668370254385" lon="-84.21020555287248">
+				<ele>935.8189611956477</ele>
+				<time>2017-11-20T20:16:34Z</time>
+				<extensions>
+					<speed>1.6606709957122803</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008660766228122" lon="-84.2101988645825">
+				<ele>935.48848150298</ele>
+				<time>2017-11-20T20:16:35Z</time>
+				<extensions>
+					<speed>0.13011659681797028</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008652014744134" lon="-84.2101963956619">
+				<ele>935.031249188818</ele>
+				<time>2017-11-20T20:16:36Z</time>
+				<extensions>
+					<speed>0.553761899471283</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008652014744134" lon="-84.2101963956619">
+				<ele>935.031249188818</ele>
+				<time>2017-11-20T20:16:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008647543658377" lon="-84.21020125939849">
+				<ele>934.9538831077516</ele>
+				<time>2017-11-20T20:16:38Z</time>
+				<extensions>
+					<speed>0.7936559319496155</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008647543658377" lon="-84.21020125939849">
+				<ele>934.9538831077516</ele>
+				<time>2017-11-20T20:16:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008637686555236" lon="-84.21020575302549">
+				<ele>934.9718148140237</ele>
+				<time>2017-11-20T20:16:40Z</time>
+				<extensions>
+					<speed>0.7856133580207825</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008637686555236" lon="-84.21020575302549">
+				<ele>934.9718148140237</ele>
+				<time>2017-11-20T20:16:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008625442255775" lon="-84.21021029599555">
+				<ele>935.1090768659487</ele>
+				<time>2017-11-20T20:16:42Z</time>
+				<extensions>
+					<speed>0.9043996930122375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008625442255775" lon="-84.21021029599555">
+				<ele>935.1090768659487</ele>
+				<time>2017-11-20T20:16:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008623537531593" lon="-84.21021520978556">
+				<ele>934.9935187138617</ele>
+				<time>2017-11-20T20:16:44Z</time>
+				<extensions>
+					<speed>0.5609539151191711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008623537531593" lon="-84.21021520978556">
+				<ele>934.9935187138617</ele>
+				<time>2017-11-20T20:16:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00862986965287" lon="-84.21022754816163">
+				<ele>934.8864789186046</ele>
+				<time>2017-11-20T20:16:46Z</time>
+				<extensions>
+					<speed>0.46634337306022644</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00862986965287" lon="-84.21022754816163">
+				<ele>934.8864789186046</ele>
+				<time>2017-11-20T20:16:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:16:48Z</time>
+				<extensions>
+					<speed>0.3486957848072052</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:16:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:16:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:16:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:16:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:16:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:16:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:16:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:16:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:16:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:16:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:16:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008640426120344" lon="-84.21023497973155">
+				<ele>934.8808881267905</ele>
+				<time>2017-11-20T20:17:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008674827547784" lon="-84.21017815814103">
+				<ele>932.549087847583</ele>
+				<time>2017-11-20T20:17:22Z</time>
+				<extensions>
+					<speed>0.9861050248146057</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008687075334274" lon="-84.21013867791862">
+				<ele>931.5219835713506</ele>
+				<time>2017-11-20T20:17:23Z</time>
+				<extensions>
+					<speed>1.873399257659912</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00869041410402" lon="-84.21010592110181">
+				<ele>931.365490809083</ele>
+				<time>2017-11-20T20:17:24Z</time>
+				<extensions>
+					<speed>2.924978256225586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00869164252303" lon="-84.21007055961411">
+				<ele>931.7115189442411</ele>
+				<time>2017-11-20T20:17:25Z</time>
+				<extensions>
+					<speed>3.6688249111175537</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008686975349175" lon="-84.2100253880716">
+				<ele>932.0316848149523</ele>
+				<time>2017-11-20T20:17:26Z</time>
+				<extensions>
+					<speed>4.606435775756836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008686496836269" lon="-84.20997213644173">
+				<ele>932.3202238893136</ele>
+				<time>2017-11-20T20:17:27Z</time>
+				<extensions>
+					<speed>5.3284687995910645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00868654391942" lon="-84.20990334252687">
+				<ele>932.5941545907408</ele>
+				<time>2017-11-20T20:17:28Z</time>
+				<extensions>
+					<speed>6.418179512023926</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00869188574128" lon="-84.20982346701139">
+				<ele>932.7452035527676</ele>
+				<time>2017-11-20T20:17:29Z</time>
+				<extensions>
+					<speed>7.6116156578063965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008693697655449" lon="-84.20973559094813">
+				<ele>933.1984264627099</ele>
+				<time>2017-11-20T20:17:30Z</time>
+				<extensions>
+					<speed>8.920719146728516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008693854992293" lon="-84.20964314719353">
+				<ele>933.3958660233766</ele>
+				<time>2017-11-20T20:17:31Z</time>
+				<extensions>
+					<speed>9.674041748046875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008695096849708" lon="-84.2095489881286">
+				<ele>934.0551838558167</ele>
+				<time>2017-11-20T20:17:32Z</time>
+				<extensions>
+					<speed>9.57794189453125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008691979976508" lon="-84.20946369638911">
+				<ele>934.340137924999</ele>
+				<time>2017-11-20T20:17:33Z</time>
+				<extensions>
+					<speed>8.646557807922363</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00869015752779" lon="-84.20939270244094">
+				<ele>934.643874344416</ele>
+				<time>2017-11-20T20:17:34Z</time>
+				<extensions>
+					<speed>7.0189080238342285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008689278630165" lon="-84.20933235252696">
+				<ele>937.1538850869983</ele>
+				<time>2017-11-20T20:17:35Z</time>
+				<extensions>
+					<speed>4.070932388305664</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008688160698915" lon="-84.20930069667585">
+				<ele>938.6817241413519</ele>
+				<time>2017-11-20T20:17:36Z</time>
+				<extensions>
+					<speed>1.4541676044464111</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008689998837623" lon="-84.20928982155392">
+				<ele>939.3440543152392</ele>
+				<time>2017-11-20T20:17:37Z</time>
+				<extensions>
+					<speed>0.6232009530067444</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008689998837623" lon="-84.20928982155392">
+				<ele>939.3440543152392</ele>
+				<time>2017-11-20T20:17:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008689696687803" lon="-84.20928430248436">
+				<ele>938.6669033607468</ele>
+				<time>2017-11-20T20:17:39Z</time>
+				<extensions>
+					<speed>1.1016203165054321</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008689957737756" lon="-84.20927176564066">
+				<ele>937.8785565849394</ele>
+				<time>2017-11-20T20:17:40Z</time>
+				<extensions>
+					<speed>1.6410518884658813</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008689353580358" lon="-84.20925771665047">
+				<ele>937.3125196825713</ele>
+				<time>2017-11-20T20:17:41Z</time>
+				<extensions>
+					<speed>1.6907504796981812</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008686334577067" lon="-84.20924230278827">
+				<ele>936.6963874958456</ele>
+				<time>2017-11-20T20:17:42Z</time>
+				<extensions>
+					<speed>2.0375845432281494</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008682799479251" lon="-84.20922225372962">
+				<ele>936.0793498819694</ele>
+				<time>2017-11-20T20:17:43Z</time>
+				<extensions>
+					<speed>2.495591163635254</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008679960270383" lon="-84.20919557309654">
+				<ele>936.0726560875773</ele>
+				<time>2017-11-20T20:17:44Z</time>
+				<extensions>
+					<speed>2.7213616371154785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008682467646043" lon="-84.20916394970345">
+				<ele>935.9980207197368</ele>
+				<time>2017-11-20T20:17:45Z</time>
+				<extensions>
+					<speed>3.171079397201538</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008683238541233" lon="-84.20912875721143">
+				<ele>935.5084657007828</ele>
+				<time>2017-11-20T20:17:46Z</time>
+				<extensions>
+					<speed>3.778201103210449</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008681699353982" lon="-84.20908572661581">
+				<ele>934.8476633951068</ele>
+				<time>2017-11-20T20:17:47Z</time>
+				<extensions>
+					<speed>4.796756267547607</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008683227456133" lon="-84.20903411764837">
+				<ele>934.060391208157</ele>
+				<time>2017-11-20T20:17:48Z</time>
+				<extensions>
+					<speed>5.959771156311035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008687027466095" lon="-84.20897109977538">
+				<ele>933.3924062205479</ele>
+				<time>2017-11-20T20:17:49Z</time>
+				<extensions>
+					<speed>6.974863529205322</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008688107616905" lon="-84.20889903687848">
+				<ele>932.6923736678436</ele>
+				<time>2017-11-20T20:17:50Z</time>
+				<extensions>
+					<speed>7.797415256500244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008687656690261" lon="-84.20882128541307">
+				<ele>932.2075038990006</ele>
+				<time>2017-11-20T20:17:51Z</time>
+				<extensions>
+					<speed>8.375981330871582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008688998528372" lon="-84.20873564601852">
+				<ele>931.4472946869209</ele>
+				<time>2017-11-20T20:17:52Z</time>
+				<extensions>
+					<speed>9.084486961364746</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00868013759218" lon="-84.2086449229971">
+				<ele>930.9465432520956</ele>
+				<time>2017-11-20T20:17:53Z</time>
+				<extensions>
+					<speed>9.719037055969238</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008668684079096" lon="-84.2085478612232">
+				<ele>930.223073082976</ele>
+				<time>2017-11-20T20:17:54Z</time>
+				<extensions>
+					<speed>10.167131423950195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008660879362305" lon="-84.20845130409818">
+				<ele>929.5981296310201</ele>
+				<time>2017-11-20T20:17:55Z</time>
+				<extensions>
+					<speed>10.258706092834473</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008658758015006" lon="-84.20835582670092">
+				<ele>928.914172295481</ele>
+				<time>2017-11-20T20:17:56Z</time>
+				<extensions>
+					<speed>10.127090454101563</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00865438726643" lon="-84.20826853465582">
+				<ele>928.4550635647029</ele>
+				<time>2017-11-20T20:17:57Z</time>
+				<extensions>
+					<speed>9.118308067321777</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008652043600097" lon="-84.20819214717102">
+				<ele>928.141150880605</ele>
+				<time>2017-11-20T20:17:58Z</time>
+				<extensions>
+					<speed>7.781325817108154</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008650502151564" lon="-84.20813082385185">
+				<ele>927.9343250654638</ele>
+				<time>2017-11-20T20:17:59Z</time>
+				<extensions>
+					<speed>6.09993314743042</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008652155689767" lon="-84.20808520555246">
+				<ele>928.000736723654</ele>
+				<time>2017-11-20T20:18:00Z</time>
+				<extensions>
+					<speed>4.149119853973389</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00865556537119" lon="-84.20805614150889">
+				<ele>927.8799274619669</ele>
+				<time>2017-11-20T20:18:01Z</time>
+				<extensions>
+					<speed>2.4602649211883545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008655958741356" lon="-84.20804399427043">
+				<ele>927.7536023659632</ele>
+				<time>2017-11-20T20:18:02Z</time>
+				<extensions>
+					<speed>0.7428629398345947</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008654128403217" lon="-84.20804252058339">
+				<ele>927.6721106162295</ele>
+				<time>2017-11-20T20:18:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008654128403217" lon="-84.20804252058339">
+				<ele>927.6721106162295</ele>
+				<time>2017-11-20T20:18:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008654128403217" lon="-84.20804252058339">
+				<ele>927.6721106162295</ele>
+				<time>2017-11-20T20:18:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008654128403217" lon="-84.20804252058339">
+				<ele>927.6721106162295</ele>
+				<time>2017-11-20T20:18:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008654128403217" lon="-84.20804252058339">
+				<ele>927.6721106162295</ele>
+				<time>2017-11-20T20:18:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008654128403217" lon="-84.20804252058339">
+				<ele>927.6721106162295</ele>
+				<time>2017-11-20T20:18:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008654128403217" lon="-84.20804252058339">
+				<ele>927.6721106162295</ele>
+				<time>2017-11-20T20:18:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008654128403217" lon="-84.20804252058339">
+				<ele>927.6721106162295</ele>
+				<time>2017-11-20T20:18:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008654128403217" lon="-84.20804252058339">
+				<ele>927.6721106162295</ele>
+				<time>2017-11-20T20:18:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008654128403217" lon="-84.20804252058339">
+				<ele>927.6721106162295</ele>
+				<time>2017-11-20T20:18:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008654128403217" lon="-84.20804252058339">
+				<ele>927.6721106162295</ele>
+				<time>2017-11-20T20:18:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008654128403217" lon="-84.20804252058339">
+				<ele>927.6721106162295</ele>
+				<time>2017-11-20T20:18:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008654128403217" lon="-84.20804252058339">
+				<ele>927.6721106162295</ele>
+				<time>2017-11-20T20:18:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00865703943951" lon="-84.20802865376001">
+				<ele>927.6570583796129</ele>
+				<time>2017-11-20T20:18:16Z</time>
+				<extensions>
+					<speed>1.5376814603805542</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00865604829912" lon="-84.20800593815483">
+				<ele>928.1390428217128</ele>
+				<time>2017-11-20T20:18:17Z</time>
+				<extensions>
+					<speed>2.1899993419647217</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008646628544613" lon="-84.20797942218486">
+				<ele>928.6622025072575</ele>
+				<time>2017-11-20T20:18:18Z</time>
+				<extensions>
+					<speed>2.6225459575653076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008633885363604" lon="-84.20795526826504">
+				<ele>928.9327825363725</ele>
+				<time>2017-11-20T20:18:19Z</time>
+				<extensions>
+					<speed>2.5268876552581787</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008622033035397" lon="-84.20793542633909">
+				<ele>928.9344209777191</ele>
+				<time>2017-11-20T20:18:20Z</time>
+				<extensions>
+					<speed>2.255978584289551</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008614180869342" lon="-84.20791672067817">
+				<ele>929.3716168422252</ele>
+				<time>2017-11-20T20:18:21Z</time>
+				<extensions>
+					<speed>2.0398733615875244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00860616595103" lon="-84.20789911078431">
+				<ele>929.6990919457749</ele>
+				<time>2017-11-20T20:18:22Z</time>
+				<extensions>
+					<speed>1.9807552099227905</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00859758637602" lon="-84.2078826427555">
+				<ele>929.93821941223</ele>
+				<time>2017-11-20T20:18:23Z</time>
+				<extensions>
+					<speed>1.9827016592025757</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008582816213835" lon="-84.20786414749769">
+				<ele>929.928439735435</ele>
+				<time>2017-11-20T20:18:24Z</time>
+				<extensions>
+					<speed>2.3398163318634033</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008553733073173" lon="-84.2078358363597">
+				<ele>929.7974033122882</ele>
+				<time>2017-11-20T20:18:25Z</time>
+				<extensions>
+					<speed>3.4114222526550293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008525462401835" lon="-84.20780884541266">
+				<ele>929.6970159662887</ele>
+				<time>2017-11-20T20:18:26Z</time>
+				<extensions>
+					<speed>4.268108367919922</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008491067562625" lon="-84.20778636735966">
+				<ele>929.5745949093252</ele>
+				<time>2017-11-20T20:18:27Z</time>
+				<extensions>
+					<speed>4.359549045562744</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008456259159278" lon="-84.20776398607653">
+				<ele>929.4519307557493</ele>
+				<time>2017-11-20T20:18:28Z</time>
+				<extensions>
+					<speed>4.4644775390625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008412687772305" lon="-84.20774692039971">
+				<ele>929.216029680334</ele>
+				<time>2017-11-20T20:18:29Z</time>
+				<extensions>
+					<speed>4.606810092926025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008365238322279" lon="-84.20772256266591">
+				<ele>929.0903287753463</ele>
+				<time>2017-11-20T20:18:30Z</time>
+				<extensions>
+					<speed>5.090713977813721</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008314567316326" lon="-84.20768886082513">
+				<ele>928.7361425925046</ele>
+				<time>2017-11-20T20:18:31Z</time>
+				<extensions>
+					<speed>5.699432849884033</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008258962030427" lon="-84.20763327575801">
+				<ele>928.3632366657257</ele>
+				<time>2017-11-20T20:18:32Z</time>
+				<extensions>
+					<speed>7.096904277801514</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00820209043624" lon="-84.20758391093388">
+				<ele>928.5008762860671</ele>
+				<time>2017-11-20T20:18:33Z</time>
+				<extensions>
+					<speed>8.072583198547363</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008139684217536" lon="-84.2075327516648">
+				<ele>928.6550214514136</ele>
+				<time>2017-11-20T20:18:34Z</time>
+				<extensions>
+					<speed>8.268289566040039</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008083497008117" lon="-84.20748351515441">
+				<ele>928.8001745278016</ele>
+				<time>2017-11-20T20:18:35Z</time>
+				<extensions>
+					<speed>8.056448936462402</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008030645970877" lon="-84.207434125863">
+				<ele>928.7033492792398</ele>
+				<time>2017-11-20T20:18:36Z</time>
+				<extensions>
+					<speed>7.8616743087768555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007975023427345" lon="-84.2073865975601">
+				<ele>928.7122338162735</ele>
+				<time>2017-11-20T20:18:37Z</time>
+				<extensions>
+					<speed>7.673745155334473</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007927742207906" lon="-84.20734390793895">
+				<ele>928.7370336344466</ele>
+				<time>2017-11-20T20:18:38Z</time>
+				<extensions>
+					<speed>7.2338056564331055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007883574387202" lon="-84.20729928198821">
+				<ele>928.8197917016223</ele>
+				<time>2017-11-20T20:18:39Z</time>
+				<extensions>
+					<speed>7.108054161071777</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007839747303645" lon="-84.20725031555592">
+				<ele>929.0460522230715</ele>
+				<time>2017-11-20T20:18:40Z</time>
+				<extensions>
+					<speed>7.034065246582031</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00780215572196" lon="-84.20720681658514">
+				<ele>929.2073962604627</ele>
+				<time>2017-11-20T20:18:41Z</time>
+				<extensions>
+					<speed>6.665046691894531</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007764660615388" lon="-84.20715986112873">
+				<ele>929.2710055280477</ele>
+				<time>2017-11-20T20:18:42Z</time>
+				<extensions>
+					<speed>6.527390956878662</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007726388548475" lon="-84.20710804313214">
+				<ele>929.3190751681104</ele>
+				<time>2017-11-20T20:18:43Z</time>
+				<extensions>
+					<speed>6.638616561889648</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007693105717262" lon="-84.20706648857438">
+				<ele>929.4252983275801</ele>
+				<time>2017-11-20T20:18:44Z</time>
+				<extensions>
+					<speed>6.323863983154297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00763433793843" lon="-84.20703809183968">
+				<ele>929.3172225300223</ele>
+				<time>2017-11-20T20:18:45Z</time>
+				<extensions>
+					<speed>6.495826244354248</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007586430335618" lon="-84.20700288887235">
+				<ele>929.2038175780326</ele>
+				<time>2017-11-20T20:18:46Z</time>
+				<extensions>
+					<speed>6.676886081695557</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00752829047091" lon="-84.20696554174258">
+				<ele>929.0110421488062</ele>
+				<time>2017-11-20T20:18:47Z</time>
+				<extensions>
+					<speed>7.148566722869873</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007469806999612" lon="-84.20692380269388">
+				<ele>928.6816610842943</ele>
+				<time>2017-11-20T20:18:48Z</time>
+				<extensions>
+					<speed>7.357215404510498</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007411395584885" lon="-84.20688133741679">
+				<ele>928.2180712437257</ele>
+				<time>2017-11-20T20:18:49Z</time>
+				<extensions>
+					<speed>7.468423366546631</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007352465756876" lon="-84.20683259915161">
+				<ele>927.845195479691</ele>
+				<time>2017-11-20T20:18:50Z</time>
+				<extensions>
+					<speed>7.724543571472168</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007288796427188" lon="-84.20678311420109">
+				<ele>927.6032358827069</ele>
+				<time>2017-11-20T20:18:51Z</time>
+				<extensions>
+					<speed>7.9631829261779785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007225342687052" lon="-84.20672803103484">
+				<ele>927.5232559936121</ele>
+				<time>2017-11-20T20:18:52Z</time>
+				<extensions>
+					<speed>8.112785339355469</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007157423176112" lon="-84.20666412122759">
+				<ele>927.9295232053846</ele>
+				<time>2017-11-20T20:18:53Z</time>
+				<extensions>
+					<speed>8.387036323547363</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007088054946149" lon="-84.20660260689132">
+				<ele>928.3688968373463</ele>
+				<time>2017-11-20T20:18:54Z</time>
+				<extensions>
+					<speed>8.6070556640625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007014967192044" lon="-84.20654257720541">
+				<ele>928.5606584856287</ele>
+				<time>2017-11-20T20:18:55Z</time>
+				<extensions>
+					<speed>8.821496963500977</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006948917917832" lon="-84.20648519981943">
+				<ele>928.6476255794987</ele>
+				<time>2017-11-20T20:18:56Z</time>
+				<extensions>
+					<speed>8.88598346710205</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006889015722916" lon="-84.20642815051129">
+				<ele>928.5198621805757</ele>
+				<time>2017-11-20T20:18:57Z</time>
+				<extensions>
+					<speed>8.878243446350098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006828765044757" lon="-84.20637040479482">
+				<ele>928.1526984507218</ele>
+				<time>2017-11-20T20:18:58Z</time>
+				<extensions>
+					<speed>8.964360237121582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006759393982968" lon="-84.20630976983254">
+				<ele>927.8286697212607</ele>
+				<time>2017-11-20T20:18:59Z</time>
+				<extensions>
+					<speed>9.190412521362305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006691461635215" lon="-84.20625694766106">
+				<ele>927.554134032689</ele>
+				<time>2017-11-20T20:19:00Z</time>
+				<extensions>
+					<speed>9.345123291015625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006628540687574" lon="-84.20620627695132">
+				<ele>927.4708260549232</ele>
+				<time>2017-11-20T20:19:01Z</time>
+				<extensions>
+					<speed>9.31279468536377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006566449160283" lon="-84.20615666662269">
+				<ele>927.4669697787613</ele>
+				<time>2017-11-20T20:19:02Z</time>
+				<extensions>
+					<speed>9.25571346282959</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006499527399383" lon="-84.20611782263703">
+				<ele>927.2777572255582</ele>
+				<time>2017-11-20T20:19:03Z</time>
+				<extensions>
+					<speed>9.219476699829102</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006424728929485" lon="-84.20607615476214">
+				<ele>927.11253506504</ele>
+				<time>2017-11-20T20:19:04Z</time>
+				<extensions>
+					<speed>9.423333168029785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006361436025715" lon="-84.20603589511192">
+				<ele>926.9796360228211</ele>
+				<time>2017-11-20T20:19:05Z</time>
+				<extensions>
+					<speed>9.342158317565918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006303769539361" lon="-84.20599897098653">
+				<ele>927.1495511839166</ele>
+				<time>2017-11-20T20:19:06Z</time>
+				<extensions>
+					<speed>9.329334259033203</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006249984573747" lon="-84.20594815705228">
+				<ele>927.382722504437</ele>
+				<time>2017-11-20T20:19:07Z</time>
+				<extensions>
+					<speed>9.418537139892578</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00619714523214" lon="-84.20590519922607">
+				<ele>927.4990740120411</ele>
+				<time>2017-11-20T20:19:08Z</time>
+				<extensions>
+					<speed>8.908409118652344</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00615195886477" lon="-84.20587653822554">
+				<ele>927.3262076275423</ele>
+				<time>2017-11-20T20:19:09Z</time>
+				<extensions>
+					<speed>7.722349166870117</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006121771357954" lon="-84.20585456566259">
+				<ele>927.1873422153294</ele>
+				<time>2017-11-20T20:19:10Z</time>
+				<extensions>
+					<speed>5.250513553619385</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006095802503978" lon="-84.2058266526965">
+				<ele>927.2322459714487</ele>
+				<time>2017-11-20T20:19:11Z</time>
+				<extensions>
+					<speed>3.769710063934326</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006076886190707" lon="-84.2058074765887">
+				<ele>927.1636245176196</ele>
+				<time>2017-11-20T20:19:12Z</time>
+				<extensions>
+					<speed>2.4254894256591797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006059236331337" lon="-84.20579493008123">
+				<ele>927.2356108436361</ele>
+				<time>2017-11-20T20:19:13Z</time>
+				<extensions>
+					<speed>1.8490667343139648</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006049815846394" lon="-84.20579669703115">
+				<ele>927.2324609933421</ele>
+				<time>2017-11-20T20:19:14Z</time>
+				<extensions>
+					<speed>1.2918332815170288</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006035957507166" lon="-84.20578774424712">
+				<ele>927.3260108372197</ele>
+				<time>2017-11-20T20:19:15Z</time>
+				<extensions>
+					<speed>1.4244617223739624</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006023040288012" lon="-84.20578054072567">
+				<ele>927.6546666380018</ele>
+				<time>2017-11-20T20:19:16Z</time>
+				<extensions>
+					<speed>1.649419903755188</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005998715390389" lon="-84.20576604104042">
+				<ele>927.9709373535588</ele>
+				<time>2017-11-20T20:19:17Z</time>
+				<extensions>
+					<speed>2.2413411140441895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005963967704485" lon="-84.20577189287556">
+				<ele>928.0347560737282</ele>
+				<time>2017-11-20T20:19:18Z</time>
+				<extensions>
+					<speed>2.9661455154418945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005918638681678" lon="-84.20577642677314">
+				<ele>927.9215071871877</ele>
+				<time>2017-11-20T20:19:19Z</time>
+				<extensions>
+					<speed>3.8106777667999268</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005885238866954" lon="-84.20580266406819">
+				<ele>927.8099570060149</ele>
+				<time>2017-11-20T20:19:20Z</time>
+				<extensions>
+					<speed>4.629034519195557</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005848525036397" lon="-84.20583747198707">
+				<ele>927.7271436685696</ele>
+				<time>2017-11-20T20:19:21Z</time>
+				<extensions>
+					<speed>5.151925563812256</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005775563565875" lon="-84.20587615863813">
+				<ele>927.4906055442989</ele>
+				<time>2017-11-20T20:19:22Z</time>
+				<extensions>
+					<speed>5.476419925689697</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005737604838611" lon="-84.20591196003632">
+				<ele>927.6365197319537</ele>
+				<time>2017-11-20T20:19:23Z</time>
+				<extensions>
+					<speed>5.383712291717529</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005714479606821" lon="-84.20593968129012">
+				<ele>928.0699562653899</ele>
+				<time>2017-11-20T20:19:24Z</time>
+				<extensions>
+					<speed>4.388427734375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005683428684494" lon="-84.20594360360042">
+				<ele>929.8345039738342</ele>
+				<time>2017-11-20T20:19:25Z</time>
+				<extensions>
+					<speed>2.712224245071411</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005668459885037" lon="-84.20594901996085">
+				<ele>931.3656988218427</ele>
+				<time>2017-11-20T20:19:26Z</time>
+				<extensions>
+					<speed>1.299068570137024</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005675285627598" lon="-84.20594821609926">
+				<ele>932.0341393342242</ele>
+				<time>2017-11-20T20:19:27Z</time>
+				<extensions>
+					<speed>1.0408762693405151</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005699243746221" lon="-84.20593662462163">
+				<ele>932.935674388893</ele>
+				<time>2017-11-20T20:19:28Z</time>
+				<extensions>
+					<speed>3.6008105278015137</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005718578531921" lon="-84.20592504633694">
+				<ele>934.548848753795</ele>
+				<time>2017-11-20T20:19:29Z</time>
+				<extensions>
+					<speed>3.235581398010254</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005737019218513" lon="-84.20591395917357">
+				<ele>935.4135105703026</ele>
+				<time>2017-11-20T20:19:30Z</time>
+				<extensions>
+					<speed>2.850480318069458</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005753861152748" lon="-84.20590263723436">
+				<ele>935.6922827800736</ele>
+				<time>2017-11-20T20:19:31Z</time>
+				<extensions>
+					<speed>2.696510076522827</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005752316249596" lon="-84.20588598267841">
+				<ele>935.544564794749</ele>
+				<time>2017-11-20T20:19:32Z</time>
+				<extensions>
+					<speed>1.897017478942871</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00574495464068" lon="-84.20587716930858">
+				<ele>935.0454391585663</ele>
+				<time>2017-11-20T20:19:33Z</time>
+				<extensions>
+					<speed>1.0243711471557617</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005733717106866" lon="-84.20588099545563">
+				<ele>934.6504263365641</ele>
+				<time>2017-11-20T20:19:34Z</time>
+				<extensions>
+					<speed>0.8344122171401978</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00571780826668" lon="-84.20589052691463">
+				<ele>934.5549360103905</ele>
+				<time>2017-11-20T20:19:35Z</time>
+				<extensions>
+					<speed>1.9847557544708252</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005694895075099" lon="-84.20590693930357">
+				<ele>934.3707362171263</ele>
+				<time>2017-11-20T20:19:36Z</time>
+				<extensions>
+					<speed>2.776123523712158</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00566988112735" lon="-84.20592523570133">
+				<ele>934.1326849404722</ele>
+				<time>2017-11-20T20:19:37Z</time>
+				<extensions>
+					<speed>3.161985397338867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005645143653911" lon="-84.2059417293742">
+				<ele>934.1605434622616</ele>
+				<time>2017-11-20T20:19:38Z</time>
+				<extensions>
+					<speed>3.2607338428497314</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005616958532242" lon="-84.20597709832478">
+				<ele>934.1410268926993</ele>
+				<time>2017-11-20T20:19:39Z</time>
+				<extensions>
+					<speed>4.0507307052612305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00557794510383" lon="-84.2060249050986">
+				<ele>933.2427763454616</ele>
+				<time>2017-11-20T20:19:40Z</time>
+				<extensions>
+					<speed>5.0992655754089355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005535080178875" lon="-84.20608283461088">
+				<ele>932.0635265754536</ele>
+				<time>2017-11-20T20:19:41Z</time>
+				<extensions>
+					<speed>6.38628625869751</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005496968786304" lon="-84.20614125418291">
+				<ele>931.4648498203605</ele>
+				<time>2017-11-20T20:19:42Z</time>
+				<extensions>
+					<speed>7.168912410736084</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005456401623244" lon="-84.20620591886792">
+				<ele>930.7698974581435</ele>
+				<time>2017-11-20T20:19:43Z</time>
+				<extensions>
+					<speed>7.839700222015381</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005411693738107" lon="-84.20627303989555">
+				<ele>930.4212367171422</ele>
+				<time>2017-11-20T20:19:44Z</time>
+				<extensions>
+					<speed>8.629841804504395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005358612196286" lon="-84.2063399032978">
+				<ele>929.8904015524313</ele>
+				<time>2017-11-20T20:19:45Z</time>
+				<extensions>
+					<speed>9.539340019226074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005296070849779" lon="-84.2064115882218">
+				<ele>929.5717379720882</ele>
+				<time>2017-11-20T20:19:46Z</time>
+				<extensions>
+					<speed>10.190935134887695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005229418365193" lon="-84.20647754334611">
+				<ele>929.4948582723737</ele>
+				<time>2017-11-20T20:19:47Z</time>
+				<extensions>
+					<speed>10.274422645568848</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005163630894623" lon="-84.20654331094958">
+				<ele>929.5102032264695</ele>
+				<time>2017-11-20T20:19:48Z</time>
+				<extensions>
+					<speed>10.230672836303711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005099379233993" lon="-84.20659687465262">
+				<ele>929.5156540991738</ele>
+				<time>2017-11-20T20:19:49Z</time>
+				<extensions>
+					<speed>9.806385040283203</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005039636950775" lon="-84.20664831107707">
+				<ele>929.573309276253</ele>
+				<time>2017-11-20T20:19:50Z</time>
+				<extensions>
+					<speed>9.300647735595703</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004996882263875" lon="-84.2066914478054">
+				<ele>929.572117167525</ele>
+				<time>2017-11-20T20:19:51Z</time>
+				<extensions>
+					<speed>8.003597259521484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004948999714431" lon="-84.20672776288102">
+				<ele>928.5892378799617</ele>
+				<time>2017-11-20T20:19:52Z</time>
+				<extensions>
+					<speed>6.8145294189453125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004910159047355" lon="-84.2067697498874">
+				<ele>928.6433927826583</ele>
+				<time>2017-11-20T20:19:53Z</time>
+				<extensions>
+					<speed>6.128122329711914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004875268083282" lon="-84.20678343546591">
+				<ele>928.5683087408543</ele>
+				<time>2017-11-20T20:19:54Z</time>
+				<extensions>
+					<speed>4.794318199157715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00485452418112" lon="-84.20676146889859">
+				<ele>928.6332868942991</ele>
+				<time>2017-11-20T20:19:55Z</time>
+				<extensions>
+					<speed>3.2901248931884766</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004817709719532" lon="-84.20674360604542">
+				<ele>928.5829584859312</ele>
+				<time>2017-11-20T20:19:56Z</time>
+				<extensions>
+					<speed>4.483574867248535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00478380883901" lon="-84.20671994599267">
+				<ele>928.6107993125916</ele>
+				<time>2017-11-20T20:19:57Z</time>
+				<extensions>
+					<speed>4.629938125610352</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004754636820332" lon="-84.20668863379096">
+				<ele>928.6612925734371</ele>
+				<time>2017-11-20T20:19:58Z</time>
+				<extensions>
+					<speed>4.659740447998047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004734919019175" lon="-84.20665150930824">
+				<ele>928.6306797023863</ele>
+				<time>2017-11-20T20:19:59Z</time>
+				<extensions>
+					<speed>4.510088920593262</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004718358364634" lon="-84.20660933994704">
+				<ele>928.5873168818653</ele>
+				<time>2017-11-20T20:20:00Z</time>
+				<extensions>
+					<speed>4.547577381134033</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004712734274616" lon="-84.2065691027061">
+				<ele>928.546952970326</ele>
+				<time>2017-11-20T20:20:01Z</time>
+				<extensions>
+					<speed>4.377496719360352</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004707751873749" lon="-84.20653182107769">
+				<ele>928.6030401531607</ele>
+				<time>2017-11-20T20:20:02Z</time>
+				<extensions>
+					<speed>4.175013542175293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004702289027408" lon="-84.2064822233245">
+				<ele>928.6747498763725</ele>
+				<time>2017-11-20T20:20:03Z</time>
+				<extensions>
+					<speed>4.182653427124023</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004705864574301" lon="-84.20645551399882">
+				<ele>928.6937980391085</ele>
+				<time>2017-11-20T20:20:04Z</time>
+				<extensions>
+					<speed>3.5825936794281006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004701146894602" lon="-84.20643690980091">
+				<ele>928.728041340597</ele>
+				<time>2017-11-20T20:20:05Z</time>
+				<extensions>
+					<speed>3.1586737632751465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004706759311631" lon="-84.20644683816445">
+				<ele>928.7890145741403</ele>
+				<time>2017-11-20T20:20:06Z</time>
+				<extensions>
+					<speed>2.2406697273254395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004733085634161" lon="-84.20650476569823">
+				<ele>930.8929197546095</ele>
+				<time>2017-11-20T20:20:07Z</time>
+				<extensions>
+					<speed>1.1485329866409302</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004747909852904" lon="-84.20654861843312">
+				<ele>931.5157094830647</ele>
+				<time>2017-11-20T20:20:08Z</time>
+				<extensions>
+					<speed>0.3557131588459015</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004747909852904" lon="-84.20654861843312">
+				<ele>931.5157094830647</ele>
+				<time>2017-11-20T20:20:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004747909852904" lon="-84.20654861843312">
+				<ele>931.5157094830647</ele>
+				<time>2017-11-20T20:20:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004747909852904" lon="-84.20654861843312">
+				<ele>931.5157094830647</ele>
+				<time>2017-11-20T20:20:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004747909852904" lon="-84.20654861843312">
+				<ele>931.5157094830647</ele>
+				<time>2017-11-20T20:20:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004747909852904" lon="-84.20654861843312">
+				<ele>931.5157094830647</ele>
+				<time>2017-11-20T20:20:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004747909852904" lon="-84.20654861843312">
+				<ele>931.5157094830647</ele>
+				<time>2017-11-20T20:20:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00477246637479" lon="-84.2065261720645">
+				<ele>929.4004470296204</ele>
+				<time>2017-11-20T20:20:15Z</time>
+				<extensions>
+					<speed>1.1673095226287842</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004776882320112" lon="-84.20652053164248">
+				<ele>928.5027178423479</ele>
+				<time>2017-11-20T20:20:16Z</time>
+				<extensions>
+					<speed>0.8098668456077576</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004776882320112" lon="-84.20652053164248">
+				<ele>928.5027178423479</ele>
+				<time>2017-11-20T20:20:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004764075453808" lon="-84.20655693664007">
+				<ele>927.7244072277099</ele>
+				<time>2017-11-20T20:20:18Z</time>
+				<extensions>
+					<speed>0.734761118888855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004764075453808" lon="-84.20655693664007">
+				<ele>927.7244072277099</ele>
+				<time>2017-11-20T20:20:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004760497449055" lon="-84.20656753798197">
+				<ele>927.9912390764803</ele>
+				<time>2017-11-20T20:20:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004760497449055" lon="-84.20656753798197">
+				<ele>927.9912390764803</ele>
+				<time>2017-11-20T20:20:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004760497449055" lon="-84.20656753798197">
+				<ele>927.9912390764803</ele>
+				<time>2017-11-20T20:20:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00476674635524" lon="-84.20656123457455">
+				<ele>928.0974817182869</ele>
+				<time>2017-11-20T20:20:23Z</time>
+				<extensions>
+					<speed>1.0689877271652222</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004766526886497" lon="-84.20654466109082">
+				<ele>927.8737800959498</ele>
+				<time>2017-11-20T20:20:24Z</time>
+				<extensions>
+					<speed>0.745820939540863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004766526886497" lon="-84.20654466109082">
+				<ele>927.8737800959498</ele>
+				<time>2017-11-20T20:20:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004768878355849" lon="-84.20655001513168">
+				<ele>928.1223109541461</ele>
+				<time>2017-11-20T20:20:26Z</time>
+				<extensions>
+					<speed>0.6961356401443481</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004768878355849" lon="-84.20655001513168">
+				<ele>928.1223109541461</ele>
+				<time>2017-11-20T20:20:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004773649825317" lon="-84.206557639817">
+				<ele>927.9406901933253</ele>
+				<time>2017-11-20T20:20:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004773649825317" lon="-84.206557639817">
+				<ele>927.9406901933253</ele>
+				<time>2017-11-20T20:20:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004773649825317" lon="-84.206557639817">
+				<ele>927.9406901933253</ele>
+				<time>2017-11-20T20:20:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004773649825317" lon="-84.206557639817">
+				<ele>927.9406901933253</ele>
+				<time>2017-11-20T20:20:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004773649825317" lon="-84.206557639817">
+				<ele>927.9406901933253</ele>
+				<time>2017-11-20T20:20:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004773649825317" lon="-84.206557639817">
+				<ele>927.9406901933253</ele>
+				<time>2017-11-20T20:20:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004773649825317" lon="-84.206557639817">
+				<ele>927.9406901933253</ele>
+				<time>2017-11-20T20:20:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004773649825317" lon="-84.206557639817">
+				<ele>927.9406901933253</ele>
+				<time>2017-11-20T20:20:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00476816749905" lon="-84.20656168598832">
+				<ele>927.8830366656184</ele>
+				<time>2017-11-20T20:20:36Z</time>
+				<extensions>
+					<speed>0.6617113947868347</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004766104710024" lon="-84.20655590176179">
+				<ele>927.4947625044733</ele>
+				<time>2017-11-20T20:20:37Z</time>
+				<extensions>
+					<speed>1.2545478343963623</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004749711918269" lon="-84.20655528420626">
+				<ele>927.0060441261157</ele>
+				<time>2017-11-20T20:20:38Z</time>
+				<extensions>
+					<speed>2.162618398666382</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004718822623502" lon="-84.20654507716614">
+				<ele>926.8049769941717</ele>
+				<time>2017-11-20T20:20:39Z</time>
+				<extensions>
+					<speed>3.9138171672821045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00468952110913" lon="-84.20652492535238">
+				<ele>926.7467043828219</ele>
+				<time>2017-11-20T20:20:40Z</time>
+				<extensions>
+					<speed>4.798186302185059</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00466002934141" lon="-84.20649226761067">
+				<ele>927.0614978997037</ele>
+				<time>2017-11-20T20:20:41Z</time>
+				<extensions>
+					<speed>5.470671653747559</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004624192880867" lon="-84.2064595540479">
+				<ele>927.1030798014253</ele>
+				<time>2017-11-20T20:20:42Z</time>
+				<extensions>
+					<speed>5.8459672927856445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004580987171687" lon="-84.20642744121805">
+				<ele>927.159360550344</ele>
+				<time>2017-11-20T20:20:43Z</time>
+				<extensions>
+					<speed>6.11377477645874</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004539404940962" lon="-84.20639367085307">
+				<ele>927.4937171088532</ele>
+				<time>2017-11-20T20:20:44Z</time>
+				<extensions>
+					<speed>5.519078731536865</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004507010725245" lon="-84.20635669435435">
+				<ele>928.1964883375913</ele>
+				<time>2017-11-20T20:20:45Z</time>
+				<extensions>
+					<speed>4.343326568603516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004481599458002" lon="-84.2063324222939">
+				<ele>929.0022867694497</ele>
+				<time>2017-11-20T20:20:46Z</time>
+				<extensions>
+					<speed>2.649182081222534</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004460441799708" lon="-84.20631834156269">
+				<ele>929.6572299776599</ele>
+				<time>2017-11-20T20:20:47Z</time>
+				<extensions>
+					<speed>1.881713628768921</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004445358181734" lon="-84.20631025292123">
+				<ele>929.9517131792381</ele>
+				<time>2017-11-20T20:20:48Z</time>
+				<extensions>
+					<speed>1.3330210447311401</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004432496206645" lon="-84.20629868385289">
+				<ele>930.3407207187265</ele>
+				<time>2017-11-20T20:20:49Z</time>
+				<extensions>
+					<speed>1.720859169960022</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004418081030801" lon="-84.20628112313874">
+				<ele>930.5535840447992</ele>
+				<time>2017-11-20T20:20:50Z</time>
+				<extensions>
+					<speed>2.16324782371521</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00440768833087" lon="-84.20625809727527">
+				<ele>930.7589595848694</ele>
+				<time>2017-11-20T20:20:51Z</time>
+				<extensions>
+					<speed>2.067146062850952</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004410868694661" lon="-84.20623896727221">
+				<ele>930.7643091827631</ele>
+				<time>2017-11-20T20:20:52Z</time>
+				<extensions>
+					<speed>1.6495015621185303</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004416734897806" lon="-84.20623009961365">
+				<ele>930.6179936146364</ele>
+				<time>2017-11-20T20:20:53Z</time>
+				<extensions>
+					<speed>1.4418580532073975</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004424377193743" lon="-84.20622130311956">
+				<ele>930.0360013032332</ele>
+				<time>2017-11-20T20:20:54Z</time>
+				<extensions>
+					<speed>1.5739272832870483</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004429496902164" lon="-84.20620787260543">
+				<ele>929.7271013883874</ele>
+				<time>2017-11-20T20:20:55Z</time>
+				<extensions>
+					<speed>2.2034449577331543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004437158289395" lon="-84.20617211058831">
+				<ele>931.2230235906318</ele>
+				<time>2017-11-20T20:20:56Z</time>
+				<extensions>
+					<speed>2.1731677055358887</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004447840492821" lon="-84.20616117373665">
+				<ele>931.1500566806644</ele>
+				<time>2017-11-20T20:20:57Z</time>
+				<extensions>
+					<speed>1.9655643701553345</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004462082209116" lon="-84.2061653012697">
+				<ele>929.6437697913498</ele>
+				<time>2017-11-20T20:20:58Z</time>
+				<extensions>
+					<speed>2.4755165576934814</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0044727368126" lon="-84.2061792232985">
+				<ele>926.8864888865501</ele>
+				<time>2017-11-20T20:20:59Z</time>
+				<extensions>
+					<speed>2.765026807785034</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004501327098115" lon="-84.20614760629066">
+				<ele>928.1324212718755</ele>
+				<time>2017-11-20T20:21:00Z</time>
+				<extensions>
+					<speed>3.2085185050964355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004527113096515" lon="-84.20612080701414">
+				<ele>928.6396273085847</ele>
+				<time>2017-11-20T20:21:01Z</time>
+				<extensions>
+					<speed>3.4960618019104004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004552824768195" lon="-84.20609711185357">
+				<ele>928.8998707300052</ele>
+				<time>2017-11-20T20:21:02Z</time>
+				<extensions>
+					<speed>3.60984468460083</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004575275949831" lon="-84.20607494498468">
+				<ele>928.8611256992444</ele>
+				<time>2017-11-20T20:21:03Z</time>
+				<extensions>
+					<speed>3.6205859184265137</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004601194828435" lon="-84.20605489795857">
+				<ele>928.6021477906033</ele>
+				<time>2017-11-20T20:21:04Z</time>
+				<extensions>
+					<speed>3.891582727432251</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004625765762446" lon="-84.20602825669823">
+				<ele>929.1115613970906</ele>
+				<time>2017-11-20T20:21:05Z</time>
+				<extensions>
+					<speed>4.050013542175293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004651254283345" lon="-84.2060056663186">
+				<ele>929.1749611496925</ele>
+				<time>2017-11-20T20:21:06Z</time>
+				<extensions>
+					<speed>4.185997009277344</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004680317711523" lon="-84.20597691405233">
+				<ele>928.9600142147392</ele>
+				<time>2017-11-20T20:21:07Z</time>
+				<extensions>
+					<speed>4.733115196228027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004710486854888" lon="-84.20594078257697">
+				<ele>929.3382977563888</ele>
+				<time>2017-11-20T20:21:08Z</time>
+				<extensions>
+					<speed>5.018094539642334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004743528207266" lon="-84.20589772418565">
+				<ele>929.7152484413236</ele>
+				<time>2017-11-20T20:21:09Z</time>
+				<extensions>
+					<speed>5.498157501220703</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004777168940544" lon="-84.20585208084064">
+				<ele>929.4592001773417</ele>
+				<time>2017-11-20T20:21:10Z</time>
+				<extensions>
+					<speed>5.856985092163086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004813640128829" lon="-84.20580400453976">
+				<ele>929.6841357890517</ele>
+				<time>2017-11-20T20:21:11Z</time>
+				<extensions>
+					<speed>6.2536797523498535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004848083611932" lon="-84.20575376261002">
+				<ele>929.383044840768</ele>
+				<time>2017-11-20T20:21:12Z</time>
+				<extensions>
+					<speed>6.3025007247924805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004889715592224" lon="-84.20570478993564">
+				<ele>929.9308765586466</ele>
+				<time>2017-11-20T20:21:13Z</time>
+				<extensions>
+					<speed>6.485853672027588</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004936293872733" lon="-84.2056557867619">
+				<ele>930.3129651052877</ele>
+				<time>2017-11-20T20:21:14Z</time>
+				<extensions>
+					<speed>6.94599723815918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004985860564117" lon="-84.20560675176549">
+				<ele>931.0869803475216</ele>
+				<time>2017-11-20T20:21:15Z</time>
+				<extensions>
+					<speed>7.426784038543701</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005033193889226" lon="-84.20555424660347">
+				<ele>931.6742652906105</ele>
+				<time>2017-11-20T20:21:16Z</time>
+				<extensions>
+					<speed>7.527063846588135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0050728127101" lon="-84.20550008227717">
+				<ele>932.3093737754971</ele>
+				<time>2017-11-20T20:21:17Z</time>
+				<extensions>
+					<speed>7.313878059387207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005111862730022" lon="-84.20544325830669">
+				<ele>933.0495237689465</ele>
+				<time>2017-11-20T20:21:18Z</time>
+				<extensions>
+					<speed>7.53253698348999</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005149896682477" lon="-84.205389628677">
+				<ele>933.3499823901802</ele>
+				<time>2017-11-20T20:21:19Z</time>
+				<extensions>
+					<speed>7.276246547698975</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005180989931826" lon="-84.20533675169096">
+				<ele>934.0609417734668</ele>
+				<time>2017-11-20T20:21:20Z</time>
+				<extensions>
+					<speed>6.851574420928955</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005209413724158" lon="-84.2052883459397">
+				<ele>934.568496171385</ele>
+				<time>2017-11-20T20:21:21Z</time>
+				<extensions>
+					<speed>6.064897537231445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005240080824446" lon="-84.20524982293794">
+				<ele>934.9197958540171</ele>
+				<time>2017-11-20T20:21:22Z</time>
+				<extensions>
+					<speed>5.045705318450928</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005268311010157" lon="-84.20521811845475">
+				<ele>935.082769330591</ele>
+				<time>2017-11-20T20:21:23Z</time>
+				<extensions>
+					<speed>3.6947805881500244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005288106344628" lon="-84.20519379345185">
+				<ele>934.7038538176566</ele>
+				<time>2017-11-20T20:21:24Z</time>
+				<extensions>
+					<speed>3.2962257862091064</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00530161791248" lon="-84.20517474911756">
+				<ele>933.1461722608656</ele>
+				<time>2017-11-20T20:21:25Z</time>
+				<extensions>
+					<speed>2.108104944229126</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005309224130357" lon="-84.20516151754873">
+				<ele>932.2001212285832</ele>
+				<time>2017-11-20T20:21:26Z</time>
+				<extensions>
+					<speed>0.7123879194259644</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005308831210781" lon="-84.20515972266699">
+				<ele>931.7169055724517</ele>
+				<time>2017-11-20T20:21:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005307733396508" lon="-84.20516509225537">
+				<ele>931.3951531732455</ele>
+				<time>2017-11-20T20:21:28Z</time>
+				<extensions>
+					<speed>1.120453119277954</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005303286586093" lon="-84.20517306948133">
+				<ele>931.2893576901406</ele>
+				<time>2017-11-20T20:21:29Z</time>
+				<extensions>
+					<speed>0.9232879877090454</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005303286586093" lon="-84.20517306948133">
+				<ele>931.2893576901406</ele>
+				<time>2017-11-20T20:21:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00530052961285" lon="-84.20518166312621">
+				<ele>931.1979955127463</ele>
+				<time>2017-11-20T20:21:31Z</time>
+				<extensions>
+					<speed>0.6253363490104675</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00530052961285" lon="-84.20518166312621">
+				<ele>931.1979955127463</ele>
+				<time>2017-11-20T20:21:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:33Z</time>
+				<extensions>
+					<speed>0.20962092280387878</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005302872296062" lon="-84.20518487316166">
+				<ele>932.708003914915</ele>
+				<time>2017-11-20T20:21:36Z</time>
+				<extensions>
+					<speed>0.7204053401947021</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005309400195905" lon="-84.20518105796278">
+				<ele>931.1548988735303</ele>
+				<time>2017-11-20T20:21:39Z</time>
+				<extensions>
+					<speed>0.9324316382408142</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:21:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:22:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:22:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:22:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:22:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:22:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:22:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:22:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:22:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:22:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:22:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:22:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:22:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:22:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:22:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:22:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:22:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:22:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:22:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005297596270797" lon="-84.20518541508996">
+				<ele>931.1290633035824</ele>
+				<time>2017-11-20T20:22:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00530314207379" lon="-84.20518144304012">
+				<ele>931.3113509723917</ele>
+				<time>2017-11-20T20:22:19Z</time>
+				<extensions>
+					<speed>0.7256239652633667</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005308068111946" lon="-84.20517582188313">
+				<ele>931.3798716533929</ele>
+				<time>2017-11-20T20:22:20Z</time>
+				<extensions>
+					<speed>0.7399460673332214</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005312057760605" lon="-84.2051699984558">
+				<ele>931.484509431757</ele>
+				<time>2017-11-20T20:22:21Z</time>
+				<extensions>
+					<speed>0.6621044278144836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005316240362314" lon="-84.20516661181607">
+				<ele>931.5463920785114</ele>
+				<time>2017-11-20T20:22:22Z</time>
+				<extensions>
+					<speed>0.4387475848197937</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005320861751647" lon="-84.20516521654903">
+				<ele>931.5948241902515</ele>
+				<time>2017-11-20T20:22:23Z</time>
+				<extensions>
+					<speed>0.4360353350639343</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005320861751647" lon="-84.20516521654903">
+				<ele>931.5948241902515</ele>
+				<time>2017-11-20T20:22:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005323835895558" lon="-84.20516146392228">
+				<ele>931.92995573394</ele>
+				<time>2017-11-20T20:22:25Z</time>
+				<extensions>
+					<speed>0.6080037355422974</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005333009479694" lon="-84.2051522766902">
+				<ele>932.088261933066</ele>
+				<time>2017-11-20T20:22:26Z</time>
+				<extensions>
+					<speed>1.6387070417404175</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005347724016497" lon="-84.20513563724792">
+				<ele>932.1885190894827</ele>
+				<time>2017-11-20T20:22:27Z</time>
+				<extensions>
+					<speed>2.844446897506714</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00536658792741" lon="-84.20511343389906">
+				<ele>932.3776171337813</ele>
+				<time>2017-11-20T20:22:28Z</time>
+				<extensions>
+					<speed>3.1818149089813232</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005385069864051" lon="-84.20509180100018">
+				<ele>932.4531203899533</ele>
+				<time>2017-11-20T20:22:29Z</time>
+				<extensions>
+					<speed>2.835890769958496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005403331986669" lon="-84.2050717636198">
+				<ele>932.334987022914</ele>
+				<time>2017-11-20T20:22:30Z</time>
+				<extensions>
+					<speed>2.6751742362976074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00541691693416" lon="-84.20505238362453">
+				<ele>931.9392819488421</ele>
+				<time>2017-11-20T20:22:31Z</time>
+				<extensions>
+					<speed>2.4625236988067627</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005430901430747" lon="-84.20503329170855">
+				<ele>931.4783410690725</ele>
+				<time>2017-11-20T20:22:32Z</time>
+				<extensions>
+					<speed>2.619696855545044</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005446115562373" lon="-84.20501686515169">
+				<ele>930.9667889513075</ele>
+				<time>2017-11-20T20:22:33Z</time>
+				<extensions>
+					<speed>2.2870442867279053</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005458546423718" lon="-84.20500180942045">
+				<ele>930.5372059019282</ele>
+				<time>2017-11-20T20:22:34Z</time>
+				<extensions>
+					<speed>2.1010398864746094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005472833248305" lon="-84.20498814645927">
+				<ele>930.0805155411363</ele>
+				<time>2017-11-20T20:22:35Z</time>
+				<extensions>
+					<speed>2.257246255874634</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005487788414218" lon="-84.20497523402283">
+				<ele>929.6501453705132</ele>
+				<time>2017-11-20T20:22:36Z</time>
+				<extensions>
+					<speed>1.9461838006973267</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005497313104868" lon="-84.20496689610526">
+				<ele>929.1437844168395</ele>
+				<time>2017-11-20T20:22:37Z</time>
+				<extensions>
+					<speed>1.1106271743774414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005500672697757" lon="-84.2049627562266">
+				<ele>928.8481941148639</ele>
+				<time>2017-11-20T20:22:38Z</time>
+				<extensions>
+					<speed>0.3437942862510681</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005500672697757" lon="-84.2049627562266">
+				<ele>928.8481941148639</ele>
+				<time>2017-11-20T20:22:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005500672697757" lon="-84.2049627562266">
+				<ele>928.8481941148639</ele>
+				<time>2017-11-20T20:22:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005500672697757" lon="-84.2049627562266">
+				<ele>928.8481941148639</ele>
+				<time>2017-11-20T20:22:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005500672697757" lon="-84.2049627562266">
+				<ele>928.8481941148639</ele>
+				<time>2017-11-20T20:22:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005500672697757" lon="-84.2049627562266">
+				<ele>928.8481941148639</ele>
+				<time>2017-11-20T20:22:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005500672697757" lon="-84.2049627562266">
+				<ele>928.8481941148639</ele>
+				<time>2017-11-20T20:22:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005500672697757" lon="-84.2049627562266">
+				<ele>928.8481941148639</ele>
+				<time>2017-11-20T20:22:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005500672697757" lon="-84.2049627562266">
+				<ele>928.8481941148639</ele>
+				<time>2017-11-20T20:22:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005500672697757" lon="-84.2049627562266">
+				<ele>928.8481941148639</ele>
+				<time>2017-11-20T20:22:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005500672697757" lon="-84.2049627562266">
+				<ele>928.8481941148639</ele>
+				<time>2017-11-20T20:22:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005500672697757" lon="-84.2049627562266">
+				<ele>928.8481941148639</ele>
+				<time>2017-11-20T20:22:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005500672697757" lon="-84.2049627562266">
+				<ele>928.8481941148639</ele>
+				<time>2017-11-20T20:22:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005500672697757" lon="-84.2049627562266">
+				<ele>928.8481941148639</ele>
+				<time>2017-11-20T20:22:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005508307326576" lon="-84.2049577353527">
+				<ele>928.9378165090457</ele>
+				<time>2017-11-20T20:22:52Z</time>
+				<extensions>
+					<speed>0.9945155382156372</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005500672697757" lon="-84.2049627562266">
+				<ele>928.8481941148639</ele>
+				<time>2017-11-20T20:22:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005508518989156" lon="-84.20495290954653">
+				<ele>929.2421197285876</ele>
+				<time>2017-11-20T20:22:54Z</time>
+				<extensions>
+					<speed>0.7729001641273499</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00551244692796" lon="-84.2049426003627">
+				<ele>929.5791113479063</ele>
+				<time>2017-11-20T20:22:55Z</time>
+				<extensions>
+					<speed>1.1229188442230225</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00551574761949" lon="-84.20493298839085">
+				<ele>929.9924561874941</ele>
+				<time>2017-11-20T20:22:56Z</time>
+				<extensions>
+					<speed>0.6012355089187622</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00551574761949" lon="-84.20493298839085">
+				<ele>929.9924561874941</ele>
+				<time>2017-11-20T20:22:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005516897043659" lon="-84.20493037366192">
+				<ele>930.251579423435</ele>
+				<time>2017-11-20T20:22:58Z</time>
+				<extensions>
+					<speed>0.13743412494659424</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005516897043659" lon="-84.20493037366192">
+				<ele>930.251579423435</ele>
+				<time>2017-11-20T20:22:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005516897043659" lon="-84.20493037366192">
+				<ele>930.251579423435</ele>
+				<time>2017-11-20T20:23:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005516897043659" lon="-84.20493037366192">
+				<ele>930.251579423435</ele>
+				<time>2017-11-20T20:23:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005516897043659" lon="-84.20493037366192">
+				<ele>930.251579423435</ele>
+				<time>2017-11-20T20:23:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005516897043659" lon="-84.20493037366192">
+				<ele>930.251579423435</ele>
+				<time>2017-11-20T20:23:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005516897043659" lon="-84.20493037366192">
+				<ele>930.251579423435</ele>
+				<time>2017-11-20T20:23:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005516897043659" lon="-84.20493037366192">
+				<ele>930.251579423435</ele>
+				<time>2017-11-20T20:23:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005516897043659" lon="-84.20493037366192">
+				<ele>930.251579423435</ele>
+				<time>2017-11-20T20:23:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005516897043659" lon="-84.20493037366192">
+				<ele>930.251579423435</ele>
+				<time>2017-11-20T20:23:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005516897043659" lon="-84.20493037366192">
+				<ele>930.251579423435</ele>
+				<time>2017-11-20T20:23:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005516897043659" lon="-84.20493037366192">
+				<ele>930.251579423435</ele>
+				<time>2017-11-20T20:23:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005516897043659" lon="-84.20493037366192">
+				<ele>930.251579423435</ele>
+				<time>2017-11-20T20:23:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005516897043659" lon="-84.20493037366192">
+				<ele>930.251579423435</ele>
+				<time>2017-11-20T20:23:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005516897043659" lon="-84.20493037366192">
+				<ele>930.251579423435</ele>
+				<time>2017-11-20T20:23:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005516897043659" lon="-84.20493037366192">
+				<ele>930.251579423435</ele>
+				<time>2017-11-20T20:23:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005516897043659" lon="-84.20493037366192">
+				<ele>930.251579423435</ele>
+				<time>2017-11-20T20:23:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005516897043659" lon="-84.20493037366192">
+				<ele>930.251579423435</ele>
+				<time>2017-11-20T20:23:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005516897043659" lon="-84.20493037366192">
+				<ele>930.251579423435</ele>
+				<time>2017-11-20T20:23:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005516897043659" lon="-84.20493037366192">
+				<ele>930.251579423435</ele>
+				<time>2017-11-20T20:23:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005523188340327" lon="-84.20492356457048">
+				<ele>930.5470894882455</ele>
+				<time>2017-11-20T20:23:18Z</time>
+				<extensions>
+					<speed>1.27003014087677</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005532287004261" lon="-84.20491179580625">
+				<ele>930.8425514278933</ele>
+				<time>2017-11-20T20:23:19Z</time>
+				<extensions>
+					<speed>1.7427012920379639</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005547752950834" lon="-84.20489805355714">
+				<ele>931.1673037465662</ele>
+				<time>2017-11-20T20:23:20Z</time>
+				<extensions>
+					<speed>2.4716084003448486</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005568356925423" lon="-84.20487930009189">
+				<ele>931.731378798373</ele>
+				<time>2017-11-20T20:23:21Z</time>
+				<extensions>
+					<speed>3.039729356765747</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005589270107757" lon="-84.20486090708667">
+				<ele>931.9322233945131</ele>
+				<time>2017-11-20T20:23:22Z</time>
+				<extensions>
+					<speed>2.924767017364502</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00561014496641" lon="-84.20484140458231">
+				<ele>932.0785769252107</ele>
+				<time>2017-11-20T20:23:23Z</time>
+				<extensions>
+					<speed>3.045571804046631</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005628792270485" lon="-84.20482280123221">
+				<ele>932.0070765111595</ele>
+				<time>2017-11-20T20:23:24Z</time>
+				<extensions>
+					<speed>2.6911840438842773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005648027504805" lon="-84.20480606477608">
+				<ele>932.1708120377734</ele>
+				<time>2017-11-20T20:23:25Z</time>
+				<extensions>
+					<speed>2.897566795349121</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005668994216979" lon="-84.20479130445557">
+				<ele>932.4187893951312</ele>
+				<time>2017-11-20T20:23:26Z</time>
+				<extensions>
+					<speed>2.9902868270874023</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00569170681449" lon="-84.20477698151642">
+				<ele>932.4320333972573</ele>
+				<time>2017-11-20T20:23:27Z</time>
+				<extensions>
+					<speed>2.892655611038208</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005710296297224" lon="-84.2047654683694">
+				<ele>932.410248012282</ele>
+				<time>2017-11-20T20:23:28Z</time>
+				<extensions>
+					<speed>2.2971911430358887</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005724936565006" lon="-84.20475219335277">
+				<ele>932.5365504156798</ele>
+				<time>2017-11-20T20:23:29Z</time>
+				<extensions>
+					<speed>2.102091073989868</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00573880204867" lon="-84.20473796479034">
+				<ele>932.7319292612374</ele>
+				<time>2017-11-20T20:23:30Z</time>
+				<extensions>
+					<speed>2.144038677215576</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005750476484703" lon="-84.20471961937336">
+				<ele>933.0662873070687</ele>
+				<time>2017-11-20T20:23:31Z</time>
+				<extensions>
+					<speed>2.483940362930298</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005764158466777" lon="-84.2046972643873">
+				<ele>933.2439342048019</ele>
+				<time>2017-11-20T20:23:32Z</time>
+				<extensions>
+					<speed>2.9320261478424072</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005780546707536" lon="-84.20467271384861">
+				<ele>933.3382227951661</ele>
+				<time>2017-11-20T20:23:33Z</time>
+				<extensions>
+					<speed>3.1358625888824463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005799165772038" lon="-84.20464498771094">
+				<ele>933.5928717879578</ele>
+				<time>2017-11-20T20:23:34Z</time>
+				<extensions>
+					<speed>3.3996574878692627</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00581646475483" lon="-84.20461544421597">
+				<ele>933.8521212181076</ele>
+				<time>2017-11-20T20:23:35Z</time>
+				<extensions>
+					<speed>3.711040496826172</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005836188947544" lon="-84.20458910826136">
+				<ele>934.1088009718806</ele>
+				<time>2017-11-20T20:23:36Z</time>
+				<extensions>
+					<speed>3.1707258224487305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005853227276557" lon="-84.20456637490149">
+				<ele>934.1795971943066</ele>
+				<time>2017-11-20T20:23:37Z</time>
+				<extensions>
+					<speed>2.8757901191711426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005870673291101" lon="-84.20454525881053">
+				<ele>934.3192723020911</ele>
+				<time>2017-11-20T20:23:38Z</time>
+				<extensions>
+					<speed>2.7917919158935547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005887017734507" lon="-84.20452294675758">
+				<ele>934.55851814989</ele>
+				<time>2017-11-20T20:23:39Z</time>
+				<extensions>
+					<speed>2.9043893814086914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005909027358332" lon="-84.2044967417471">
+				<ele>934.9363594166934</ele>
+				<time>2017-11-20T20:23:40Z</time>
+				<extensions>
+					<speed>3.6131174564361572</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005933248747814" lon="-84.20447005961759">
+				<ele>935.1871603624895</ele>
+				<time>2017-11-20T20:23:41Z</time>
+				<extensions>
+					<speed>3.7710306644439697</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00595998004357" lon="-84.20444359284613">
+				<ele>935.5092940907925</ele>
+				<time>2017-11-20T20:23:42Z</time>
+				<extensions>
+					<speed>3.913691997528076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005987311186733" lon="-84.20441236052793">
+				<ele>935.7572708185762</ele>
+				<time>2017-11-20T20:23:43Z</time>
+				<extensions>
+					<speed>4.177231788635254</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006008550316068" lon="-84.20438282408988">
+				<ele>936.050862127915</ele>
+				<time>2017-11-20T20:23:44Z</time>
+				<extensions>
+					<speed>3.4155867099761963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006024615463483" lon="-84.20435824467562">
+				<ele>936.4751164438203</ele>
+				<time>2017-11-20T20:23:45Z</time>
+				<extensions>
+					<speed>2.530179977416992</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006035947467756" lon="-84.20434080902126">
+				<ele>936.4643034636974</ele>
+				<time>2017-11-20T20:23:46Z</time>
+				<extensions>
+					<speed>1.7416110038757324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006040075765211" lon="-84.20433167894794">
+				<ele>936.19961348176</ele>
+				<time>2017-11-20T20:23:47Z</time>
+				<extensions>
+					<speed>0.498262882232666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006038364150339" lon="-84.20433095935763">
+				<ele>935.9232254000381</ele>
+				<time>2017-11-20T20:23:48Z</time>
+				<extensions>
+					<speed>0.9281890392303467</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00603511614662" lon="-84.2043365364224">
+				<ele>935.9166607474908</ele>
+				<time>2017-11-20T20:23:49Z</time>
+				<extensions>
+					<speed>1.0550302267074585</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006030103381704" lon="-84.20434304825862">
+				<ele>935.8455049656332</ele>
+				<time>2017-11-20T20:23:50Z</time>
+				<extensions>
+					<speed>1.2338143587112427</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006031270145536" lon="-84.20434976064786">
+				<ele>935.706257591024</ele>
+				<time>2017-11-20T20:23:51Z</time>
+				<extensions>
+					<speed>0.8209681510925293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006031270145536" lon="-84.20434976064786">
+				<ele>935.706257591024</ele>
+				<time>2017-11-20T20:23:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006042806385063" lon="-84.20435269910001">
+				<ele>936.2260418469086</ele>
+				<time>2017-11-20T20:23:53Z</time>
+				<extensions>
+					<speed>0.885213315486908</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006042806385063" lon="-84.20435269910001">
+				<ele>936.2260418469086</ele>
+				<time>2017-11-20T20:23:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00604639715705" lon="-84.20435381768242">
+				<ele>936.082702527754</ele>
+				<time>2017-11-20T20:23:55Z</time>
+				<extensions>
+					<speed>0.08238579332828522</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00604639715705" lon="-84.20435381768242">
+				<ele>936.082702527754</ele>
+				<time>2017-11-20T20:23:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00604639715705" lon="-84.20435381768242">
+				<ele>936.082702527754</ele>
+				<time>2017-11-20T20:23:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00604639715705" lon="-84.20435381768242">
+				<ele>936.082702527754</ele>
+				<time>2017-11-20T20:23:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00604639715705" lon="-84.20435381768242">
+				<ele>936.082702527754</ele>
+				<time>2017-11-20T20:23:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00604639715705" lon="-84.20435381768242">
+				<ele>936.082702527754</ele>
+				<time>2017-11-20T20:24:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00604639715705" lon="-84.20435381768242">
+				<ele>936.082702527754</ele>
+				<time>2017-11-20T20:24:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00604639715705" lon="-84.20435381768242">
+				<ele>936.082702527754</ele>
+				<time>2017-11-20T20:24:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00604639715705" lon="-84.20435381768242">
+				<ele>936.082702527754</ele>
+				<time>2017-11-20T20:24:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00604639715705" lon="-84.20435381768242">
+				<ele>936.082702527754</ele>
+				<time>2017-11-20T20:24:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00604639715705" lon="-84.20435381768242">
+				<ele>936.082702527754</ele>
+				<time>2017-11-20T20:24:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00604639715705" lon="-84.20435381768242">
+				<ele>936.082702527754</ele>
+				<time>2017-11-20T20:24:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006053732849203" lon="-84.20434450977787">
+				<ele>935.1313506476581</ele>
+				<time>2017-11-20T20:24:07Z</time>
+				<extensions>
+					<speed>1.2911330461502075</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006066038523006" lon="-84.20432913211543">
+				<ele>934.530565161258</ele>
+				<time>2017-11-20T20:24:08Z</time>
+				<extensions>
+					<speed>2.402282953262329</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00608440278131" lon="-84.20430796544788">
+				<ele>933.9311808114871</ele>
+				<time>2017-11-20T20:24:09Z</time>
+				<extensions>
+					<speed>3.0448927879333496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006106946979603" lon="-84.20428238272021">
+				<ele>934.1758480509743</ele>
+				<time>2017-11-20T20:24:10Z</time>
+				<extensions>
+					<speed>3.9063894748687744</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006131363820721" lon="-84.20425278965195">
+				<ele>934.4518383825198</ele>
+				<time>2017-11-20T20:24:11Z</time>
+				<extensions>
+					<speed>4.442356109619141</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00615866577278" lon="-84.20422039987625">
+				<ele>934.6754744891077</ele>
+				<time>2017-11-20T20:24:12Z</time>
+				<extensions>
+					<speed>4.67119026184082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006182426579501" lon="-84.20418636284938">
+				<ele>934.412299499847</ele>
+				<time>2017-11-20T20:24:13Z</time>
+				<extensions>
+					<speed>4.221410751342773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00620568577368" lon="-84.20415151733614">
+				<ele>934.0212054289877</ele>
+				<time>2017-11-20T20:24:14Z</time>
+				<extensions>
+					<speed>3.9393341541290283</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006226516061535" lon="-84.20411920297373">
+				<ele>934.4878263985738</ele>
+				<time>2017-11-20T20:24:15Z</time>
+				<extensions>
+					<speed>3.318061113357544</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006243558165215" lon="-84.20409781481685">
+				<ele>934.423241360113</ele>
+				<time>2017-11-20T20:24:16Z</time>
+				<extensions>
+					<speed>1.988494873046875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006254371247302" lon="-84.204085360935">
+				<ele>934.0332542201504</ele>
+				<time>2017-11-20T20:24:17Z</time>
+				<extensions>
+					<speed>0.6781240701675415</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006257345719337" lon="-84.2040799634662">
+				<ele>933.8589674895629</ele>
+				<time>2017-11-20T20:24:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006257345719337" lon="-84.2040799634662">
+				<ele>933.8589674895629</ele>
+				<time>2017-11-20T20:24:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006257345719337" lon="-84.2040799634662">
+				<ele>933.8589674895629</ele>
+				<time>2017-11-20T20:24:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006265301710108" lon="-84.20407395120844">
+				<ele>934.7406370257959</ele>
+				<time>2017-11-20T20:24:21Z</time>
+				<extensions>
+					<speed>0.8544182777404785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006277125610087" lon="-84.20407427033605">
+				<ele>935.1895790668204</ele>
+				<time>2017-11-20T20:24:22Z</time>
+				<extensions>
+					<speed>1.7789452075958252</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006298078274448" lon="-84.20407303920008">
+				<ele>935.2819768544286</ele>
+				<time>2017-11-20T20:24:23Z</time>
+				<extensions>
+					<speed>2.4847381114959717</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006328685039069" lon="-84.20407698589214">
+				<ele>935.9235290773213</ele>
+				<time>2017-11-20T20:24:24Z</time>
+				<extensions>
+					<speed>3.559248924255371</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006360787482597" lon="-84.2040860563841">
+				<ele>935.9634097991511</ele>
+				<time>2017-11-20T20:24:25Z</time>
+				<extensions>
+					<speed>4.426484107971191</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006402400259576" lon="-84.2040998349294">
+				<ele>936.1983967861161</ele>
+				<time>2017-11-20T20:24:26Z</time>
+				<extensions>
+					<speed>5.381197452545166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006444168075452" lon="-84.20412692099805">
+				<ele>936.5568202473223</ele>
+				<time>2017-11-20T20:24:27Z</time>
+				<extensions>
+					<speed>6.222235679626465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006489715557253" lon="-84.20416455641829">
+				<ele>936.6980027826503</ele>
+				<time>2017-11-20T20:24:28Z</time>
+				<extensions>
+					<speed>7.0457024574279785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006538128103687" lon="-84.2042095319788">
+				<ele>937.2337626228109</ele>
+				<time>2017-11-20T20:24:29Z</time>
+				<extensions>
+					<speed>7.807392597198486</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006590546002586" lon="-84.20425801440904">
+				<ele>937.7348648840562</ele>
+				<time>2017-11-20T20:24:30Z</time>
+				<extensions>
+					<speed>8.186583518981934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00664614868048" lon="-84.20430808786904">
+				<ele>938.3783497978002</ele>
+				<time>2017-11-20T20:24:31Z</time>
+				<extensions>
+					<speed>8.556719779968262</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006704619938896" lon="-84.20436028027842">
+				<ele>938.9426704589278</ele>
+				<time>2017-11-20T20:24:32Z</time>
+				<extensions>
+					<speed>8.771499633789063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006762490473372" lon="-84.20441593628708">
+				<ele>939.384979262948</ele>
+				<time>2017-11-20T20:24:33Z</time>
+				<extensions>
+					<speed>8.957833290100098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00681989322567" lon="-84.20447370188027">
+				<ele>939.8806679425761</ele>
+				<time>2017-11-20T20:24:34Z</time>
+				<extensions>
+					<speed>9.049471855163574</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006876010762632" lon="-84.20453011279791">
+				<ele>940.1585489157587</ele>
+				<time>2017-11-20T20:24:35Z</time>
+				<extensions>
+					<speed>8.793102264404297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006930723441343" lon="-84.2045763883236">
+				<ele>940.741591045633</ele>
+				<time>2017-11-20T20:24:36Z</time>
+				<extensions>
+					<speed>7.788815498352051</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00698025851214" lon="-84.20461541739313">
+				<ele>941.0066635459661</ele>
+				<time>2017-11-20T20:24:37Z</time>
+				<extensions>
+					<speed>6.609915733337402</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007020598370906" lon="-84.20465088040818">
+				<ele>940.9133048914373</ele>
+				<time>2017-11-20T20:24:38Z</time>
+				<extensions>
+					<speed>5.485927581787109</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007053809181102" lon="-84.20468112515026">
+				<ele>940.9306721044704</ele>
+				<time>2017-11-20T20:24:39Z</time>
+				<extensions>
+					<speed>4.823337554931641</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007086369642863" lon="-84.2047038367933">
+				<ele>941.358439440839</ele>
+				<time>2017-11-20T20:24:40Z</time>
+				<extensions>
+					<speed>4.112843036651611</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007117797766181" lon="-84.20471612473315">
+				<ele>941.788248562254</ele>
+				<time>2017-11-20T20:24:41Z</time>
+				<extensions>
+					<speed>3.359590530395508</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007145912519702" lon="-84.2047215591935">
+				<ele>941.8239786159247</ele>
+				<time>2017-11-20T20:24:42Z</time>
+				<extensions>
+					<speed>2.605156421661377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007168439378752" lon="-84.2047167319153">
+				<ele>941.7062746156007</ele>
+				<time>2017-11-20T20:24:43Z</time>
+				<extensions>
+					<speed>1.5590401887893677</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007184794721306" lon="-84.20470956110061">
+				<ele>942.0223393356428</ele>
+				<time>2017-11-20T20:24:44Z</time>
+				<extensions>
+					<speed>1.3117811679840088</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00719645867277" lon="-84.20470511952284">
+				<ele>942.0036875987425</ele>
+				<time>2017-11-20T20:24:45Z</time>
+				<extensions>
+					<speed>1.6960994005203247</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007209303461899" lon="-84.20470172693274">
+				<ele>941.8997200299054</ele>
+				<time>2017-11-20T20:24:46Z</time>
+				<extensions>
+					<speed>2.1910290718078613</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00722947254394" lon="-84.20469873730839">
+				<ele>941.8474492905661</ele>
+				<time>2017-11-20T20:24:47Z</time>
+				<extensions>
+					<speed>2.74094557762146</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007256852046003" lon="-84.20469133206498">
+				<ele>942.1679807612672</ele>
+				<time>2017-11-20T20:24:48Z</time>
+				<extensions>
+					<speed>3.1830337047576904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007285172050981" lon="-84.20467642185169">
+				<ele>942.0605494286865</ele>
+				<time>2017-11-20T20:24:49Z</time>
+				<extensions>
+					<speed>3.4334261417388916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007316086239369" lon="-84.20465310187727">
+				<ele>942.2769367201254</ele>
+				<time>2017-11-20T20:24:50Z</time>
+				<extensions>
+					<speed>4.053435802459717</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007348629174816" lon="-84.20462551154431">
+				<ele>942.7053799154237</ele>
+				<time>2017-11-20T20:24:51Z</time>
+				<extensions>
+					<speed>4.007021903991699</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007376843668398" lon="-84.2045970411262">
+				<ele>943.2454589903355</ele>
+				<time>2017-11-20T20:24:52Z</time>
+				<extensions>
+					<speed>3.5992305278778076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00739861207969" lon="-84.20457570802428">
+				<ele>943.5442804805934</ele>
+				<time>2017-11-20T20:24:53Z</time>
+				<extensions>
+					<speed>2.2809340953826904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007410582580189" lon="-84.20456676071319">
+				<ele>943.7367273792624</ele>
+				<time>2017-11-20T20:24:54Z</time>
+				<extensions>
+					<speed>0.631852388381958</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007412616085585" lon="-84.20456721680776">
+				<ele>943.7516865292564</ele>
+				<time>2017-11-20T20:24:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007408842167278" lon="-84.20457104519478">
+				<ele>943.6803867248818</ele>
+				<time>2017-11-20T20:24:56Z</time>
+				<extensions>
+					<speed>1.1824183464050293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007400592784037" lon="-84.2045777972111">
+				<ele>943.5466936295852</ele>
+				<time>2017-11-20T20:24:57Z</time>
+				<extensions>
+					<speed>1.1421655416488647</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00739321051348" lon="-84.2045850041624">
+				<ele>943.6672014379874</ele>
+				<time>2017-11-20T20:24:58Z</time>
+				<extensions>
+					<speed>1.0865172147750854</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007387277826396" lon="-84.2045908706029">
+				<ele>943.4438477344811</ele>
+				<time>2017-11-20T20:24:59Z</time>
+				<extensions>
+					<speed>0.8596595525741577</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007387277826396" lon="-84.2045908706029">
+				<ele>943.4438477344811</ele>
+				<time>2017-11-20T20:25:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007386498586788" lon="-84.20459805745608">
+				<ele>943.1628719493747</ele>
+				<time>2017-11-20T20:25:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007386498586788" lon="-84.20459805745608">
+				<ele>943.1628719493747</ele>
+				<time>2017-11-20T20:25:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007386498586788" lon="-84.20459805745608">
+				<ele>943.1628719493747</ele>
+				<time>2017-11-20T20:25:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007386498586788" lon="-84.20459805745608">
+				<ele>943.1628719493747</ele>
+				<time>2017-11-20T20:25:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007386498586788" lon="-84.20459805745608">
+				<ele>943.1628719493747</ele>
+				<time>2017-11-20T20:25:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007386498586788" lon="-84.20459805745608">
+				<ele>943.1628719493747</ele>
+				<time>2017-11-20T20:25:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007386498586788" lon="-84.20459805745608">
+				<ele>943.1628719493747</ele>
+				<time>2017-11-20T20:25:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007391423006348" lon="-84.20459391536384">
+				<ele>942.7249283948913</ele>
+				<time>2017-11-20T20:25:08Z</time>
+				<extensions>
+					<speed>0.6609585881233215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007402465105674" lon="-84.20458757265537">
+				<ele>942.7848733803257</ele>
+				<time>2017-11-20T20:25:09Z</time>
+				<extensions>
+					<speed>1.0502110719680786</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007415935546312" lon="-84.20458113735971">
+				<ele>942.5645435573533</ele>
+				<time>2017-11-20T20:25:10Z</time>
+				<extensions>
+					<speed>1.4554561376571655</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007432692354717" lon="-84.20456867257487">
+				<ele>942.2702824901789</ele>
+				<time>2017-11-20T20:25:11Z</time>
+				<extensions>
+					<speed>2.228910446166992</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007455181812526" lon="-84.20454346363988">
+				<ele>942.3478541485965</ele>
+				<time>2017-11-20T20:25:12Z</time>
+				<extensions>
+					<speed>4.050815582275391</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007481301001858" lon="-84.20451064679929">
+				<ele>942.7934862859547</ele>
+				<time>2017-11-20T20:25:13Z</time>
+				<extensions>
+					<speed>4.191234111785889</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007508263493726" lon="-84.20447892551881">
+				<ele>943.2028870247304</ele>
+				<time>2017-11-20T20:25:14Z</time>
+				<extensions>
+					<speed>4.318299770355225</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007541738482042" lon="-84.204448095499">
+				<ele>943.8150189742446</ele>
+				<time>2017-11-20T20:25:15Z</time>
+				<extensions>
+					<speed>4.95546817779541</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007578701945327" lon="-84.20441564842558">
+				<ele>943.9553296836093</ele>
+				<time>2017-11-20T20:25:16Z</time>
+				<extensions>
+					<speed>5.509540557861328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007620023012336" lon="-84.20437841781238">
+				<ele>944.613533849828</ele>
+				<time>2017-11-20T20:25:17Z</time>
+				<extensions>
+					<speed>6.005599498748779</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00766296754267" lon="-84.20434237961646">
+				<ele>944.8069522455335</ele>
+				<time>2017-11-20T20:25:18Z</time>
+				<extensions>
+					<speed>5.876474857330322</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007707181861738" lon="-84.2043054669257">
+				<ele>945.049884185195</ele>
+				<time>2017-11-20T20:25:19Z</time>
+				<extensions>
+					<speed>6.244824409484863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007752908624942" lon="-84.20426532299267">
+				<ele>945.3423665957525</ele>
+				<time>2017-11-20T20:25:20Z</time>
+				<extensions>
+					<speed>6.420851230621338</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007799302599267" lon="-84.2042238894475">
+				<ele>945.6698005897924</ele>
+				<time>2017-11-20T20:25:21Z</time>
+				<extensions>
+					<speed>6.139189720153809</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00784337056283" lon="-84.204182565764">
+				<ele>945.5409535495564</ele>
+				<time>2017-11-20T20:25:22Z</time>
+				<extensions>
+					<speed>6.2539472579956055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007887596536944" lon="-84.20414091873451">
+				<ele>945.6667290432379</ele>
+				<time>2017-11-20T20:25:23Z</time>
+				<extensions>
+					<speed>6.2317399978637695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00793277858843" lon="-84.20409977820803">
+				<ele>946.0308231003582</ele>
+				<time>2017-11-20T20:25:24Z</time>
+				<extensions>
+					<speed>6.258744239807129</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007976952398263" lon="-84.20406048758987">
+				<ele>946.1816140264273</ele>
+				<time>2017-11-20T20:25:25Z</time>
+				<extensions>
+					<speed>6.218352317810059</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008021208567724" lon="-84.20402190530545">
+				<ele>945.9240094721317</ele>
+				<time>2017-11-20T20:25:26Z</time>
+				<extensions>
+					<speed>6.119196891784668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00806392565818" lon="-84.203984320601">
+				<ele>946.3262638878077</ele>
+				<time>2017-11-20T20:25:27Z</time>
+				<extensions>
+					<speed>5.931351661682129</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008105405883548" lon="-84.20394607670545">
+				<ele>946.4242221461609</ele>
+				<time>2017-11-20T20:25:28Z</time>
+				<extensions>
+					<speed>5.95533561706543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00814881025571" lon="-84.20390639600076">
+				<ele>946.6375691015273</ele>
+				<time>2017-11-20T20:25:29Z</time>
+				<extensions>
+					<speed>6.301521301269531</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008192386752256" lon="-84.20386763772103">
+				<ele>946.9216545615345</ele>
+				<time>2017-11-20T20:25:30Z</time>
+				<extensions>
+					<speed>6.18237829208374</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008236243656283" lon="-84.20382925828346">
+				<ele>947.2308837808669</ele>
+				<time>2017-11-20T20:25:31Z</time>
+				<extensions>
+					<speed>6.315887928009033</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008282298794537" lon="-84.2037897182222">
+				<ele>947.6329548060894</ele>
+				<time>2017-11-20T20:25:32Z</time>
+				<extensions>
+					<speed>6.664414882659912</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00833145474901" lon="-84.2037474112691">
+				<ele>947.8840201981366</ele>
+				<time>2017-11-20T20:25:33Z</time>
+				<extensions>
+					<speed>7.091671466827393</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008383570582113" lon="-84.20370550545972">
+				<ele>948.0548151358962</ele>
+				<time>2017-11-20T20:25:34Z</time>
+				<extensions>
+					<speed>6.908562660217285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008430942592069" lon="-84.20366741648208">
+				<ele>948.2142478032038</ele>
+				<time>2017-11-20T20:25:35Z</time>
+				<extensions>
+					<speed>5.784176826477051</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008469181373787" lon="-84.20363605738326">
+				<ele>947.6027292432263</ele>
+				<time>2017-11-20T20:25:36Z</time>
+				<extensions>
+					<speed>4.204991340637207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008495393561153" lon="-84.20361403370646">
+				<ele>946.7980980984867</ele>
+				<time>2017-11-20T20:25:37Z</time>
+				<extensions>
+					<speed>2.672067880630493</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008511000770119" lon="-84.20359818934718">
+				<ele>946.0231238259003</ele>
+				<time>2017-11-20T20:25:38Z</time>
+				<extensions>
+					<speed>1.6900577545166016</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00852117996342" lon="-84.20358790954931">
+				<ele>946.4179011303931</ele>
+				<time>2017-11-20T20:25:39Z</time>
+				<extensions>
+					<speed>1.4205938577651978</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008531510228407" lon="-84.20357715198008">
+				<ele>946.8919390467927</ele>
+				<time>2017-11-20T20:25:40Z</time>
+				<extensions>
+					<speed>1.5632716417312622</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008544292361307" lon="-84.20356438898696">
+				<ele>947.7614453202114</ele>
+				<time>2017-11-20T20:25:41Z</time>
+				<extensions>
+					<speed>1.8994255065917969</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008560326209228" lon="-84.20354964066003">
+				<ele>949.012498064898</ele>
+				<time>2017-11-20T20:25:42Z</time>
+				<extensions>
+					<speed>2.345860004425049</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008579425464053" lon="-84.20353308248974">
+				<ele>949.6649018572643</ele>
+				<time>2017-11-20T20:25:43Z</time>
+				<extensions>
+					<speed>2.7710986137390137</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008601790076744" lon="-84.2035112471433">
+				<ele>950.4753831252456</ele>
+				<time>2017-11-20T20:25:44Z</time>
+				<extensions>
+					<speed>3.7343575954437256</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008632754572863" lon="-84.20348478393446">
+				<ele>950.6106902202591</ele>
+				<time>2017-11-20T20:25:45Z</time>
+				<extensions>
+					<speed>4.9208831787109375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008672725208159" lon="-84.20345191493662">
+				<ele>950.7430974747986</ele>
+				<time>2017-11-20T20:25:46Z</time>
+				<extensions>
+					<speed>5.712798595428467</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008718035888432" lon="-84.20341497367639">
+				<ele>950.6117829391733</ele>
+				<time>2017-11-20T20:25:47Z</time>
+				<extensions>
+					<speed>6.389030933380127</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008764997847678" lon="-84.20337669187744">
+				<ele>950.187621220015</ele>
+				<time>2017-11-20T20:25:48Z</time>
+				<extensions>
+					<speed>6.516060829162598</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008812020461402" lon="-84.20333719207972">
+				<ele>950.1607907302678</ele>
+				<time>2017-11-20T20:25:49Z</time>
+				<extensions>
+					<speed>6.706104755401611</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008857542750796" lon="-84.2032975047911">
+				<ele>950.173021110706</ele>
+				<time>2017-11-20T20:25:50Z</time>
+				<extensions>
+					<speed>6.346089839935303</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008900320046392" lon="-84.20325909512184">
+				<ele>950.6303760670125</ele>
+				<time>2017-11-20T20:25:51Z</time>
+				<extensions>
+					<speed>6.090763568878174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008935466409417" lon="-84.20322672027365">
+				<ele>951.0018643792719</ele>
+				<time>2017-11-20T20:25:52Z</time>
+				<extensions>
+					<speed>4.381298065185547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008960346758121" lon="-84.2032029148044">
+				<ele>951.4242951618508</ele>
+				<time>2017-11-20T20:25:53Z</time>
+				<extensions>
+					<speed>2.919433832168579</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008972179365857" lon="-84.2031921758312">
+				<ele>951.8765381230041</ele>
+				<time>2017-11-20T20:25:54Z</time>
+				<extensions>
+					<speed>0.7865933775901794</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008964254746305" lon="-84.2032029408948">
+				<ele>952.3242857353762</ele>
+				<time>2017-11-20T20:25:56Z</time>
+				<extensions>
+					<speed>1.3418601751327515</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008956074748383" lon="-84.20321556417616">
+				<ele>952.3940506707877</ele>
+				<time>2017-11-20T20:25:57Z</time>
+				<extensions>
+					<speed>1.5148805379867554</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008948764635438" lon="-84.20322742234606">
+				<ele>952.5593956531957</ele>
+				<time>2017-11-20T20:25:58Z</time>
+				<extensions>
+					<speed>1.1259081363677979</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008943653442175" lon="-84.20323154633152">
+				<ele>952.7007538704202</ele>
+				<time>2017-11-20T20:25:59Z</time>
+				<extensions>
+					<speed>0.46841150522232056</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008943653442175" lon="-84.20323154633152">
+				<ele>952.7007538704202</ele>
+				<time>2017-11-20T20:26:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008938850253443" lon="-84.20323361509348">
+				<ele>952.5350034441799</ele>
+				<time>2017-11-20T20:26:01Z</time>
+				<extensions>
+					<speed>0.4075475037097931</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008938850253443" lon="-84.20323361509348">
+				<ele>952.5350034441799</ele>
+				<time>2017-11-20T20:26:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008933535838725" lon="-84.20324033957368">
+				<ele>952.4111990453675</ele>
+				<time>2017-11-20T20:26:03Z</time>
+				<extensions>
+					<speed>0.8254339694976807</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008928947818854" lon="-84.20325163292827">
+				<ele>952.3452970227227</ele>
+				<time>2017-11-20T20:26:04Z</time>
+				<extensions>
+					<speed>1.3448781967163086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008929440801532" lon="-84.20325369342473">
+				<ele>952.1388423833996</ele>
+				<time>2017-11-20T20:26:05Z</time>
+				<extensions>
+					<speed>0.6425425410270691</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008929440801532" lon="-84.20325369342473">
+				<ele>952.1388423833996</ele>
+				<time>2017-11-20T20:26:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00894037232565" lon="-84.20324098108202">
+				<ele>951.8905680831522</ele>
+				<time>2017-11-20T20:26:07Z</time>
+				<extensions>
+					<speed>2.2649178504943848</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00895680259635" lon="-84.20322384336119">
+				<ele>951.933921369724</ele>
+				<time>2017-11-20T20:26:08Z</time>
+				<extensions>
+					<speed>2.778111219406128</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008975392305649" lon="-84.20320767450026">
+				<ele>951.9589001685381</ele>
+				<time>2017-11-20T20:26:09Z</time>
+				<extensions>
+					<speed>2.5111711025238037</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008997923069481" lon="-84.20318817528411">
+				<ele>952.247401050292</ele>
+				<time>2017-11-20T20:26:10Z</time>
+				<extensions>
+					<speed>3.4377682209014893</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009027295778116" lon="-84.20316213931633">
+				<ele>952.2104918090627</ele>
+				<time>2017-11-20T20:26:11Z</time>
+				<extensions>
+					<speed>4.439182758331299</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009061598611577" lon="-84.20313428948602">
+				<ele>952.0886254906654</ele>
+				<time>2017-11-20T20:26:12Z</time>
+				<extensions>
+					<speed>4.7646708488464355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009097914489155" lon="-84.2031047572874">
+				<ele>951.5605414062738</ele>
+				<time>2017-11-20T20:26:13Z</time>
+				<extensions>
+					<speed>4.826937198638916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009129580220167" lon="-84.20307869716716">
+				<ele>951.4039696920663</ele>
+				<time>2017-11-20T20:26:14Z</time>
+				<extensions>
+					<speed>3.694016456604004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009152306560686" lon="-84.20306069553564">
+				<ele>951.3913521980867</ele>
+				<time>2017-11-20T20:26:15Z</time>
+				<extensions>
+					<speed>2.4119391441345215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009168243346588" lon="-84.20304998771879">
+				<ele>951.5195484943688</ele>
+				<time>2017-11-20T20:26:16Z</time>
+				<extensions>
+					<speed>1.7856292724609375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009181441984667" lon="-84.20304301319811">
+				<ele>951.6605033865198</ele>
+				<time>2017-11-20T20:26:17Z</time>
+				<extensions>
+					<speed>1.5963352918624878</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009195751258218" lon="-84.20303657094799">
+				<ele>952.0018670596182</ele>
+				<time>2017-11-20T20:26:18Z</time>
+				<extensions>
+					<speed>1.7180014848709106</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009211529376003" lon="-84.20302732468103">
+				<ele>952.000683340244</ele>
+				<time>2017-11-20T20:26:19Z</time>
+				<extensions>
+					<speed>2.004987955093384</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009228631009343" lon="-84.20301450248786">
+				<ele>951.9233062695712</ele>
+				<time>2017-11-20T20:26:20Z</time>
+				<extensions>
+					<speed>2.4784135818481445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009249177115176" lon="-84.2029976195841">
+				<ele>951.9302604300901</ele>
+				<time>2017-11-20T20:26:21Z</time>
+				<extensions>
+					<speed>3.0705766677856445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009275057854845" lon="-84.20297747620506">
+				<ele>952.0375351486728</ele>
+				<time>2017-11-20T20:26:22Z</time>
+				<extensions>
+					<speed>3.7519445419311523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009304436468678" lon="-84.2029522878852">
+				<ele>951.9782933974639</ele>
+				<time>2017-11-20T20:26:23Z</time>
+				<extensions>
+					<speed>4.666839122772217</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009338212249945" lon="-84.20292039146332">
+				<ele>951.9524101298302</ele>
+				<time>2017-11-20T20:26:24Z</time>
+				<extensions>
+					<speed>5.4466633796691895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00938019195098" lon="-84.20288600374202">
+				<ele>952.5440902272239</ele>
+				<time>2017-11-20T20:26:25Z</time>
+				<extensions>
+					<speed>6.414158344268799</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009428508408705" lon="-84.20284329289258">
+				<ele>952.4118246240541</ele>
+				<time>2017-11-20T20:26:26Z</time>
+				<extensions>
+					<speed>6.978946208953857</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00948170077528" lon="-84.20279719200828">
+				<ele>951.8908929368481</ele>
+				<time>2017-11-20T20:26:27Z</time>
+				<extensions>
+					<speed>7.311758041381836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009537273720575" lon="-84.2027518128163">
+				<ele>951.7293737316504</ele>
+				<time>2017-11-20T20:26:28Z</time>
+				<extensions>
+					<speed>7.724973678588867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009595962317483" lon="-84.20270694500923">
+				<ele>951.7347873775288</ele>
+				<time>2017-11-20T20:26:29Z</time>
+				<extensions>
+					<speed>7.920282363891602</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0096559767263" lon="-84.20265846079431">
+				<ele>951.606390113011</ele>
+				<time>2017-11-20T20:26:30Z</time>
+				<extensions>
+					<speed>8.388659477233887</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009717744204968" lon="-84.202607028165">
+				<ele>951.537437139079</ele>
+				<time>2017-11-20T20:26:31Z</time>
+				<extensions>
+					<speed>8.712918281555176</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009782341144101" lon="-84.20255504391757">
+				<ele>951.5609134370461</ele>
+				<time>2017-11-20T20:26:32Z</time>
+				<extensions>
+					<speed>8.952099800109863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009846818247661" lon="-84.20250114763711">
+				<ele>951.443628212437</ele>
+				<time>2017-11-20T20:26:33Z</time>
+				<extensions>
+					<speed>9.01826000213623</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00991025045673" lon="-84.20244697144412">
+				<ele>951.3479515183717</ele>
+				<time>2017-11-20T20:26:34Z</time>
+				<extensions>
+					<speed>9.061460494995117</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009973758173535" lon="-84.20239363232356">
+				<ele>951.2389639485627</ele>
+				<time>2017-11-20T20:26:35Z</time>
+				<extensions>
+					<speed>8.917673110961914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01003575142615" lon="-84.20234162250313">
+				<ele>951.0230730324984</ele>
+				<time>2017-11-20T20:26:36Z</time>
+				<extensions>
+					<speed>8.535356521606445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010095998612957" lon="-84.20229142330481">
+				<ele>950.7535994630307</ele>
+				<time>2017-11-20T20:26:37Z</time>
+				<extensions>
+					<speed>8.233196258544922</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010154408072127" lon="-84.20224519732264">
+				<ele>950.289305260405</ele>
+				<time>2017-11-20T20:26:38Z</time>
+				<extensions>
+					<speed>7.395407199859619</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010203817892258" lon="-84.2022071846716">
+				<ele>950.0103546185419</ele>
+				<time>2017-11-20T20:26:39Z</time>
+				<extensions>
+					<speed>5.760438442230225</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010239315660538" lon="-84.20217056876207">
+				<ele>947.8499028040096</ele>
+				<time>2017-11-20T20:26:40Z</time>
+				<extensions>
+					<speed>3.5574026107788086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010260194078011" lon="-84.20214884138889">
+				<ele>946.3857719022781</ele>
+				<time>2017-11-20T20:26:41Z</time>
+				<extensions>
+					<speed>1.667934775352478</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01026824930609" lon="-84.2021407954802">
+				<ele>945.628734972328</ele>
+				<time>2017-11-20T20:26:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010246249683568" lon="-84.20214392195545">
+				<ele>943.7898210929707</ele>
+				<time>2017-11-20T20:26:44Z</time>
+				<extensions>
+					<speed>1.6304494142532349</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010230899097307" lon="-84.20214299436729">
+				<ele>942.4940928779542</ele>
+				<time>2017-11-20T20:26:45Z</time>
+				<extensions>
+					<speed>1.3699159622192383</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010220322276439" lon="-84.20214754186975">
+				<ele>942.1584898866713</ele>
+				<time>2017-11-20T20:26:46Z</time>
+				<extensions>
+					<speed>1.2153902053833008</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01021293760805" lon="-84.2021522812243">
+				<ele>942.0687048798427</ele>
+				<time>2017-11-20T20:26:47Z</time>
+				<extensions>
+					<speed>0.7897827625274658</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01021293760805" lon="-84.2021522812243">
+				<ele>942.0687048798427</ele>
+				<time>2017-11-20T20:26:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010214318751233" lon="-84.20215477288127">
+				<ele>943.0749167930335</ele>
+				<time>2017-11-20T20:26:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010214318751233" lon="-84.20215477288127">
+				<ele>943.0749167930335</ele>
+				<time>2017-11-20T20:26:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010214318751233" lon="-84.20215477288127">
+				<ele>943.0749167930335</ele>
+				<time>2017-11-20T20:26:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010214318751233" lon="-84.20215477288127">
+				<ele>943.0749167930335</ele>
+				<time>2017-11-20T20:26:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010214318751233" lon="-84.20215477288127">
+				<ele>943.0749167930335</ele>
+				<time>2017-11-20T20:26:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010214318751233" lon="-84.20215477288127">
+				<ele>943.0749167930335</ele>
+				<time>2017-11-20T20:26:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010214318751233" lon="-84.20215477288127">
+				<ele>943.0749167930335</ele>
+				<time>2017-11-20T20:26:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010214318751233" lon="-84.20215477288127">
+				<ele>943.0749167930335</ele>
+				<time>2017-11-20T20:26:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010214318751233" lon="-84.20215477288127">
+				<ele>943.0749167930335</ele>
+				<time>2017-11-20T20:26:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010214318751233" lon="-84.20215477288127">
+				<ele>943.0749167930335</ele>
+				<time>2017-11-20T20:26:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01022197636774" lon="-84.20215132105182">
+				<ele>943.8060442330316</ele>
+				<time>2017-11-20T20:26:59Z</time>
+				<extensions>
+					<speed>1.0865857601165771</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010235662233017" lon="-84.20214258836886">
+				<ele>944.206841873005</ele>
+				<time>2017-11-20T20:27:00Z</time>
+				<extensions>
+					<speed>2.1344809532165527</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010259264938819" lon="-84.20212877618914">
+				<ele>944.2177905822173</ele>
+				<time>2017-11-20T20:27:01Z</time>
+				<extensions>
+					<speed>3.1930654048919678</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010288008765052" lon="-84.20211117428101">
+				<ele>944.4873475823551</ele>
+				<time>2017-11-20T20:27:02Z</time>
+				<extensions>
+					<speed>3.575653553009033</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010321099462185" lon="-84.20209139555284">
+				<ele>944.6987384995446</ele>
+				<time>2017-11-20T20:27:03Z</time>
+				<extensions>
+					<speed>4.3380045890808105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01035862597055" lon="-84.20207037857382">
+				<ele>944.8411837145686</ele>
+				<time>2017-11-20T20:27:04Z</time>
+				<extensions>
+					<speed>4.760089874267578</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010400742684466" lon="-84.2020478723673">
+				<ele>944.8314646137878</ele>
+				<time>2017-11-20T20:27:05Z</time>
+				<extensions>
+					<speed>5.055001258850098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01044720867964" lon="-84.20202423033257">
+				<ele>944.6585063105449</ele>
+				<time>2017-11-20T20:27:06Z</time>
+				<extensions>
+					<speed>5.614722728729248</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010498254982068" lon="-84.2019989952913">
+				<ele>944.7044111555442</ele>
+				<time>2017-11-20T20:27:07Z</time>
+				<extensions>
+					<speed>6.225795745849609</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010553446656367" lon="-84.20197188268072">
+				<ele>944.8679541442543</ele>
+				<time>2017-11-20T20:27:08Z</time>
+				<extensions>
+					<speed>6.5386061668396</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010609481651093" lon="-84.20194423186962">
+				<ele>944.654029299505</ele>
+				<time>2017-11-20T20:27:09Z</time>
+				<extensions>
+					<speed>6.776364803314209</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010666937436001" lon="-84.20191621847621">
+				<ele>944.4083936307579</ele>
+				<time>2017-11-20T20:27:10Z</time>
+				<extensions>
+					<speed>6.9323954582214355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010726091268562" lon="-84.20188944845547">
+				<ele>944.9435061160475</ele>
+				<time>2017-11-20T20:27:11Z</time>
+				<extensions>
+					<speed>7.198729038238525</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010788838071079" lon="-84.2018607469897">
+				<ele>945.6494374061003</ele>
+				<time>2017-11-20T20:27:12Z</time>
+				<extensions>
+					<speed>7.598865985870361</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01085410113243" lon="-84.20183087043756">
+				<ele>946.4468226600438</ele>
+				<time>2017-11-20T20:27:13Z</time>
+				<extensions>
+					<speed>7.8175506591796875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01091845618383" lon="-84.20179925103483">
+				<ele>946.867324559018</ele>
+				<time>2017-11-20T20:27:14Z</time>
+				<extensions>
+					<speed>7.836001873016357</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010978378427358" lon="-84.20176643024774">
+				<ele>947.1212608627975</ele>
+				<time>2017-11-20T20:27:15Z</time>
+				<extensions>
+					<speed>7.023675441741943</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011029436286066" lon="-84.20173706737978">
+				<ele>947.4008873812854</ele>
+				<time>2017-11-20T20:27:16Z</time>
+				<extensions>
+					<speed>6.03027868270874</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011070341312447" lon="-84.20171612171346">
+				<ele>947.5252902666107</ele>
+				<time>2017-11-20T20:27:17Z</time>
+				<extensions>
+					<speed>4.102144241333008</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011097402080852" lon="-84.20170174538477">
+				<ele>947.8248279867694</ele>
+				<time>2017-11-20T20:27:18Z</time>
+				<extensions>
+					<speed>2.5387792587280273</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011115000679766" lon="-84.20169067685735">
+				<ele>948.2757297493517</ele>
+				<time>2017-11-20T20:27:19Z</time>
+				<extensions>
+					<speed>2.0457069873809814</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011130934929806" lon="-84.20168147930838">
+				<ele>948.8319036830217</ele>
+				<time>2017-11-20T20:27:20Z</time>
+				<extensions>
+					<speed>1.957288384437561</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011146951744958" lon="-84.20167226671934">
+				<ele>949.1610381808132</ele>
+				<time>2017-11-20T20:27:21Z</time>
+				<extensions>
+					<speed>2.1781201362609863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011167274026853" lon="-84.20166068961892">
+				<ele>949.4450064459816</ele>
+				<time>2017-11-20T20:27:22Z</time>
+				<extensions>
+					<speed>2.8330283164978027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011193042564784" lon="-84.20164617369034">
+				<ele>950.1390664242208</ele>
+				<time>2017-11-20T20:27:23Z</time>
+				<extensions>
+					<speed>3.8087544441223145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01122648484229" lon="-84.2016294873934">
+				<ele>950.4671372193843</ele>
+				<time>2017-11-20T20:27:24Z</time>
+				<extensions>
+					<speed>4.500931262969971</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011264173784042" lon="-84.20161170598278">
+				<ele>950.8895714357495</ele>
+				<time>2017-11-20T20:27:25Z</time>
+				<extensions>
+					<speed>4.919388771057129</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011310717392897" lon="-84.2015900416964">
+				<ele>951.6931867012754</ele>
+				<time>2017-11-20T20:27:26Z</time>
+				<extensions>
+					<speed>6.460525989532471</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0113581345734" lon="-84.20156718484232">
+				<ele>952.2944805929437</ele>
+				<time>2017-11-20T20:27:27Z</time>
+				<extensions>
+					<speed>6.254014492034912</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011401624874095" lon="-84.20154380020365">
+				<ele>952.7422503689304</ele>
+				<time>2017-11-20T20:27:28Z</time>
+				<extensions>
+					<speed>5.485152721405029</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011440507098651" lon="-84.20152259334823">
+				<ele>952.9339302945882</ele>
+				<time>2017-11-20T20:27:29Z</time>
+				<extensions>
+					<speed>4.305291652679443</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011471750971142" lon="-84.20150560066321">
+				<ele>953.2073938790709</ele>
+				<time>2017-11-20T20:27:30Z</time>
+				<extensions>
+					<speed>3.412038564682007</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01149198024913" lon="-84.20149429814032">
+				<ele>952.8562238775194</ele>
+				<time>2017-11-20T20:27:31Z</time>
+				<extensions>
+					<speed>1.594774603843689</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011498016920816" lon="-84.20148987856244">
+				<ele>952.554859733209</ele>
+				<time>2017-11-20T20:27:32Z</time>
+				<extensions>
+					<speed>0.17877914011478424</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491559641607" lon="-84.20148974670605">
+				<ele>953.070958815515</ele>
+				<time>2017-11-20T20:27:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011498664790498" lon="-84.20148684696598">
+				<ele>953.2700592717156</ele>
+				<time>2017-11-20T20:27:57Z</time>
+				<extensions>
+					<speed>1.284408450126648</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011512492727768" lon="-84.20147926561334">
+				<ele>953.1322362236679</ele>
+				<time>2017-11-20T20:27:58Z</time>
+				<extensions>
+					<speed>2.0835049152374268</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011532179149011" lon="-84.2014665366533">
+				<ele>952.9760980606079</ele>
+				<time>2017-11-20T20:27:59Z</time>
+				<extensions>
+					<speed>2.8316051959991455</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011561744556081" lon="-84.20144905760085">
+				<ele>952.6430629910901</ele>
+				<time>2017-11-20T20:28:00Z</time>
+				<extensions>
+					<speed>4.239321231842041</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011601168658943" lon="-84.20142788230768">
+				<ele>952.4923546612263</ele>
+				<time>2017-11-20T20:28:01Z</time>
+				<extensions>
+					<speed>5.359170436859131</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011650540933287" lon="-84.2014016608363">
+				<ele>952.43778491579</ele>
+				<time>2017-11-20T20:28:02Z</time>
+				<extensions>
+					<speed>6.735237121582031</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011712601710842" lon="-84.20136912846112">
+				<ele>952.6230649407953</ele>
+				<time>2017-11-20T20:28:03Z</time>
+				<extensions>
+					<speed>8.16394329071045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01178777517318" lon="-84.20133283826644">
+				<ele>952.2619563322514</ele>
+				<time>2017-11-20T20:28:04Z</time>
+				<extensions>
+					<speed>9.406765937805176</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011871588226851" lon="-84.20129211111727">
+				<ele>952.0440389513969</ele>
+				<time>2017-11-20T20:28:05Z</time>
+				<extensions>
+					<speed>10.01531982421875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011957296309303" lon="-84.2012499365972">
+				<ele>951.8603523792699</ele>
+				<time>2017-11-20T20:28:06Z</time>
+				<extensions>
+					<speed>10.236336708068848</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01203918815974" lon="-84.2012089498908">
+				<ele>951.4026382323354</ele>
+				<time>2017-11-20T20:28:07Z</time>
+				<extensions>
+					<speed>9.509282112121582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012110903093387" lon="-84.20117010501585">
+				<ele>950.6448818165809</ele>
+				<time>2017-11-20T20:28:08Z</time>
+				<extensions>
+					<speed>8.259350776672363</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012167775358334" lon="-84.201138113113">
+				<ele>950.1723691830412</ele>
+				<time>2017-11-20T20:28:09Z</time>
+				<extensions>
+					<speed>6.282575607299805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012205180233726" lon="-84.2011139914247">
+				<ele>949.9425998274237</ele>
+				<time>2017-11-20T20:28:10Z</time>
+				<extensions>
+					<speed>4.225588321685791</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01222424189122" lon="-84.20109952759462">
+				<ele>950.0285289539024</ele>
+				<time>2017-11-20T20:28:11Z</time>
+				<extensions>
+					<speed>2.1982834339141846</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012229243960197" lon="-84.20109362855408">
+				<ele>950.2012844448909</ele>
+				<time>2017-11-20T20:28:12Z</time>
+				<extensions>
+					<speed>0.7516821026802063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012227379576649" lon="-84.20109066492404">
+				<ele>950.3328932467848</ele>
+				<time>2017-11-20T20:28:13Z</time>
+				<extensions>
+					<speed>0.13808083534240723</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012227379576649" lon="-84.20109066492404">
+				<ele>950.3328932467848</ele>
+				<time>2017-11-20T20:28:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012227379576649" lon="-84.20109066492404">
+				<ele>950.3328932467848</ele>
+				<time>2017-11-20T20:28:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012233077313194" lon="-84.20108671597202">
+				<ele>950.5848802765831</ele>
+				<time>2017-11-20T20:28:16Z</time>
+				<extensions>
+					<speed>0.9192457795143127</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012241174051358" lon="-84.20108127584591">
+				<ele>950.8191188964993</ele>
+				<time>2017-11-20T20:28:17Z</time>
+				<extensions>
+					<speed>1.6671994924545288</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012257778571614" lon="-84.20107347189743">
+				<ele>951.0090007185936</ele>
+				<time>2017-11-20T20:28:18Z</time>
+				<extensions>
+					<speed>2.6434056758880615</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012281668232164" lon="-84.20106368557462">
+				<ele>951.1343532735482</ele>
+				<time>2017-11-20T20:28:19Z</time>
+				<extensions>
+					<speed>3.491830348968506</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012311658900439" lon="-84.2010498600943">
+				<ele>951.0340139986947</ele>
+				<time>2017-11-20T20:28:20Z</time>
+				<extensions>
+					<speed>3.9774773120880127</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01234834045943" lon="-84.2010319723911">
+				<ele>950.8882517982274</ele>
+				<time>2017-11-20T20:28:21Z</time>
+				<extensions>
+					<speed>4.799314975738525</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012389874364132" lon="-84.20101167575982">
+				<ele>950.4280771501362</ele>
+				<time>2017-11-20T20:28:22Z</time>
+				<extensions>
+					<speed>4.963911533355713</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012434394184373" lon="-84.20098777152761">
+				<ele>950.1666781194508</ele>
+				<time>2017-11-20T20:28:23Z</time>
+				<extensions>
+					<speed>5.556085109710693</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012480263285566" lon="-84.20096167229593">
+				<ele>950.0835827076808</ele>
+				<time>2017-11-20T20:28:24Z</time>
+				<extensions>
+					<speed>5.035183429718018</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012525755791495" lon="-84.20093566109064">
+				<ele>950.5288510732353</ele>
+				<time>2017-11-20T20:28:25Z</time>
+				<extensions>
+					<speed>5.4321441650390625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012568118673443" lon="-84.20091207496193">
+				<ele>950.7985177263618</ele>
+				<time>2017-11-20T20:28:26Z</time>
+				<extensions>
+					<speed>4.635791301727295</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012602199336355" lon="-84.20089233015409">
+				<ele>950.9448980120942</ele>
+				<time>2017-11-20T20:28:27Z</time>
+				<extensions>
+					<speed>3.222374677658081</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012625875858015" lon="-84.20087834076651">
+				<ele>951.0917863892391</ele>
+				<time>2017-11-20T20:28:28Z</time>
+				<extensions>
+					<speed>1.8677284717559814</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012640269129381" lon="-84.20086981877684">
+				<ele>951.229355243966</ele>
+				<time>2017-11-20T20:28:29Z</time>
+				<extensions>
+					<speed>0.9174395799636841</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012644243518587" lon="-84.20086281993987">
+				<ele>951.3845105227083</ele>
+				<time>2017-11-20T20:28:30Z</time>
+				<extensions>
+					<speed>0.017562860623002052</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012644243518587" lon="-84.20086281993987">
+				<ele>951.4050603266805</ele>
+				<time>2017-11-20T20:28:31Z</time>
+				<extensions>
+					<speed>1.0591506958007813</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012644243518587" lon="-84.20086281993987">
+				<ele>951.8070744629949</ele>
+				<time>2017-11-20T20:28:32Z</time>
+				<extensions>
+					<speed>1.0631552934646606</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012644243518587" lon="-84.20086281993987">
+				<ele>951.8818535581231</ele>
+				<time>2017-11-20T20:28:33Z</time>
+				<extensions>
+					<speed>1.1034728288650513</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012609907710962" lon="-84.20085278774373">
+				<ele>952.0297313565388</ele>
+				<time>2017-11-20T20:28:34Z</time>
+				<extensions>
+					<speed>0.6324564218521118</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012605937947301" lon="-84.20084960364987">
+				<ele>952.2886011367664</ele>
+				<time>2017-11-20T20:28:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012607056089216" lon="-84.2008439907363">
+				<ele>952.4911200907081</ele>
+				<time>2017-11-20T20:28:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012607056089216" lon="-84.2008439907363">
+				<ele>952.4911200907081</ele>
+				<time>2017-11-20T20:28:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012607056089216" lon="-84.2008439907363">
+				<ele>952.4911200907081</ele>
+				<time>2017-11-20T20:28:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012607056089216" lon="-84.2008439907363">
+				<ele>952.4911200907081</ele>
+				<time>2017-11-20T20:28:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012607056089216" lon="-84.2008439907363">
+				<ele>952.4911200907081</ele>
+				<time>2017-11-20T20:28:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012615136284092" lon="-84.20084017909635">
+				<ele>952.3483317345381</ele>
+				<time>2017-11-20T20:28:41Z</time>
+				<extensions>
+					<speed>1.143980860710144</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012631765986793" lon="-84.20083524188043">
+				<ele>952.6575437989086</ele>
+				<time>2017-11-20T20:28:42Z</time>
+				<extensions>
+					<speed>2.0498452186584473</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012657539117559" lon="-84.20082437378262">
+				<ele>952.0400214772671</ele>
+				<time>2017-11-20T20:28:43Z</time>
+				<extensions>
+					<speed>3.0030248165130615</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012686958981211" lon="-84.200812094444">
+				<ele>952.3132194718346</ele>
+				<time>2017-11-20T20:28:44Z</time>
+				<extensions>
+					<speed>3.0947303771972656</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012709446338107" lon="-84.20080289520057">
+				<ele>952.5407386934385</ele>
+				<time>2017-11-20T20:28:45Z</time>
+				<extensions>
+					<speed>2.036198139190674</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012725105636317" lon="-84.20079555232095">
+				<ele>952.6777460211888</ele>
+				<time>2017-11-20T20:28:46Z</time>
+				<extensions>
+					<speed>0.6468309760093689</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01272983801093" lon="-84.2007917863322">
+				<ele>953.3038161611184</ele>
+				<time>2017-11-20T20:28:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01272983801093" lon="-84.2007917863322">
+				<ele>953.3038161611184</ele>
+				<time>2017-11-20T20:28:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01272983801093" lon="-84.2007917863322">
+				<ele>953.3038161611184</ele>
+				<time>2017-11-20T20:28:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01272983801093" lon="-84.2007917863322">
+				<ele>953.3038161611184</ele>
+				<time>2017-11-20T20:28:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01272983801093" lon="-84.2007917863322">
+				<ele>953.3038161611184</ele>
+				<time>2017-11-20T20:28:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01272983801093" lon="-84.2007917863322">
+				<ele>953.3038161611184</ele>
+				<time>2017-11-20T20:28:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01272983801093" lon="-84.2007917863322">
+				<ele>953.3038161611184</ele>
+				<time>2017-11-20T20:28:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01272983801093" lon="-84.2007917863322">
+				<ele>953.3038161611184</ele>
+				<time>2017-11-20T20:28:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01272983801093" lon="-84.2007917863322">
+				<ele>953.3038161611184</ele>
+				<time>2017-11-20T20:28:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01272983801093" lon="-84.2007917863322">
+				<ele>953.3038161611184</ele>
+				<time>2017-11-20T20:28:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01272983801093" lon="-84.2007917863322">
+				<ele>953.3038161611184</ele>
+				<time>2017-11-20T20:28:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01272983801093" lon="-84.2007917863322">
+				<ele>953.3038161611184</ele>
+				<time>2017-11-20T20:28:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01272983801093" lon="-84.2007917863322">
+				<ele>953.3038161611184</ele>
+				<time>2017-11-20T20:28:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01272983801093" lon="-84.2007917863322">
+				<ele>953.3038161611184</ele>
+				<time>2017-11-20T20:29:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01272983801093" lon="-84.2007917863322">
+				<ele>953.3038161611184</ele>
+				<time>2017-11-20T20:29:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01272983801093" lon="-84.2007917863322">
+				<ele>953.3038161611184</ele>
+				<time>2017-11-20T20:29:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0127343040754" lon="-84.20078972431905">
+				<ele>952.7381139872596</ele>
+				<time>2017-11-20T20:29:03Z</time>
+				<extensions>
+					<speed>0.7099924087524414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012745204882544" lon="-84.20078341580317">
+				<ele>953.0209316518158</ele>
+				<time>2017-11-20T20:29:04Z</time>
+				<extensions>
+					<speed>1.8263906240463257</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01276426710596" lon="-84.20077253880534">
+				<ele>953.0801792321727</ele>
+				<time>2017-11-20T20:29:05Z</time>
+				<extensions>
+					<speed>2.8295364379882813</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012788079148926" lon="-84.20075946043764">
+				<ele>952.8814674261957</ele>
+				<time>2017-11-20T20:29:06Z</time>
+				<extensions>
+					<speed>3.4954798221588135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012817611946518" lon="-84.20074340541842">
+				<ele>952.9634405840188</ele>
+				<time>2017-11-20T20:29:07Z</time>
+				<extensions>
+					<speed>3.6756749153137207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012846958795475" lon="-84.20072745540429">
+				<ele>953.2252689749002</ele>
+				<time>2017-11-20T20:29:08Z</time>
+				<extensions>
+					<speed>3.124920129776001</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012869085394389" lon="-84.20071386082185">
+				<ele>953.4028169605881</ele>
+				<time>2017-11-20T20:29:09Z</time>
+				<extensions>
+					<speed>2.0329012870788574</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012883122854776" lon="-84.20070553549041">
+				<ele>953.3300249530002</ele>
+				<time>2017-11-20T20:29:10Z</time>
+				<extensions>
+					<speed>1.0321922302246094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012890861271265" lon="-84.20070441814026">
+				<ele>952.7650485513732</ele>
+				<time>2017-11-20T20:29:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012890861271265" lon="-84.20070441814026">
+				<ele>952.7650485513732</ele>
+				<time>2017-11-20T20:29:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012890861271265" lon="-84.20070441814026">
+				<ele>952.7650485513732</ele>
+				<time>2017-11-20T20:29:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012890861271265" lon="-84.20070441814026">
+				<ele>952.7650485513732</ele>
+				<time>2017-11-20T20:29:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012890861271265" lon="-84.20070441814026">
+				<ele>952.7650485513732</ele>
+				<time>2017-11-20T20:29:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012890861271265" lon="-84.20070441814026">
+				<ele>952.7650485513732</ele>
+				<time>2017-11-20T20:29:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012890861271265" lon="-84.20070441814026">
+				<ele>952.7650485513732</ele>
+				<time>2017-11-20T20:29:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012890861271265" lon="-84.20070441814026">
+				<ele>952.7650485513732</ele>
+				<time>2017-11-20T20:29:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012890861271265" lon="-84.20070441814026">
+				<ele>952.7650485513732</ele>
+				<time>2017-11-20T20:29:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012890861271265" lon="-84.20070441814026">
+				<ele>952.7650485513732</ele>
+				<time>2017-11-20T20:29:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01289801309066" lon="-84.20070257377975">
+				<ele>953.2354220375419</ele>
+				<time>2017-11-20T20:29:21Z</time>
+				<extensions>
+					<speed>1.2281112670898438</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01291370231918" lon="-84.20070297841116">
+				<ele>953.9090783111751</ele>
+				<time>2017-11-20T20:29:22Z</time>
+				<extensions>
+					<speed>2.065805196762085</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012937272452541" lon="-84.20071090227329">
+				<ele>954.3248855881393</ele>
+				<time>2017-11-20T20:29:23Z</time>
+				<extensions>
+					<speed>3.232889413833618</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012970715120215" lon="-84.20072751051168">
+				<ele>954.3079469352961</ele>
+				<time>2017-11-20T20:29:24Z</time>
+				<extensions>
+					<speed>4.485753536224365</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013008684722918" lon="-84.20075791499293">
+				<ele>954.0351970503107</ele>
+				<time>2017-11-20T20:29:25Z</time>
+				<extensions>
+					<speed>5.582221984863281</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013048124492109" lon="-84.20079669899377">
+				<ele>954.3113282211125</ele>
+				<time>2017-11-20T20:29:26Z</time>
+				<extensions>
+					<speed>6.278933525085449</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013086315210671" lon="-84.20083848814552">
+				<ele>954.728023997508</ele>
+				<time>2017-11-20T20:29:27Z</time>
+				<extensions>
+					<speed>6.3579511642456055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013111991785168" lon="-84.20087916381871">
+				<ele>954.9121210156009</ele>
+				<time>2017-11-20T20:29:28Z</time>
+				<extensions>
+					<speed>5.211003303527832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013130358617769" lon="-84.20091561145253">
+				<ele>955.0023419316858</ele>
+				<time>2017-11-20T20:29:29Z</time>
+				<extensions>
+					<speed>4.093193054199219</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013137071499504" lon="-84.20094612706643">
+				<ele>955.4719122750685</ele>
+				<time>2017-11-20T20:29:30Z</time>
+				<extensions>
+					<speed>2.990870237350464</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013145723073437" lon="-84.20096441213342">
+				<ele>955.6730925366282</ele>
+				<time>2017-11-20T20:29:31Z</time>
+				<extensions>
+					<speed>1.6097222566604614</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013143745680136" lon="-84.20097320010031">
+				<ele>955.8840556917712</ele>
+				<time>2017-11-20T20:29:32Z</time>
+				<extensions>
+					<speed>0.1651746928691864</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013140387729877" lon="-84.20097464419331">
+				<ele>956.2709790179506</ele>
+				<time>2017-11-20T20:29:33Z</time>
+				<extensions>
+					<speed>0.36895257234573364</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013140387729877" lon="-84.20097464419331">
+				<ele>956.2709790179506</ele>
+				<time>2017-11-20T20:29:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013133256056003" lon="-84.20097022526177">
+				<ele>956.6574497502297</ele>
+				<time>2017-11-20T20:29:35Z</time>
+				<extensions>
+					<speed>0.6646978855133057</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013133256056003" lon="-84.20097022526177">
+				<ele>956.6574497502297</ele>
+				<time>2017-11-20T20:29:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013129836012698" lon="-84.20096959274743">
+				<ele>957.1121038608253</ele>
+				<time>2017-11-20T20:29:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013129836012698" lon="-84.20096959274743">
+				<ele>957.1121038608253</ele>
+				<time>2017-11-20T20:29:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013129836012698" lon="-84.20096959274743">
+				<ele>957.1121038608253</ele>
+				<time>2017-11-20T20:29:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013129836012698" lon="-84.20096959274743">
+				<ele>957.1121038608253</ele>
+				<time>2017-11-20T20:29:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013129836012698" lon="-84.20096959274743">
+				<ele>957.1121038608253</ele>
+				<time>2017-11-20T20:29:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013129836012698" lon="-84.20096959274743">
+				<ele>957.1121038608253</ele>
+				<time>2017-11-20T20:29:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013129836012698" lon="-84.20096959274743">
+				<ele>957.1121038608253</ele>
+				<time>2017-11-20T20:29:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013129836012698" lon="-84.20096959274743">
+				<ele>957.1121038608253</ele>
+				<time>2017-11-20T20:29:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013129836012698" lon="-84.20096959274743">
+				<ele>957.1121038608253</ele>
+				<time>2017-11-20T20:29:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013135191084132" lon="-84.20097519539236">
+				<ele>955.605012210086</ele>
+				<time>2017-11-20T20:29:46Z</time>
+				<extensions>
+					<speed>1.855945110321045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013147699076558" lon="-84.20099193962707">
+				<ele>954.384025788866</ele>
+				<time>2017-11-20T20:29:47Z</time>
+				<extensions>
+					<speed>2.4729137420654297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013166729290502" lon="-84.20101477178342">
+				<ele>953.1805055420846</ele>
+				<time>2017-11-20T20:29:48Z</time>
+				<extensions>
+					<speed>4.011310577392578</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013192681762456" lon="-84.20104936879152">
+				<ele>951.7126953555271</ele>
+				<time>2017-11-20T20:29:49Z</time>
+				<extensions>
+					<speed>5.683537483215332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01322885884769" lon="-84.20109427463017">
+				<ele>951.6845355220139</ele>
+				<time>2017-11-20T20:29:50Z</time>
+				<extensions>
+					<speed>6.686984062194824</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013274468353725" lon="-84.20114862262129">
+				<ele>951.1004406288266</ele>
+				<time>2017-11-20T20:29:51Z</time>
+				<extensions>
+					<speed>8.560677528381348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013329256219137" lon="-84.20121325971904">
+				<ele>951.0288382628933</ele>
+				<time>2017-11-20T20:29:52Z</time>
+				<extensions>
+					<speed>9.695744514465332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013390233105035" lon="-84.20127889783076">
+				<ele>949.3775544418022</ele>
+				<time>2017-11-20T20:29:53Z</time>
+				<extensions>
+					<speed>10.079912185668945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013460784333065" lon="-84.20133242599172">
+				<ele>947.2777183977887</ele>
+				<time>2017-11-20T20:29:54Z</time>
+				<extensions>
+					<speed>9.717618942260742</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013517283851744" lon="-84.2013954486669">
+				<ele>947.5552327400073</ele>
+				<time>2017-11-20T20:29:55Z</time>
+				<extensions>
+					<speed>9.214508056640625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01357066634532" lon="-84.20145807920485">
+				<ele>947.2710977755487</ele>
+				<time>2017-11-20T20:29:56Z</time>
+				<extensions>
+					<speed>8.667116165161133</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013622747538351" lon="-84.20151705119964">
+				<ele>947.0343256322667</ele>
+				<time>2017-11-20T20:29:57Z</time>
+				<extensions>
+					<speed>8.238805770874023</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013675684062616" lon="-84.20157284007182">
+				<ele>946.6864585923031</ele>
+				<time>2017-11-20T20:29:58Z</time>
+				<extensions>
+					<speed>8.301597595214844</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01373054488995" lon="-84.20162973388842">
+				<ele>946.2308719791472</ele>
+				<time>2017-11-20T20:29:59Z</time>
+				<extensions>
+					<speed>8.59115219116211</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013780857994755" lon="-84.2016879616306">
+				<ele>945.6185987284407</ele>
+				<time>2017-11-20T20:30:00Z</time>
+				<extensions>
+					<speed>8.499421119689941</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013830457729261" lon="-84.20174925158916">
+				<ele>945.2960821213201</ele>
+				<time>2017-11-20T20:30:01Z</time>
+				<extensions>
+					<speed>8.884164810180664</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013874853268417" lon="-84.20181606801492">
+				<ele>944.8767219549045</ele>
+				<time>2017-11-20T20:30:02Z</time>
+				<extensions>
+					<speed>8.837907791137695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013918885164562" lon="-84.20188463818248">
+				<ele>945.1036364790052</ele>
+				<time>2017-11-20T20:30:03Z</time>
+				<extensions>
+					<speed>8.846426963806152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013959362560442" lon="-84.20195703794217">
+				<ele>944.7863112539053</ele>
+				<time>2017-11-20T20:30:04Z</time>
+				<extensions>
+					<speed>9.291069984436035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013996353220353" lon="-84.20203443644805">
+				<ele>944.5241974284872</ele>
+				<time>2017-11-20T20:30:05Z</time>
+				<extensions>
+					<speed>9.597468376159668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014031686248876" lon="-84.20211261362029">
+				<ele>944.5633470257744</ele>
+				<time>2017-11-20T20:30:06Z</time>
+				<extensions>
+					<speed>9.505166053771973</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014066134169685" lon="-84.2021891014063">
+				<ele>944.3250176385045</ele>
+				<time>2017-11-20T20:30:07Z</time>
+				<extensions>
+					<speed>8.721781730651855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014098030512667" lon="-84.20226034889387">
+				<ele>944.0636898735538</ele>
+				<time>2017-11-20T20:30:08Z</time>
+				<extensions>
+					<speed>8.62281608581543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01412579254811" lon="-84.20233179115081">
+				<ele>944.0250032301992</ele>
+				<time>2017-11-20T20:30:09Z</time>
+				<extensions>
+					<speed>8.257003784179688</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014154088639993" lon="-84.20239471557494">
+				<ele>944.19576921314</ele>
+				<time>2017-11-20T20:30:10Z</time>
+				<extensions>
+					<speed>7.072142124176025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014179379010663" lon="-84.20244368862168">
+				<ele>945.0529129840434</ele>
+				<time>2017-11-20T20:30:11Z</time>
+				<extensions>
+					<speed>5.191045761108398</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014202497140785" lon="-84.2024769219534">
+				<ele>946.6240076720715</ele>
+				<time>2017-11-20T20:30:12Z</time>
+				<extensions>
+					<speed>3.893970489501953</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014227001918979" lon="-84.20249146005268">
+				<ele>946.6706408243626</ele>
+				<time>2017-11-20T20:30:13Z</time>
+				<extensions>
+					<speed>2.9331181049346924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014250785303183" lon="-84.20249185405936">
+				<ele>946.5073236115277</ele>
+				<time>2017-11-20T20:30:14Z</time>
+				<extensions>
+					<speed>2.5763514041900635</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014273023029414" lon="-84.2024794008186">
+				<ele>945.5848871571943</ele>
+				<time>2017-11-20T20:30:15Z</time>
+				<extensions>
+					<speed>3.0176680088043213</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014294630310253" lon="-84.20246029967488">
+				<ele>946.0785435028374</ele>
+				<time>2017-11-20T20:30:16Z</time>
+				<extensions>
+					<speed>3.2067983150482178</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014322281129557" lon="-84.20244008182839">
+				<ele>946.0121225211769</ele>
+				<time>2017-11-20T20:30:17Z</time>
+				<extensions>
+					<speed>4.213149070739746</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01435792081885" lon="-84.20241874459259">
+				<ele>945.5357677964494</ele>
+				<time>2017-11-20T20:30:18Z</time>
+				<extensions>
+					<speed>4.871636390686035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014399094873495" lon="-84.20239762624225">
+				<ele>946.0303251110017</ele>
+				<time>2017-11-20T20:30:19Z</time>
+				<extensions>
+					<speed>5.1670756340026855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014445411232307" lon="-84.20237510112545">
+				<ele>946.1924535706639</ele>
+				<time>2017-11-20T20:30:20Z</time>
+				<extensions>
+					<speed>5.466434478759766</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014499916554106" lon="-84.20234783031441">
+				<ele>947.3820382207632</ele>
+				<time>2017-11-20T20:30:21Z</time>
+				<extensions>
+					<speed>6.273438930511475</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01455655493623" lon="-84.20231892225841">
+				<ele>947.9167342046276</ele>
+				<time>2017-11-20T20:30:22Z</time>
+				<extensions>
+					<speed>6.833647727966309</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014617830728984" lon="-84.20228798384349">
+				<ele>948.3427385156974</ele>
+				<time>2017-11-20T20:30:23Z</time>
+				<extensions>
+					<speed>7.347908020019531</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014676000107274" lon="-84.20225571540689">
+				<ele>948.8301747888327</ele>
+				<time>2017-11-20T20:30:24Z</time>
+				<extensions>
+					<speed>7.308271408081055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014735453967365" lon="-84.20222165522607">
+				<ele>949.2166966684163</ele>
+				<time>2017-11-20T20:30:25Z</time>
+				<extensions>
+					<speed>7.347461700439453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014797006599473" lon="-84.2021872914863">
+				<ele>949.48677375447</ele>
+				<time>2017-11-20T20:30:26Z</time>
+				<extensions>
+					<speed>7.510369777679443</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014860823944069" lon="-84.20215391908681">
+				<ele>949.8715678025037</ele>
+				<time>2017-11-20T20:30:27Z</time>
+				<extensions>
+					<speed>7.997921943664551</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01492625353342" lon="-84.2021182963441">
+				<ele>950.0753279682249</ele>
+				<time>2017-11-20T20:30:28Z</time>
+				<extensions>
+					<speed>8.14087200164795</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014995455500895" lon="-84.20208172621282">
+				<ele>950.5766772767529</ele>
+				<time>2017-11-20T20:30:29Z</time>
+				<extensions>
+					<speed>8.543645858764648</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015064613177959" lon="-84.20204551856102">
+				<ele>950.9596287161112</ele>
+				<time>2017-11-20T20:30:30Z</time>
+				<extensions>
+					<speed>8.44533920288086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01513397057743" lon="-84.20200918234954">
+				<ele>952.366439265199</ele>
+				<time>2017-11-20T20:30:31Z</time>
+				<extensions>
+					<speed>8.492058753967285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01519902889047" lon="-84.20197067934868">
+				<ele>952.6202437542379</ele>
+				<time>2017-11-20T20:30:32Z</time>
+				<extensions>
+					<speed>7.870309352874756</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015254578095288" lon="-84.20192993296459">
+				<ele>953.0456082569435</ele>
+				<time>2017-11-20T20:30:33Z</time>
+				<extensions>
+					<speed>6.715114116668701</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015297776699272" lon="-84.20188705952235">
+				<ele>953.6012920634821</ele>
+				<time>2017-11-20T20:30:34Z</time>
+				<extensions>
+					<speed>6.116517543792725</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015330685603054" lon="-84.20184471752246">
+				<ele>953.5044000130147</ele>
+				<time>2017-11-20T20:30:35Z</time>
+				<extensions>
+					<speed>5.486169815063477</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015362540668047" lon="-84.20180649998217">
+				<ele>953.1324056927115</ele>
+				<time>2017-11-20T20:30:36Z</time>
+				<extensions>
+					<speed>4.960865020751953</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015392372347137" lon="-84.20177615681693">
+				<ele>952.6630875011906</ele>
+				<time>2017-11-20T20:30:37Z</time>
+				<extensions>
+					<speed>4.076723575592041</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015420887827418" lon="-84.20176106347012">
+				<ele>952.4439627937973</ele>
+				<time>2017-11-20T20:30:38Z</time>
+				<extensions>
+					<speed>2.8662450313568115</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01544163433962" lon="-84.20175702626938">
+				<ele>952.7743722870946</ele>
+				<time>2017-11-20T20:30:39Z</time>
+				<extensions>
+					<speed>1.3904832601547241</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015450282098945" lon="-84.20175959649859">
+				<ele>952.8746334677562</ele>
+				<time>2017-11-20T20:30:40Z</time>
+				<extensions>
+					<speed>0.5556153655052185</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01544769209098" lon="-84.20176678081886">
+				<ele>952.7120748516172</ele>
+				<time>2017-11-20T20:30:41Z</time>
+				<extensions>
+					<speed>1.0072786808013916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015437802235379" lon="-84.20177425906452">
+				<ele>952.2501285048202</ele>
+				<time>2017-11-20T20:30:42Z</time>
+				<extensions>
+					<speed>1.669372320175171</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01542245747169" lon="-84.20178257510207">
+				<ele>951.0552035244182</ele>
+				<time>2017-11-20T20:30:43Z</time>
+				<extensions>
+					<speed>2.147082567214966</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015404884293579" lon="-84.2017932448718">
+				<ele>950.4077513786033</ele>
+				<time>2017-11-20T20:30:44Z</time>
+				<extensions>
+					<speed>2.4910075664520264</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01538378234084" lon="-84.2018011982979">
+				<ele>949.9405785547569</ele>
+				<time>2017-11-20T20:30:45Z</time>
+				<extensions>
+					<speed>2.312527894973755</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0153675851084" lon="-84.20180497242244">
+				<ele>950.3768359534442</ele>
+				<time>2017-11-20T20:30:46Z</time>
+				<extensions>
+					<speed>1.5034936666488647</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015357305421531" lon="-84.20180558761749">
+				<ele>950.4571311492473</ele>
+				<time>2017-11-20T20:30:47Z</time>
+				<extensions>
+					<speed>1.3986668586730957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015346214327453" lon="-84.20180651678608">
+				<ele>950.3468255484477</ele>
+				<time>2017-11-20T20:30:48Z</time>
+				<extensions>
+					<speed>1.2305498123168945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015336988526064" lon="-84.20180548126923">
+				<ele>950.1925572864711</ele>
+				<time>2017-11-20T20:30:49Z</time>
+				<extensions>
+					<speed>0.9192808866500854</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015336988526064" lon="-84.20180548126923">
+				<ele>950.1925572864711</ele>
+				<time>2017-11-20T20:30:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015330401832207" lon="-84.20180369020443">
+				<ele>949.9725570837036</ele>
+				<time>2017-11-20T20:30:51Z</time>
+				<extensions>
+					<speed>0.916163980960846</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015330401832207" lon="-84.20180369020443">
+				<ele>949.9725570837036</ele>
+				<time>2017-11-20T20:30:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015322304849658" lon="-84.20180167985787">
+				<ele>949.9950781874359</ele>
+				<time>2017-11-20T20:30:53Z</time>
+				<extensions>
+					<speed>0.7623199820518494</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015322304849658" lon="-84.20180167985787">
+				<ele>949.9950781874359</ele>
+				<time>2017-11-20T20:30:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015321163441104" lon="-84.20180270954657">
+				<ele>949.428758110851</ele>
+				<time>2017-11-20T20:30:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015321163441104" lon="-84.20180270954657">
+				<ele>949.428758110851</ele>
+				<time>2017-11-20T20:30:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015321163441104" lon="-84.20180270954657">
+				<ele>949.428758110851</ele>
+				<time>2017-11-20T20:30:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015321163441104" lon="-84.20180270954657">
+				<ele>949.428758110851</ele>
+				<time>2017-11-20T20:30:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015321163441104" lon="-84.20180270954657">
+				<ele>949.428758110851</ele>
+				<time>2017-11-20T20:30:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015321163441104" lon="-84.20180270954657">
+				<ele>949.428758110851</ele>
+				<time>2017-11-20T20:31:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015321163441104" lon="-84.20180270954657">
+				<ele>949.428758110851</ele>
+				<time>2017-11-20T20:31:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015321163441104" lon="-84.20180270954657">
+				<ele>949.428758110851</ele>
+				<time>2017-11-20T20:31:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015321163441104" lon="-84.20180270954657">
+				<ele>949.428758110851</ele>
+				<time>2017-11-20T20:31:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015321163441104" lon="-84.20180270954657">
+				<ele>949.428758110851</ele>
+				<time>2017-11-20T20:31:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015321163441104" lon="-84.20180270954657">
+				<ele>949.428758110851</ele>
+				<time>2017-11-20T20:31:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015321163441104" lon="-84.20180270954657">
+				<ele>949.428758110851</ele>
+				<time>2017-11-20T20:31:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015324821754334" lon="-84.20181268626571">
+				<ele>948.7968159690499</ele>
+				<time>2017-11-20T20:31:07Z</time>
+				<extensions>
+					<speed>1.2962013483047485</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015328576628335" lon="-84.20182784744206">
+				<ele>948.3833064418286</ele>
+				<time>2017-11-20T20:31:08Z</time>
+				<extensions>
+					<speed>1.660468339920044</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015333671059775" lon="-84.20184583106318">
+				<ele>948.0641019716859</ele>
+				<time>2017-11-20T20:31:09Z</time>
+				<extensions>
+					<speed>2.215245485305786</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015336544001064" lon="-84.2018670786153">
+				<ele>947.8672744240612</ele>
+				<time>2017-11-20T20:31:10Z</time>
+				<extensions>
+					<speed>2.3875555992126465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015333763696113" lon="-84.2018906780385">
+				<ele>947.37937549036</ele>
+				<time>2017-11-20T20:31:11Z</time>
+				<extensions>
+					<speed>2.532482862472534</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01532542737462" lon="-84.20191456323822">
+				<ele>946.8348246486858</ele>
+				<time>2017-11-20T20:31:12Z</time>
+				<extensions>
+					<speed>2.6939330101013184</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015308264672644" lon="-84.20193998455548">
+				<ele>946.7764247814193</ele>
+				<time>2017-11-20T20:31:13Z</time>
+				<extensions>
+					<speed>3.4280550479888916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015282353518373" lon="-84.2019681927448">
+				<ele>946.6427619131282</ele>
+				<time>2017-11-20T20:31:14Z</time>
+				<extensions>
+					<speed>4.442012310028076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015244544054337" lon="-84.20199791587642">
+				<ele>946.5252715619281</ele>
+				<time>2017-11-20T20:31:15Z</time>
+				<extensions>
+					<speed>5.289519786834717</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015196288273184" lon="-84.20203035627371">
+				<ele>946.3098236136138</ele>
+				<time>2017-11-20T20:31:16Z</time>
+				<extensions>
+					<speed>6.418208122253418</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0151410926324" lon="-84.2020637667041">
+				<ele>946.0242682565004</ele>
+				<time>2017-11-20T20:31:17Z</time>
+				<extensions>
+					<speed>7.370599746704102</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01507432193886" lon="-84.20210177036975">
+				<ele>945.8015596009791</ele>
+				<time>2017-11-20T20:31:18Z</time>
+				<extensions>
+					<speed>9.03487777709961</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014997354504372" lon="-84.2021423676947">
+				<ele>946.1776563273743</ele>
+				<time>2017-11-20T20:31:19Z</time>
+				<extensions>
+					<speed>10.04524040222168</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014910177276958" lon="-84.20218342340031">
+				<ele>946.1302836816758</ele>
+				<time>2017-11-20T20:31:20Z</time>
+				<extensions>
+					<speed>10.683903694152832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014817145569564" lon="-84.20222612082796">
+				<ele>945.7229510908946</ele>
+				<time>2017-11-20T20:31:21Z</time>
+				<extensions>
+					<speed>11.07757568359375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01472379631146" lon="-84.20226721384674">
+				<ele>945.10780391749</ele>
+				<time>2017-11-20T20:31:22Z</time>
+				<extensions>
+					<speed>10.818936347961426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014635467258124" lon="-84.20230680670515">
+				<ele>944.8692904775962</ele>
+				<time>2017-11-20T20:31:23Z</time>
+				<extensions>
+					<speed>9.943827629089355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014556042900157" lon="-84.20234081866549">
+				<ele>944.9080318072811</ele>
+				<time>2017-11-20T20:31:24Z</time>
+				<extensions>
+					<speed>8.731483459472656</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01448356428618" lon="-84.20237290607386">
+				<ele>944.5688996929675</ele>
+				<time>2017-11-20T20:31:25Z</time>
+				<extensions>
+					<speed>8.144403457641602</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014423036590438" lon="-84.20240245185256">
+				<ele>944.925044964999</ele>
+				<time>2017-11-20T20:31:26Z</time>
+				<extensions>
+					<speed>6.57828950881958</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01437461883792" lon="-84.20242911414645">
+				<ele>944.9899899298325</ele>
+				<time>2017-11-20T20:31:27Z</time>
+				<extensions>
+					<speed>5.481410503387451</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014335845005181" lon="-84.20245163936409">
+				<ele>945.3706599250436</ele>
+				<time>2017-11-20T20:31:28Z</time>
+				<extensions>
+					<speed>4.541018962860107</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014304271716764" lon="-84.2024662480366">
+				<ele>945.3282591802999</ele>
+				<time>2017-11-20T20:31:29Z</time>
+				<extensions>
+					<speed>3.122013568878174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014282912989449" lon="-84.20247365326291">
+				<ele>945.8198270266876</ele>
+				<time>2017-11-20T20:31:30Z</time>
+				<extensions>
+					<speed>1.857990026473999</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014274969213217" lon="-84.20247720323414">
+				<ele>946.0071209585294</ele>
+				<time>2017-11-20T20:31:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014277522251131" lon="-84.202475033852">
+				<ele>945.8005594359711</ele>
+				<time>2017-11-20T20:31:32Z</time>
+				<extensions>
+					<speed>0.4612937569618225</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014277522251131" lon="-84.202475033852">
+				<ele>945.8005594359711</ele>
+				<time>2017-11-20T20:31:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014283709729433" lon="-84.20246763296183">
+				<ele>946.8360126242042</ele>
+				<time>2017-11-20T20:31:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014283709729433" lon="-84.20246763296183">
+				<ele>946.8360126242042</ele>
+				<time>2017-11-20T20:31:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014283709729433" lon="-84.20246763296183">
+				<ele>946.8360126242042</ele>
+				<time>2017-11-20T20:31:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014283709729433" lon="-84.20246763296183">
+				<ele>946.8360126242042</ele>
+				<time>2017-11-20T20:31:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014283709729433" lon="-84.20246763296183">
+				<ele>946.8360126242042</ele>
+				<time>2017-11-20T20:31:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014276552832849" lon="-84.20247126850509">
+				<ele>946.4347266424447</ele>
+				<time>2017-11-20T20:31:39Z</time>
+				<extensions>
+					<speed>0.7159127593040466</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014266021336857" lon="-84.20247358864475">
+				<ele>945.7691645696759</ele>
+				<time>2017-11-20T20:31:40Z</time>
+				<extensions>
+					<speed>1.3698161840438843</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014249201699053" lon="-84.20247048701184">
+				<ele>945.4011557502672</ele>
+				<time>2017-11-20T20:31:41Z</time>
+				<extensions>
+					<speed>2.514313220977783</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01422324332272" lon="-84.20245833517293">
+				<ele>944.8825591476634</ele>
+				<time>2017-11-20T20:31:42Z</time>
+				<extensions>
+					<speed>3.8559725284576416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014188182190525" lon="-84.2024321835901">
+				<ele>944.1760421441868</ele>
+				<time>2017-11-20T20:31:43Z</time>
+				<extensions>
+					<speed>5.125463485717773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014147278649844" lon="-84.20238833327089">
+				<ele>943.3941015610471</ele>
+				<time>2017-11-20T20:31:44Z</time>
+				<extensions>
+					<speed>7.13163423538208</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01410407611442" lon="-84.20232707208908">
+				<ele>942.5326201831922</ele>
+				<time>2017-11-20T20:31:45Z</time>
+				<extensions>
+					<speed>8.545621871948242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014059345013345" lon="-84.20225252372113">
+				<ele>941.9897700818256</ele>
+				<time>2017-11-20T20:31:46Z</time>
+				<extensions>
+					<speed>9.878766059875488</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014015013125352" lon="-84.20216760224956">
+				<ele>941.588343443349</ele>
+				<time>2017-11-20T20:31:47Z</time>
+				<extensions>
+					<speed>10.574542999267578</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013971640315626" lon="-84.20207888382635">
+				<ele>941.253259354271</ele>
+				<time>2017-11-20T20:31:48Z</time>
+				<extensions>
+					<speed>10.656037330627441</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01392850292533" lon="-84.20199012919822">
+				<ele>941.0529438210651</ele>
+				<time>2017-11-20T20:31:49Z</time>
+				<extensions>
+					<speed>10.7149019241333</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013888479965482" lon="-84.20190127622793">
+				<ele>940.8938261615112</ele>
+				<time>2017-11-20T20:31:50Z</time>
+				<extensions>
+					<speed>10.529426574707031</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013846479109556" lon="-84.20181709189679">
+				<ele>941.2372380420566</ele>
+				<time>2017-11-20T20:31:51Z</time>
+				<extensions>
+					<speed>9.39930534362793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013799816395316" lon="-84.20174697648372">
+				<ele>941.9068996980786</ele>
+				<time>2017-11-20T20:31:52Z</time>
+				<extensions>
+					<speed>8.537383079528809</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013758349154777" lon="-84.20168443215736">
+				<ele>942.06251990702</ele>
+				<time>2017-11-20T20:31:53Z</time>
+				<extensions>
+					<speed>7.995300769805908</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013716675779857" lon="-84.20162491948595">
+				<ele>942.424867765978</ele>
+				<time>2017-11-20T20:31:54Z</time>
+				<extensions>
+					<speed>7.721230506896973</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013676321430163" lon="-84.20157396476651">
+				<ele>943.1163750616834</ele>
+				<time>2017-11-20T20:31:55Z</time>
+				<extensions>
+					<speed>6.921063423156738</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013638625664502" lon="-84.20153136156057">
+				<ele>943.8619056725875</ele>
+				<time>2017-11-20T20:31:56Z</time>
+				<extensions>
+					<speed>6.262314319610596</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013604161314145" lon="-84.20149483496321">
+				<ele>944.3304342599586</ele>
+				<time>2017-11-20T20:31:57Z</time>
+				<extensions>
+					<speed>5.932939052581787</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013570889043011" lon="-84.20145854157454">
+				<ele>944.4732719659805</ele>
+				<time>2017-11-20T20:31:58Z</time>
+				<extensions>
+					<speed>5.632086753845215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013539415662168" lon="-84.20142345998626">
+				<ele>944.6383557207882</ele>
+				<time>2017-11-20T20:31:59Z</time>
+				<extensions>
+					<speed>5.497752666473389</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01350963978359" lon="-84.201389296243">
+				<ele>944.9716480504721</ele>
+				<time>2017-11-20T20:32:00Z</time>
+				<extensions>
+					<speed>5.3678669929504395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013479968500041" lon="-84.20135386252923">
+				<ele>945.5752065181732</ele>
+				<time>2017-11-20T20:32:01Z</time>
+				<extensions>
+					<speed>5.115835189819336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013452123371296" lon="-84.201318948873">
+				<ele>946.0111945644021</ele>
+				<time>2017-11-20T20:32:02Z</time>
+				<extensions>
+					<speed>4.958789348602295</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013424363743388" lon="-84.2012863542797">
+				<ele>946.320936691016</ele>
+				<time>2017-11-20T20:32:03Z</time>
+				<extensions>
+					<speed>4.750614643096924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013397571930575" lon="-84.20125406572575">
+				<ele>946.9040457420051</ele>
+				<time>2017-11-20T20:32:04Z</time>
+				<extensions>
+					<speed>4.739460468292236</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013371660581214" lon="-84.20122321757869">
+				<ele>947.5252392133698</ele>
+				<time>2017-11-20T20:32:05Z</time>
+				<extensions>
+					<speed>4.554135799407959</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013348038645939" lon="-84.20119288863964">
+				<ele>948.440961342305</ele>
+				<time>2017-11-20T20:32:06Z</time>
+				<extensions>
+					<speed>4.453390598297119</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01332514670347" lon="-84.20116238920133">
+				<ele>949.1222199779004</ele>
+				<time>2017-11-20T20:32:07Z</time>
+				<extensions>
+					<speed>4.232859134674072</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013303573479297" lon="-84.20113232054493">
+				<ele>949.6110208146274</ele>
+				<time>2017-11-20T20:32:08Z</time>
+				<extensions>
+					<speed>3.8857076168060303</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013280989201744" lon="-84.20110341004481">
+				<ele>949.9548595855013</ele>
+				<time>2017-11-20T20:32:09Z</time>
+				<extensions>
+					<speed>3.943378210067749</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0132567007017" lon="-84.20107411081874">
+				<ele>950.1033348729834</ele>
+				<time>2017-11-20T20:32:10Z</time>
+				<extensions>
+					<speed>4.296823501586914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013230422213109" lon="-84.20104295656954">
+				<ele>950.1650552805513</ele>
+				<time>2017-11-20T20:32:11Z</time>
+				<extensions>
+					<speed>4.479342460632324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013205430505568" lon="-84.20101147163393">
+				<ele>949.7384633366019</ele>
+				<time>2017-11-20T20:32:12Z</time>
+				<extensions>
+					<speed>4.522379398345947</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013180748567514" lon="-84.20098074580132">
+				<ele>949.4222636418417</ele>
+				<time>2017-11-20T20:32:13Z</time>
+				<extensions>
+					<speed>4.2389068603515625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013157345967665" lon="-84.20094987254278">
+				<ele>949.2761436272413</ele>
+				<time>2017-11-20T20:32:14Z</time>
+				<extensions>
+					<speed>4.1751508712768555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013138641372185" lon="-84.20092080433025">
+				<ele>949.263013843447</ele>
+				<time>2017-11-20T20:32:15Z</time>
+				<extensions>
+					<speed>3.466942548751831</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013125436309053" lon="-84.200898460256">
+				<ele>949.3158543789759</ele>
+				<time>2017-11-20T20:32:16Z</time>
+				<extensions>
+					<speed>2.386042356491089</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013119557325357" lon="-84.20088551477646">
+				<ele>949.3552098218352</ele>
+				<time>2017-11-20T20:32:17Z</time>
+				<extensions>
+					<speed>1.0463886260986328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013121266618317" lon="-84.20087915272936">
+				<ele>949.6849367879331</ele>
+				<time>2017-11-20T20:32:18Z</time>
+				<extensions>
+					<speed>0.4887329638004303</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013121266618317" lon="-84.20087915272936">
+				<ele>949.6849367879331</ele>
+				<time>2017-11-20T20:32:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013124735677133" lon="-84.20088166100666">
+				<ele>949.5733442250639</ele>
+				<time>2017-11-20T20:32:20Z</time>
+				<extensions>
+					<speed>0.48564213514328003</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013124735677133" lon="-84.20088166100666">
+				<ele>949.5733442250639</ele>
+				<time>2017-11-20T20:32:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013127527540917" lon="-84.20088583699624">
+				<ele>949.3930536257103</ele>
+				<time>2017-11-20T20:32:22Z</time>
+				<extensions>
+					<speed>0.3803257346153259</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013127527540917" lon="-84.20088583699624">
+				<ele>949.3930536257103</ele>
+				<time>2017-11-20T20:32:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013127527540917" lon="-84.20088583699624">
+				<ele>949.3930536257103</ele>
+				<time>2017-11-20T20:32:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013127527540917" lon="-84.20088583699624">
+				<ele>949.3930536257103</ele>
+				<time>2017-11-20T20:32:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013127527540917" lon="-84.20088583699624">
+				<ele>949.3930536257103</ele>
+				<time>2017-11-20T20:32:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013127527540917" lon="-84.20088583699624">
+				<ele>949.3930536257103</ele>
+				<time>2017-11-20T20:32:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013127527540917" lon="-84.20088583699624">
+				<ele>949.3930536257103</ele>
+				<time>2017-11-20T20:32:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013127527540917" lon="-84.20088583699624">
+				<ele>949.3930536257103</ele>
+				<time>2017-11-20T20:32:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013127527540917" lon="-84.20088583699624">
+				<ele>949.3930536257103</ele>
+				<time>2017-11-20T20:32:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013127527540917" lon="-84.20088583699624">
+				<ele>949.3930536257103</ele>
+				<time>2017-11-20T20:32:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013120366827044" lon="-84.20088499055149">
+				<ele>949.2767918286845</ele>
+				<time>2017-11-20T20:32:32Z</time>
+				<extensions>
+					<speed>1.1632030010223389</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013108522212208" lon="-84.20087795850027">
+				<ele>949.0154670309275</ele>
+				<time>2017-11-20T20:32:33Z</time>
+				<extensions>
+					<speed>2.0379436016082764</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013094070101797" lon="-84.20086171165164">
+				<ele>949.1078312350437</ele>
+				<time>2017-11-20T20:32:34Z</time>
+				<extensions>
+					<speed>2.83378267288208</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013080338519863" lon="-84.20083969806073">
+				<ele>948.8793410155922</ele>
+				<time>2017-11-20T20:32:35Z</time>
+				<extensions>
+					<speed>3.1501145362854004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013065994153981" lon="-84.20081914587071">
+				<ele>948.7329567726701</ele>
+				<time>2017-11-20T20:32:36Z</time>
+				<extensions>
+					<speed>2.5160562992095947</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013051501227933" lon="-84.20080358221617">
+				<ele>948.6411386951804</ele>
+				<time>2017-11-20T20:32:37Z</time>
+				<extensions>
+					<speed>1.991377830505371</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013043765157652" lon="-84.20079341124058">
+				<ele>948.5922988848761</ele>
+				<time>2017-11-20T20:32:38Z</time>
+				<extensions>
+					<speed>0.8235486745834351</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013041904840646" lon="-84.20078863594253">
+				<ele>948.736915118061</ele>
+				<time>2017-11-20T20:32:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013041904840646" lon="-84.20078863594253">
+				<ele>948.736915118061</ele>
+				<time>2017-11-20T20:32:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013041904840646" lon="-84.20078863594253">
+				<ele>948.736915118061</ele>
+				<time>2017-11-20T20:32:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013041904840646" lon="-84.20078863594253">
+				<ele>948.736915118061</ele>
+				<time>2017-11-20T20:32:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013041904840646" lon="-84.20078863594253">
+				<ele>948.736915118061</ele>
+				<time>2017-11-20T20:32:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013041904840646" lon="-84.20078863594253">
+				<ele>948.736915118061</ele>
+				<time>2017-11-20T20:32:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013035112453384" lon="-84.2007831506981">
+				<ele>948.6502907862887</ele>
+				<time>2017-11-20T20:32:45Z</time>
+				<extensions>
+					<speed>1.2945693731307983</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01302486725272" lon="-84.20077374548687">
+				<ele>947.9247536798939</ele>
+				<time>2017-11-20T20:32:46Z</time>
+				<extensions>
+					<speed>1.7122173309326172</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013014970033481" lon="-84.20076119223094">
+				<ele>947.8883624635637</ele>
+				<time>2017-11-20T20:32:47Z</time>
+				<extensions>
+					<speed>1.4329922199249268</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013009325953478" lon="-84.2007493982685">
+				<ele>947.5993476780131</ele>
+				<time>2017-11-20T20:32:48Z</time>
+				<extensions>
+					<speed>1.2143179178237915</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013008307192411" lon="-84.20074044233336">
+				<ele>947.2474663350731</ele>
+				<time>2017-11-20T20:32:49Z</time>
+				<extensions>
+					<speed>0.6271533966064453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013008307192411" lon="-84.20074044233336">
+				<ele>947.2474663350731</ele>
+				<time>2017-11-20T20:32:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013010514545025" lon="-84.20074016969124">
+				<ele>946.9962509134784</ele>
+				<time>2017-11-20T20:32:51Z</time>
+				<extensions>
+					<speed>0.0871034637093544</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013010514545025" lon="-84.20074016969124">
+				<ele>946.9962509134784</ele>
+				<time>2017-11-20T20:32:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013011555152866" lon="-84.20073637330134">
+				<ele>947.1838659252971</ele>
+				<time>2017-11-20T20:32:53Z</time>
+				<extensions>
+					<speed>0.919045090675354</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013012456767328" lon="-84.20072792627118">
+				<ele>947.2035765638575</ele>
+				<time>2017-11-20T20:32:54Z</time>
+				<extensions>
+					<speed>1.5054858922958374</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01301707591965" lon="-84.2007097386447">
+				<ele>948.0932202497497</ele>
+				<time>2017-11-20T20:32:55Z</time>
+				<extensions>
+					<speed>2.16432785987854</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013028197328174" lon="-84.20068353981048">
+				<ele>949.2792722340673</ele>
+				<time>2017-11-20T20:32:56Z</time>
+				<extensions>
+					<speed>3.1542341709136963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013045524689064" lon="-84.20065380648892">
+				<ele>949.7484848638996</ele>
+				<time>2017-11-20T20:32:57Z</time>
+				<extensions>
+					<speed>3.90419864654541</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013072546323006" lon="-84.20062203114061">
+				<ele>950.0906679695472</ele>
+				<time>2017-11-20T20:32:58Z</time>
+				<extensions>
+					<speed>4.860812664031982</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013110225444557" lon="-84.20058664575868">
+				<ele>951.0553426397964</ele>
+				<time>2017-11-20T20:32:59Z</time>
+				<extensions>
+					<speed>5.714573383331299</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013156097395447" lon="-84.20055358283062">
+				<ele>951.7892156140879</ele>
+				<time>2017-11-20T20:33:00Z</time>
+				<extensions>
+					<speed>6.274758338928223</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013208135738621" lon="-84.20052225630026">
+				<ele>952.3126695035025</ele>
+				<time>2017-11-20T20:33:01Z</time>
+				<extensions>
+					<speed>6.5374579429626465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013259192922106" lon="-84.20049339549458">
+				<ele>952.9069652799517</ele>
+				<time>2017-11-20T20:33:02Z</time>
+				<extensions>
+					<speed>6.121145725250244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01330734433118" lon="-84.20046863954167">
+				<ele>953.1570441648364</ele>
+				<time>2017-11-20T20:33:03Z</time>
+				<extensions>
+					<speed>5.603370666503906</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01335086249399" lon="-84.20044684934297">
+				<ele>953.323527161032</ele>
+				<time>2017-11-20T20:33:04Z</time>
+				<extensions>
+					<speed>5.212019443511963</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013392200914785" lon="-84.20042900723767">
+				<ele>953.713201562874</ele>
+				<time>2017-11-20T20:33:05Z</time>
+				<extensions>
+					<speed>4.564835548400879</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013428191022301" lon="-84.2004101286333">
+				<ele>954.8059028591961</ele>
+				<time>2017-11-20T20:33:06Z</time>
+				<extensions>
+					<speed>4.046023368835449</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013460754442962" lon="-84.20039375240724">
+				<ele>955.461508275941</ele>
+				<time>2017-11-20T20:33:07Z</time>
+				<extensions>
+					<speed>3.7171967029571533</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013490610865025" lon="-84.20037973209935">
+				<ele>956.1136297741905</ele>
+				<time>2017-11-20T20:33:08Z</time>
+				<extensions>
+					<speed>3.1749014854431152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013516613947916" lon="-84.20036388104404">
+				<ele>956.5683877347037</ele>
+				<time>2017-11-20T20:33:09Z</time>
+				<extensions>
+					<speed>3.300544023513794</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013544507169064" lon="-84.20034271590069">
+				<ele>957.0304136276245</ele>
+				<time>2017-11-20T20:33:10Z</time>
+				<extensions>
+					<speed>3.787346601486206</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01357407919595" lon="-84.20032086764495">
+				<ele>957.5759507054463</ele>
+				<time>2017-11-20T20:33:11Z</time>
+				<extensions>
+					<speed>3.9119744300842285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013606962483475" lon="-84.20029787816357">
+				<ele>958.1134222410619</ele>
+				<time>2017-11-20T20:33:12Z</time>
+				<extensions>
+					<speed>4.393320560455322</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01364925436812" lon="-84.20027068881656">
+				<ele>958.7577947089449</ele>
+				<time>2017-11-20T20:33:13Z</time>
+				<extensions>
+					<speed>5.391509056091309</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01369424416263" lon="-84.20023949906596">
+				<ele>958.5776620591059</ele>
+				<time>2017-11-20T20:33:14Z</time>
+				<extensions>
+					<speed>5.858310699462891</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0137410826949" lon="-84.20020115157111">
+				<ele>960.0636401502416</ele>
+				<time>2017-11-20T20:33:15Z</time>
+				<extensions>
+					<speed>6.252753734588623</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013790924756272" lon="-84.20016254004386">
+				<ele>962.0780309811234</ele>
+				<time>2017-11-20T20:33:16Z</time>
+				<extensions>
+					<speed>6.732848167419434</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013842884822832" lon="-84.20012364377538">
+				<ele>963.0552709642798</ele>
+				<time>2017-11-20T20:33:17Z</time>
+				<extensions>
+					<speed>7.051089286804199</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013893709666274" lon="-84.20008093017063">
+				<ele>963.7619993994012</ele>
+				<time>2017-11-20T20:33:18Z</time>
+				<extensions>
+					<speed>7.205791473388672</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01394467617995" lon="-84.20003613777854">
+				<ele>964.2813453273848</ele>
+				<time>2017-11-20T20:33:19Z</time>
+				<extensions>
+					<speed>7.273263931274414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013994788875177" lon="-84.19998887205251">
+				<ele>964.3088311702013</ele>
+				<time>2017-11-20T20:33:20Z</time>
+				<extensions>
+					<speed>7.402010440826416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014043624679793" lon="-84.19993917360473">
+				<ele>964.6622753078118</ele>
+				<time>2017-11-20T20:33:21Z</time>
+				<extensions>
+					<speed>7.455739974975586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014093349508713" lon="-84.19989115417097">
+				<ele>965.0819316217676</ele>
+				<time>2017-11-20T20:33:22Z</time>
+				<extensions>
+					<speed>7.512526512145996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014143801185753" lon="-84.19984215722066">
+				<ele>965.2054577935487</ele>
+				<time>2017-11-20T20:33:23Z</time>
+				<extensions>
+					<speed>7.560647964477539</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014194113904486" lon="-84.19979316229004">
+				<ele>965.7477459078655</ele>
+				<time>2017-11-20T20:33:24Z</time>
+				<extensions>
+					<speed>7.599680423736572</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014245607136395" lon="-84.19974415518297">
+				<ele>966.2670811098069</ele>
+				<time>2017-11-20T20:33:25Z</time>
+				<extensions>
+					<speed>7.67726469039917</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014302267375047" lon="-84.19969380930704">
+				<ele>967.1292929844931</ele>
+				<time>2017-11-20T20:33:26Z</time>
+				<extensions>
+					<speed>8.086655616760254</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014363908076216" lon="-84.19964590772273">
+				<ele>967.5954454159364</ele>
+				<time>2017-11-20T20:33:27Z</time>
+				<extensions>
+					<speed>8.197036743164063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014423206226853" lon="-84.19959983774969">
+				<ele>968.1167872836813</ele>
+				<time>2017-11-20T20:33:28Z</time>
+				<extensions>
+					<speed>7.8607401847839355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014480930033324" lon="-84.19955347546464">
+				<ele>968.4022989999503</ele>
+				<time>2017-11-20T20:33:29Z</time>
+				<extensions>
+					<speed>8.007171630859375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014537696706764" lon="-84.19950384661352">
+				<ele>969.1258731111884</ele>
+				<time>2017-11-20T20:33:30Z</time>
+				<extensions>
+					<speed>7.847034931182861</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014592626995832" lon="-84.19945537900469">
+				<ele>969.7394708031788</ele>
+				<time>2017-11-20T20:33:31Z</time>
+				<extensions>
+					<speed>7.789058685302734</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014646983995972" lon="-84.19940982752946">
+				<ele>969.929019629024</ele>
+				<time>2017-11-20T20:33:32Z</time>
+				<extensions>
+					<speed>7.716914176940918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014700826733508" lon="-84.19936604365155">
+				<ele>970.2044815327972</ele>
+				<time>2017-11-20T20:33:33Z</time>
+				<extensions>
+					<speed>7.570437908172607</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014756130959128" lon="-84.19932553669669">
+				<ele>970.6054701972753</ele>
+				<time>2017-11-20T20:33:34Z</time>
+				<extensions>
+					<speed>7.160078525543213</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014808691160278" lon="-84.19928573555244">
+				<ele>971.2384757408872</ele>
+				<time>2017-11-20T20:33:35Z</time>
+				<extensions>
+					<speed>6.782967567443848</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014859691147871" lon="-84.19924575364264">
+				<ele>971.6337267290801</ele>
+				<time>2017-11-20T20:33:36Z</time>
+				<extensions>
+					<speed>6.909695625305176</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01491255286652" lon="-84.19920352466524">
+				<ele>972.2567245159298</ele>
+				<time>2017-11-20T20:33:37Z</time>
+				<extensions>
+					<speed>7.251917362213135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01496823129312" lon="-84.19916095924907">
+				<ele>972.9725694889203</ele>
+				<time>2017-11-20T20:33:38Z</time>
+				<extensions>
+					<speed>7.5166015625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015024930216493" lon="-84.19911626627122">
+				<ele>973.6762580024078</ele>
+				<time>2017-11-20T20:33:39Z</time>
+				<extensions>
+					<speed>7.636242866516113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015080788268797" lon="-84.19907153839661">
+				<ele>973.9633850939572</ele>
+				<time>2017-11-20T20:33:40Z</time>
+				<extensions>
+					<speed>7.627077579498291</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01513829621013" lon="-84.19902596328936">
+				<ele>974.3493388211355</ele>
+				<time>2017-11-20T20:33:41Z</time>
+				<extensions>
+					<speed>7.939793109893799</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015196436553598" lon="-84.19898064582003">
+				<ele>974.3116266783327</ele>
+				<time>2017-11-20T20:33:42Z</time>
+				<extensions>
+					<speed>7.975404739379883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015254449938853" lon="-84.19893353948599">
+				<ele>974.7011293508112</ele>
+				<time>2017-11-20T20:33:43Z</time>
+				<extensions>
+					<speed>8.194429397583008</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015313052848533" lon="-84.19888397760924">
+				<ele>974.8518692264333</ele>
+				<time>2017-11-20T20:33:44Z</time>
+				<extensions>
+					<speed>8.267293930053711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015370036398854" lon="-84.1988320053423">
+				<ele>974.9872885318473</ele>
+				<time>2017-11-20T20:33:45Z</time>
+				<extensions>
+					<speed>8.245206832885742</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01542536082072" lon="-84.19877570703635">
+				<ele>973.905514341779</ele>
+				<time>2017-11-20T20:33:46Z</time>
+				<extensions>
+					<speed>8.476852416992188</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01547647417528" lon="-84.19871401657674">
+				<ele>972.8225149326026</ele>
+				<time>2017-11-20T20:33:47Z</time>
+				<extensions>
+					<speed>8.352116584777832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015519840683565" lon="-84.19864797469224">
+				<ele>973.0453599654138</ele>
+				<time>2017-11-20T20:33:48Z</time>
+				<extensions>
+					<speed>8.583505630493164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015555664233254" lon="-84.19857743296578">
+				<ele>973.4048024779186</ele>
+				<time>2017-11-20T20:33:49Z</time>
+				<extensions>
+					<speed>8.64121150970459</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015586482352482" lon="-84.19850235824894">
+				<ele>973.4269131170586</ele>
+				<time>2017-11-20T20:33:50Z</time>
+				<extensions>
+					<speed>8.536750793457031</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015611980672602" lon="-84.19842700450745">
+				<ele>973.0305073503405</ele>
+				<time>2017-11-20T20:33:51Z</time>
+				<extensions>
+					<speed>8.539103507995605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015635587664912" lon="-84.19835074615966">
+				<ele>972.3737483015284</ele>
+				<time>2017-11-20T20:33:52Z</time>
+				<extensions>
+					<speed>8.519598007202148</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015659368516" lon="-84.19827435825599">
+				<ele>971.7033453993499</ele>
+				<time>2017-11-20T20:33:53Z</time>
+				<extensions>
+					<speed>8.71340274810791</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015686048224335" lon="-84.19819914788305">
+				<ele>971.5422755395994</ele>
+				<time>2017-11-20T20:33:54Z</time>
+				<extensions>
+					<speed>8.581214904785156</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015714498880824" lon="-84.19812448240734">
+				<ele>971.1387734813616</ele>
+				<time>2017-11-20T20:33:55Z</time>
+				<extensions>
+					<speed>8.652263641357422</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01574202374929" lon="-84.19805055209369">
+				<ele>971.1773758381605</ele>
+				<time>2017-11-20T20:33:56Z</time>
+				<extensions>
+					<speed>8.438651084899902</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015769395880875" lon="-84.19797988361225">
+				<ele>970.9054418439046</ele>
+				<time>2017-11-20T20:33:57Z</time>
+				<extensions>
+					<speed>8.364492416381836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015796443417022" lon="-84.19791227088808">
+				<ele>971.103138178587</ele>
+				<time>2017-11-20T20:33:58Z</time>
+				<extensions>
+					<speed>8.061199188232422</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01582306848449" lon="-84.19784808702296">
+				<ele>971.6016382146627</ele>
+				<time>2017-11-20T20:33:59Z</time>
+				<extensions>
+					<speed>7.5132012367248535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015851866826926" lon="-84.19778914545321">
+				<ele>971.5266033159569</ele>
+				<time>2017-11-20T20:34:00Z</time>
+				<extensions>
+					<speed>6.854959487915039</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015884459095187" lon="-84.19773251130934">
+				<ele>971.9850975647569</ele>
+				<time>2017-11-20T20:34:01Z</time>
+				<extensions>
+					<speed>6.876428127288818</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01591925024308" lon="-84.19767816874632">
+				<ele>972.452639747411</ele>
+				<time>2017-11-20T20:34:02Z</time>
+				<extensions>
+					<speed>7.1090006828308105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015952800291094" lon="-84.19761743954184">
+				<ele>973.0306535800919</ele>
+				<time>2017-11-20T20:34:03Z</time>
+				<extensions>
+					<speed>7.630430698394775</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015983357406766" lon="-84.1975542109162">
+				<ele>973.4263097010553</ele>
+				<time>2017-11-20T20:34:04Z</time>
+				<extensions>
+					<speed>7.80321741104126</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01601332612567" lon="-84.1974883903614">
+				<ele>973.6925819460303</ele>
+				<time>2017-11-20T20:34:05Z</time>
+				<extensions>
+					<speed>8.284284591674805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016043501561805" lon="-84.19741741988719">
+				<ele>974.2114060660824</ele>
+				<time>2017-11-20T20:34:06Z</time>
+				<extensions>
+					<speed>8.465473175048828</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016075770053703" lon="-84.19734595474648">
+				<ele>974.2016836572438</ele>
+				<time>2017-11-20T20:34:07Z</time>
+				<extensions>
+					<speed>8.60710620880127</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016109910530458" lon="-84.19727333843284">
+				<ele>974.3417885098606</ele>
+				<time>2017-11-20T20:34:08Z</time>
+				<extensions>
+					<speed>8.760396957397461</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01614634714131" lon="-84.19720094856734">
+				<ele>974.371040198952</ele>
+				<time>2017-11-20T20:34:09Z</time>
+				<extensions>
+					<speed>8.679222106933594</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016184544292582" lon="-84.19713129808497">
+				<ele>974.8259522626176</ele>
+				<time>2017-11-20T20:34:10Z</time>
+				<extensions>
+					<speed>8.430159568786621</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016222436160477" lon="-84.19706452565659">
+				<ele>975.1504421038553</ele>
+				<time>2017-11-20T20:34:11Z</time>
+				<extensions>
+					<speed>8.51338005065918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01626225068703" lon="-84.19699840431643">
+				<ele>975.6905101146549</ele>
+				<time>2017-11-20T20:34:12Z</time>
+				<extensions>
+					<speed>8.450712203979492</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01630193731687" lon="-84.19693481941185">
+				<ele>975.9158176919445</ele>
+				<time>2017-11-20T20:34:13Z</time>
+				<extensions>
+					<speed>8.047131538391113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016340991049121" lon="-84.19687351530082">
+				<ele>976.1081556640565</ele>
+				<time>2017-11-20T20:34:14Z</time>
+				<extensions>
+					<speed>7.7704973220825195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016378984124039" lon="-84.19682096882289">
+				<ele>975.9820691775531</ele>
+				<time>2017-11-20T20:34:15Z</time>
+				<extensions>
+					<speed>6.270602703094482</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016411923394791" lon="-84.19678025395407">
+				<ele>975.6094284662977</ele>
+				<time>2017-11-20T20:34:16Z</time>
+				<extensions>
+					<speed>4.944964408874512</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016437345711033" lon="-84.19675044814338">
+				<ele>975.3567143911496</ele>
+				<time>2017-11-20T20:34:17Z</time>
+				<extensions>
+					<speed>3.4902682304382324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016455465715593" lon="-84.1967318881734">
+				<ele>974.6559758298099</ele>
+				<time>2017-11-20T20:34:18Z</time>
+				<extensions>
+					<speed>2.1096014976501465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016469644493387" lon="-84.19672546326272">
+				<ele>973.7418354935944</ele>
+				<time>2017-11-20T20:34:19Z</time>
+				<extensions>
+					<speed>0.9688840508460999</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016474803386423" lon="-84.19672917895988">
+				<ele>973.034937415272</ele>
+				<time>2017-11-20T20:34:20Z</time>
+				<extensions>
+					<speed>0.48466935753822327</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016474803386423" lon="-84.19672917895988">
+				<ele>973.034937415272</ele>
+				<time>2017-11-20T20:34:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016473039305753" lon="-84.1967345269327">
+				<ele>972.820685618557</ele>
+				<time>2017-11-20T20:34:22Z</time>
+				<extensions>
+					<speed>1.017031192779541</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016471749790563" lon="-84.19673952325753">
+				<ele>972.582984732464</ele>
+				<time>2017-11-20T20:34:23Z</time>
+				<extensions>
+					<speed>0.7447741031646729</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016471749790563" lon="-84.19673952325753">
+				<ele>972.582984732464</ele>
+				<time>2017-11-20T20:34:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01647550002715" lon="-84.19673833541466">
+				<ele>972.7711714962497</ele>
+				<time>2017-11-20T20:34:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01647550002715" lon="-84.19673833541466">
+				<ele>972.7711714962497</ele>
+				<time>2017-11-20T20:34:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01647550002715" lon="-84.19673833541466">
+				<ele>972.7711714962497</ele>
+				<time>2017-11-20T20:34:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01647550002715" lon="-84.19673833541466">
+				<ele>972.7711714962497</ele>
+				<time>2017-11-20T20:34:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01647550002715" lon="-84.19673833541466">
+				<ele>972.7711714962497</ele>
+				<time>2017-11-20T20:34:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01647550002715" lon="-84.19673833541466">
+				<ele>972.7711714962497</ele>
+				<time>2017-11-20T20:34:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01647550002715" lon="-84.19673833541466">
+				<ele>972.7711714962497</ele>
+				<time>2017-11-20T20:34:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016479615896252" lon="-84.19672977500097">
+				<ele>972.2349784914404</ele>
+				<time>2017-11-20T20:34:32Z</time>
+				<extensions>
+					<speed>1.0544377565383911</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016488993040362" lon="-84.19671563851773">
+				<ele>972.1333875982091</ele>
+				<time>2017-11-20T20:34:33Z</time>
+				<extensions>
+					<speed>2.0624215602874756</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016503131446663" lon="-84.19669305063523">
+				<ele>972.2840305771679</ele>
+				<time>2017-11-20T20:34:34Z</time>
+				<extensions>
+					<speed>3.1302883625030518</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0165209809536" lon="-84.19666498699655">
+				<ele>972.449026205577</ele>
+				<time>2017-11-20T20:34:35Z</time>
+				<extensions>
+					<speed>3.7491791248321533</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016543863131075" lon="-84.19663711843708">
+				<ele>972.1692940993235</ele>
+				<time>2017-11-20T20:34:36Z</time>
+				<extensions>
+					<speed>3.8630425930023193</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01656979899027" lon="-84.19660255567247">
+				<ele>972.4256501561031</ele>
+				<time>2017-11-20T20:34:37Z</time>
+				<extensions>
+					<speed>4.431015491485596</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016595156656134" lon="-84.19656735493362">
+				<ele>972.2679962487891</ele>
+				<time>2017-11-20T20:34:38Z</time>
+				<extensions>
+					<speed>4.921398162841797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016623789212444" lon="-84.19653153475954">
+				<ele>971.9130008257926</ele>
+				<time>2017-11-20T20:34:39Z</time>
+				<extensions>
+					<speed>5.105218887329102</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01665804402763" lon="-84.1964959555739">
+				<ele>971.1714098351076</ele>
+				<time>2017-11-20T20:34:40Z</time>
+				<extensions>
+					<speed>5.3566975593566895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016695524233187" lon="-84.19645967268922">
+				<ele>970.4840226378292</ele>
+				<time>2017-11-20T20:34:41Z</time>
+				<extensions>
+					<speed>5.609577655792236</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016734440063004" lon="-84.19642404709049">
+				<ele>969.6673119226471</ele>
+				<time>2017-11-20T20:34:42Z</time>
+				<extensions>
+					<speed>5.585653305053711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016771629220795" lon="-84.19639133056971">
+				<ele>968.7777331322432</ele>
+				<time>2017-11-20T20:34:43Z</time>
+				<extensions>
+					<speed>5.081526279449463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016803162757832" lon="-84.19636326142778">
+				<ele>967.509674671106</ele>
+				<time>2017-11-20T20:34:44Z</time>
+				<extensions>
+					<speed>4.137465953826904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016826152193033" lon="-84.19634242679577">
+				<ele>966.3394772196189</ele>
+				<time>2017-11-20T20:34:45Z</time>
+				<extensions>
+					<speed>2.4911272525787354</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016838119526955" lon="-84.19633001139384">
+				<ele>965.917974521406</ele>
+				<time>2017-11-20T20:34:46Z</time>
+				<extensions>
+					<speed>1.1737844944000244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016849423031474" lon="-84.19632613195803">
+				<ele>966.1285650050268</ele>
+				<time>2017-11-20T20:34:47Z</time>
+				<extensions>
+					<speed>1.5012836456298828</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016864886752812" lon="-84.19632348293491">
+				<ele>966.4077725689858</ele>
+				<time>2017-11-20T20:34:48Z</time>
+				<extensions>
+					<speed>1.6110819578170776</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016879770848735" lon="-84.19631782198118">
+				<ele>966.6198988324031</ele>
+				<time>2017-11-20T20:34:49Z</time>
+				<extensions>
+					<speed>1.839977741241455</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016897824455466" lon="-84.1963082044834">
+				<ele>967.3279690491036</ele>
+				<time>2017-11-20T20:34:50Z</time>
+				<extensions>
+					<speed>2.46224045753479</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016922692956996" lon="-84.1962912977991">
+				<ele>968.7530232779682</ele>
+				<time>2017-11-20T20:34:51Z</time>
+				<extensions>
+					<speed>3.725431442260742</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016952919821264" lon="-84.19626872376386">
+				<ele>969.4647552454844</ele>
+				<time>2017-11-20T20:34:52Z</time>
+				<extensions>
+					<speed>4.4731245040893555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016984394441204" lon="-84.19624172826842">
+				<ele>969.4178399527445</ele>
+				<time>2017-11-20T20:34:53Z</time>
+				<extensions>
+					<speed>4.6570820808410645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017017495824346" lon="-84.19621298000044">
+				<ele>969.2448208173737</ele>
+				<time>2017-11-20T20:34:54Z</time>
+				<extensions>
+					<speed>4.623061656951904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017052376205383" lon="-84.19618198118872">
+				<ele>969.3042748058215</ele>
+				<time>2017-11-20T20:34:55Z</time>
+				<extensions>
+					<speed>4.752947807312012</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017089228791486" lon="-84.19615095903198">
+				<ele>969.5625125365332</ele>
+				<time>2017-11-20T20:34:56Z</time>
+				<extensions>
+					<speed>4.835235595703125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017125336837465" lon="-84.19612045057146">
+				<ele>969.7640128731728</ele>
+				<time>2017-11-20T20:34:57Z</time>
+				<extensions>
+					<speed>4.850679874420166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017159189430812" lon="-84.19608867918004">
+				<ele>970.1900644144043</ele>
+				<time>2017-11-20T20:34:58Z</time>
+				<extensions>
+					<speed>4.787863731384277</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017193691276619" lon="-84.19605893170696">
+				<ele>970.3376332297921</ele>
+				<time>2017-11-20T20:34:59Z</time>
+				<extensions>
+					<speed>4.745657444000244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017226079441091" lon="-84.19603449935575">
+				<ele>970.2675497317687</ele>
+				<time>2017-11-20T20:35:00Z</time>
+				<extensions>
+					<speed>4.117900371551514</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01725557202403" lon="-84.19601624600453">
+				<ele>970.2100805426016</ele>
+				<time>2017-11-20T20:35:01Z</time>
+				<extensions>
+					<speed>3.631988048553467</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017281079032134" lon="-84.1960076610629">
+				<ele>970.4270365331322</ele>
+				<time>2017-11-20T20:35:02Z</time>
+				<extensions>
+					<speed>2.6074137687683105</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017297958154522" lon="-84.19600592603776">
+				<ele>970.6987203536555</ele>
+				<time>2017-11-20T20:35:03Z</time>
+				<extensions>
+					<speed>1.1561294794082642</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017302944011195" lon="-84.1960084416554">
+				<ele>970.7713456274942</ele>
+				<time>2017-11-20T20:35:04Z</time>
+				<extensions>
+					<speed>0.45426270365715027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017302944011195" lon="-84.1960084416554">
+				<ele>970.7713456274942</ele>
+				<time>2017-11-20T20:35:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01729418201881" lon="-84.19601299320476">
+				<ele>970.7759726690128</ele>
+				<time>2017-11-20T20:35:06Z</time>
+				<extensions>
+					<speed>1.2418476343154907</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017278083196294" lon="-84.19601979914788">
+				<ele>970.5896006589755</ele>
+				<time>2017-11-20T20:35:07Z</time>
+				<extensions>
+					<speed>1.558993935585022</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017261918806966" lon="-84.19602822863513">
+				<ele>970.4925651233643</ele>
+				<time>2017-11-20T20:35:08Z</time>
+				<extensions>
+					<speed>1.7090659141540527</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017243648327328" lon="-84.19603712045824">
+				<ele>969.8460174873471</ele>
+				<time>2017-11-20T20:35:09Z</time>
+				<extensions>
+					<speed>1.8502931594848633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017222444879842" lon="-84.19604632539465">
+				<ele>968.4776564296335</ele>
+				<time>2017-11-20T20:35:10Z</time>
+				<extensions>
+					<speed>1.724501609802246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017200818918997" lon="-84.19604688480308">
+				<ele>967.8519203178585</ele>
+				<time>2017-11-20T20:35:11Z</time>
+				<extensions>
+					<speed>1.8574942350387573</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017182966204873" lon="-84.19603900137548">
+				<ele>967.8489157389849</ele>
+				<time>2017-11-20T20:35:12Z</time>
+				<extensions>
+					<speed>1.7619601488113403</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017163557715511" lon="-84.19603382487179">
+				<ele>967.912322724238</ele>
+				<time>2017-11-20T20:35:13Z</time>
+				<extensions>
+					<speed>1.832343339920044</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017146827988087" lon="-84.19602608300548">
+				<ele>968.4278752934188</ele>
+				<time>2017-11-20T20:35:14Z</time>
+				<extensions>
+					<speed>1.869391679763794</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017132098511858" lon="-84.1960165128731">
+				<ele>968.6926293913275</ele>
+				<time>2017-11-20T20:35:15Z</time>
+				<extensions>
+					<speed>1.8339357376098633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017118306878166" lon="-84.1960075728743">
+				<ele>968.5794719513506</ele>
+				<time>2017-11-20T20:35:16Z</time>
+				<extensions>
+					<speed>1.5904895067214966</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017103212644978" lon="-84.1960006594667">
+				<ele>968.3263699952513</ele>
+				<time>2017-11-20T20:35:17Z</time>
+				<extensions>
+					<speed>1.6359461545944214</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017089627529012" lon="-84.19599523585858">
+				<ele>968.3184069208801</ele>
+				<time>2017-11-20T20:35:18Z</time>
+				<extensions>
+					<speed>1.4808366298675537</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017079289605016" lon="-84.19599014074464">
+				<ele>968.3442577933893</ele>
+				<time>2017-11-20T20:35:19Z</time>
+				<extensions>
+					<speed>1.084923267364502</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01707398085822" lon="-84.19598653702137">
+				<ele>968.2328406255692</ele>
+				<time>2017-11-20T20:35:20Z</time>
+				<extensions>
+					<speed>0.6280407309532166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01707398085822" lon="-84.19598653702137">
+				<ele>968.2328406255692</ele>
+				<time>2017-11-20T20:35:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017071922704256" lon="-84.19598496850634">
+				<ele>968.2619494581595</ele>
+				<time>2017-11-20T20:35:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017071922704256" lon="-84.19598496850634">
+				<ele>968.2619494581595</ele>
+				<time>2017-11-20T20:35:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017071922704256" lon="-84.19598496850634">
+				<ele>968.2619494581595</ele>
+				<time>2017-11-20T20:35:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017071922704256" lon="-84.19598496850634">
+				<ele>968.2619494581595</ele>
+				<time>2017-11-20T20:35:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017071922704256" lon="-84.19598496850634">
+				<ele>968.2619494581595</ele>
+				<time>2017-11-20T20:35:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+		</trkseg>
+	</trk>
+</gpx>

--- a/bus_alajuela-targuases/asistentes/fran_2017_11_6.gpx
+++ b/bus_alajuela-targuases/asistentes/fran_2017_11_6.gpx
@@ -1,0 +1,10908 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="OSMTracker for Android™ - https://github.com/nguillaumin/osmtracker-android" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd ">
+	<wpt lat="10.015191207410863" lon="-84.21334405514422">
+		<ele>935.938239752315</ele>
+		<time>2017-11-06T18:44:00Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015191207410863" lon="-84.21334405514422">
+		<ele>935.938239752315</ele>
+		<time>2017-11-06T18:44:03Z</time>
+		<name><![CDATA[3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015682972551408" lon="-84.21184051291061">
+		<ele>956.0814775852486</ele>
+		<time>2017-11-06T18:44:40Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015680965936175" lon="-84.21184873431281">
+		<ele>956.4509461941198</ele>
+		<time>2017-11-06T18:44:41Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.007190977343468" lon="-84.20657359502624">
+		<ele>949.9576341584325</ele>
+		<time>2017-11-06T18:53:34Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.007188511016897" lon="-84.20654761734798">
+		<ele>951.9180018762127</ele>
+		<time>2017-11-06T18:53:35Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.005092950292477" lon="-84.20535933532538">
+		<ele>954.3088297732174</ele>
+		<time>2017-11-06T18:55:10Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.005098041252417" lon="-84.20534686207549">
+		<ele>954.9812690503895</ele>
+		<time>2017-11-06T18:55:11Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.006550988137464" lon="-84.20418389167389">
+		<ele>947.950715999119</ele>
+		<time>2017-11-06T18:56:49Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.006587924416614" lon="-84.20421587395222">
+		<ele>947.8928878167644</ele>
+		<time>2017-11-06T18:56:50Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.007381831713811" lon="-84.20450427960951">
+		<ele>947.6863559065387</ele>
+		<time>2017-11-06T18:57:39Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.007381831713811" lon="-84.20450427960951">
+		<ele>947.6863559065387</ele>
+		<time>2017-11-06T18:57:40Z</time>
+		<name><![CDATA[3]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.010258883180505" lon="-84.20213709982337">
+		<ele>962.8589761024341</ele>
+		<time>2017-11-06T18:59:02Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.010247720037126" lon="-84.20214964351895">
+		<ele>963.761163495481</ele>
+		<time>2017-11-06T18:59:04Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.01146032260072" lon="-84.20141015923929">
+		<ele>968.2479384746403</ele>
+		<time>2017-11-06T18:59:42Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.01146769741212" lon="-84.201413804682">
+		<ele>968.6724278526381</ele>
+		<time>2017-11-06T18:59:43Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015387460880223" lon="-84.20166989795469">
+		<ele>944.7811749055982</ele>
+		<time>2017-11-06T19:01:53Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.015387460880223" lon="-84.20166989795469">
+		<ele>944.7811749055982</ele>
+		<time>2017-11-06T19:01:54Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.016190990866825" lon="-84.19707822677549">
+		<ele>974.3878954667598</ele>
+		<time>2017-11-06T19:05:53Z</time>
+		<name><![CDATA[Parada de autobús]]></name>
+		<sat>0</sat>
+	</wpt>
+	<wpt lat="10.016190990866825" lon="-84.19707822677549">
+		<ele>974.3878954667598</ele>
+		<time>2017-11-06T19:05:53Z</time>
+		<name><![CDATA[1]]></name>
+		<sat>0</sat>
+	</wpt>
+	<trk>
+		<name><![CDATA[Trazado con OSMTracker para Android™]]></name>
+		<trkseg>
+			<trkpt lat="10.01413222202335" lon="-84.21679548354379">
+				<ele>900.5338648306206</ele>
+				<time>2017-11-06T18:39:43Z</time>
+				<extensions>
+					<speed>0.029965758323669434</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0142254652139" lon="-84.21678875155709">
+				<ele>928.6991786137223</ele>
+				<time>2017-11-06T18:39:49Z</time>
+				<extensions>
+					<speed>0.5793575048446655</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:39:50Z</time>
+				<extensions>
+					<speed>0.3783539831638336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:39:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:39:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:39:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:39:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:39:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:39:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:39:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:39:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:39:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014128118095256" lon="-84.21675982471895">
+				<ele>891.4370277924463</ele>
+				<time>2017-11-06T18:40:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014137639171324" lon="-84.21675961099457">
+				<ele>891.6905791107565</ele>
+				<time>2017-11-06T18:40:57Z</time>
+				<extensions>
+					<speed>0.727324903011322</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014150875831776" lon="-84.21675501990825">
+				<ele>891.8268822804093</ele>
+				<time>2017-11-06T18:40:58Z</time>
+				<extensions>
+					<speed>1.3210082054138184</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01417193097094" lon="-84.21672712397364">
+				<ele>892.7525467406958</ele>
+				<time>2017-11-06T18:40:59Z</time>
+				<extensions>
+					<speed>2.685473680496216</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014193398760964" lon="-84.21669784172389">
+				<ele>893.844892877154</ele>
+				<time>2017-11-06T18:41:00Z</time>
+				<extensions>
+					<speed>4.2570695877075195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014215344878604" lon="-84.21665778489216">
+				<ele>894.6773686809465</ele>
+				<time>2017-11-06T18:41:01Z</time>
+				<extensions>
+					<speed>5.2551774978637695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014231903097178" lon="-84.21661179498594">
+				<ele>895.1160595184192</ele>
+				<time>2017-11-06T18:41:02Z</time>
+				<extensions>
+					<speed>5.467159748077393</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014243385436467" lon="-84.21656292470112">
+				<ele>895.4621237702668</ele>
+				<time>2017-11-06T18:41:03Z</time>
+				<extensions>
+					<speed>5.575468063354492</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014255478820838" lon="-84.21651587241075">
+				<ele>895.7117730788887</ele>
+				<time>2017-11-06T18:41:04Z</time>
+				<extensions>
+					<speed>5.399305820465088</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014268882436767" lon="-84.21647164335454">
+				<ele>896.1422699028626</ele>
+				<time>2017-11-06T18:41:05Z</time>
+				<extensions>
+					<speed>5.248669147491455</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01427462526789" lon="-84.21644534717996">
+				<ele>896.5112126972526</ele>
+				<time>2017-11-06T18:41:06Z</time>
+				<extensions>
+					<speed>3.9093663692474365</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014277905007907" lon="-84.21642641561596">
+				<ele>897.0464688427746</ele>
+				<time>2017-11-06T18:41:07Z</time>
+				<extensions>
+					<speed>1.8183399438858032</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014280543083432" lon="-84.21641037547583">
+				<ele>897.6318543301895</ele>
+				<time>2017-11-06T18:41:08Z</time>
+				<extensions>
+					<speed>1.1045799255371094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014283839737274" lon="-84.21639014986944">
+				<ele>898.2331168670207</ele>
+				<time>2017-11-06T18:41:09Z</time>
+				<extensions>
+					<speed>1.5948609113693237</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014290424922445" lon="-84.21637317548588">
+				<ele>898.7852616785094</ele>
+				<time>2017-11-06T18:41:10Z</time>
+				<extensions>
+					<speed>1.9150844812393188</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014298886765769" lon="-84.21634850381537">
+				<ele>899.4613883225247</ele>
+				<time>2017-11-06T18:41:11Z</time>
+				<extensions>
+					<speed>2.568326950073242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014311468428994" lon="-84.21631722257072">
+				<ele>899.9344296259806</ele>
+				<time>2017-11-06T18:41:12Z</time>
+				<extensions>
+					<speed>3.3709475994110107</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014325954288035" lon="-84.21627657744105">
+				<ele>900.3361449735239</ele>
+				<time>2017-11-06T18:41:13Z</time>
+				<extensions>
+					<speed>4.25160551071167</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01433919203175" lon="-84.21622681622966">
+				<ele>900.8488195678219</ele>
+				<time>2017-11-06T18:41:14Z</time>
+				<extensions>
+					<speed>5.298295974731445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014349250894838" lon="-84.21617885972265">
+				<ele>901.0530670173466</ele>
+				<time>2017-11-06T18:41:15Z</time>
+				<extensions>
+					<speed>5.319430351257324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014363126710775" lon="-84.21613222906377">
+				<ele>901.2382580712438</ele>
+				<time>2017-11-06T18:41:16Z</time>
+				<extensions>
+					<speed>5.064176559448242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014390846616868" lon="-84.21609808193031">
+				<ele>901.7057299222797</ele>
+				<time>2017-11-06T18:41:17Z</time>
+				<extensions>
+					<speed>4.722402095794678</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014406524467624" lon="-84.21605864214987">
+				<ele>901.9308612411842</ele>
+				<time>2017-11-06T18:41:18Z</time>
+				<extensions>
+					<speed>4.491015911102295</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014420930981236" lon="-84.21601494863563">
+				<ele>902.565273988992</ele>
+				<time>2017-11-06T18:41:19Z</time>
+				<extensions>
+					<speed>4.36583948135376</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01443821395057" lon="-84.21597615824295">
+				<ele>903.4082509232685</ele>
+				<time>2017-11-06T18:41:20Z</time>
+				<extensions>
+					<speed>4.180458068847656</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01445166872531" lon="-84.21594135801004">
+				<ele>903.8767394982278</ele>
+				<time>2017-11-06T18:41:21Z</time>
+				<extensions>
+					<speed>3.9086341857910156</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014472692624645" lon="-84.21591249203692">
+				<ele>904.5657598981634</ele>
+				<time>2017-11-06T18:41:22Z</time>
+				<extensions>
+					<speed>3.4379820823669434</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014490662663151" lon="-84.21589198256457">
+				<ele>905.8765197964385</ele>
+				<time>2017-11-06T18:41:23Z</time>
+				<extensions>
+					<speed>2.475339889526367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014498326630253" lon="-84.21587686746751">
+				<ele>906.7624545712024</ele>
+				<time>2017-11-06T18:41:24Z</time>
+				<extensions>
+					<speed>1.2754980325698853</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014505616851702" lon="-84.21587094723232">
+				<ele>907.605237647891</ele>
+				<time>2017-11-06T18:41:25Z</time>
+				<extensions>
+					<speed>0.3696646988391876</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014505616851702" lon="-84.21587094723232">
+				<ele>907.605237647891</ele>
+				<time>2017-11-06T18:41:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014504645102283" lon="-84.21587924590692">
+				<ele>908.4473850782961</ele>
+				<time>2017-11-06T18:41:27Z</time>
+				<extensions>
+					<speed>0.7247697114944458</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014505616851702" lon="-84.21587094723232">
+				<ele>907.605237647891</ele>
+				<time>2017-11-06T18:41:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014505616851702" lon="-84.21587094723232">
+				<ele>907.605237647891</ele>
+				<time>2017-11-06T18:41:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014505616851702" lon="-84.21587094723232">
+				<ele>907.605237647891</ele>
+				<time>2017-11-06T18:41:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014505616851702" lon="-84.21587094723232">
+				<ele>907.605237647891</ele>
+				<time>2017-11-06T18:41:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014505616851702" lon="-84.21587094723232">
+				<ele>907.605237647891</ele>
+				<time>2017-11-06T18:41:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014505616851702" lon="-84.21587094723232">
+				<ele>907.605237647891</ele>
+				<time>2017-11-06T18:41:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014505616851702" lon="-84.21587094723232">
+				<ele>907.605237647891</ele>
+				<time>2017-11-06T18:41:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014505616851702" lon="-84.21587094723232">
+				<ele>907.605237647891</ele>
+				<time>2017-11-06T18:41:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014505616851702" lon="-84.21587094723232">
+				<ele>907.605237647891</ele>
+				<time>2017-11-06T18:41:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014505616851702" lon="-84.21587094723232">
+				<ele>907.605237647891</ele>
+				<time>2017-11-06T18:41:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014505616851702" lon="-84.21587094723232">
+				<ele>907.605237647891</ele>
+				<time>2017-11-06T18:41:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014505616851702" lon="-84.21587094723232">
+				<ele>907.605237647891</ele>
+				<time>2017-11-06T18:41:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014505616851702" lon="-84.21587094723232">
+				<ele>907.605237647891</ele>
+				<time>2017-11-06T18:41:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014505616851702" lon="-84.21587094723232">
+				<ele>907.605237647891</ele>
+				<time>2017-11-06T18:41:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014505616851702" lon="-84.21587094723232">
+				<ele>907.605237647891</ele>
+				<time>2017-11-06T18:41:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014505616851702" lon="-84.21587094723232">
+				<ele>907.605237647891</ele>
+				<time>2017-11-06T18:41:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014508325427277" lon="-84.21586429528308">
+				<ele>908.206297762692</ele>
+				<time>2017-11-06T18:41:44Z</time>
+				<extensions>
+					<speed>0.7540674209594727</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01451253923176" lon="-84.21584371929549">
+				<ele>908.9410799769685</ele>
+				<time>2017-11-06T18:41:45Z</time>
+				<extensions>
+					<speed>1.9154525995254517</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014517645825231" lon="-84.21581723665393">
+				<ele>909.4981071390212</ele>
+				<time>2017-11-06T18:41:46Z</time>
+				<extensions>
+					<speed>2.6304051876068115</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014524004890099" lon="-84.21578663559592">
+				<ele>910.0604994799942</ele>
+				<time>2017-11-06T18:41:47Z</time>
+				<extensions>
+					<speed>2.9289815425872803</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014529525548289" lon="-84.21575912599492">
+				<ele>910.8603829508647</ele>
+				<time>2017-11-06T18:41:48Z</time>
+				<extensions>
+					<speed>3.1506035327911377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014538766492276" lon="-84.21572820102224">
+				<ele>911.496430198662</ele>
+				<time>2017-11-06T18:41:49Z</time>
+				<extensions>
+					<speed>3.412031650543213</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014552806011451" lon="-84.21569326774691">
+				<ele>912.352633564733</ele>
+				<time>2017-11-06T18:41:50Z</time>
+				<extensions>
+					<speed>3.9046213626861572</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01456562931913" lon="-84.21565471523131">
+				<ele>913.1009778352454</ele>
+				<time>2017-11-06T18:41:51Z</time>
+				<extensions>
+					<speed>4.399110317230225</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014578453135528" lon="-84.21561218668538">
+				<ele>913.8929549828172</ele>
+				<time>2017-11-06T18:41:52Z</time>
+				<extensions>
+					<speed>4.6527628898620605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014589781230985" lon="-84.21556666695352">
+				<ele>914.3819909561425</ele>
+				<time>2017-11-06T18:41:53Z</time>
+				<extensions>
+					<speed>4.742673397064209</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014602301551601" lon="-84.21551657671601">
+				<ele>914.9370090505108</ele>
+				<time>2017-11-06T18:41:54Z</time>
+				<extensions>
+					<speed>4.975596904754639</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014614187836665" lon="-84.21546762690836">
+				<ele>915.139407238923</ele>
+				<time>2017-11-06T18:41:55Z</time>
+				<extensions>
+					<speed>5.082050800323486</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014626954689223" lon="-84.21541500854451">
+				<ele>915.3741647219285</ele>
+				<time>2017-11-06T18:41:56Z</time>
+				<extensions>
+					<speed>5.531715393066406</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014644309595958" lon="-84.21535634167688">
+				<ele>915.5883846934885</ele>
+				<time>2017-11-06T18:41:57Z</time>
+				<extensions>
+					<speed>6.252530097961426</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014659663805407" lon="-84.2152940882051">
+				<ele>915.6888770200312</ele>
+				<time>2017-11-06T18:41:58Z</time>
+				<extensions>
+					<speed>6.444551467895508</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014675974002497" lon="-84.21523365497237">
+				<ele>915.9084033984691</ele>
+				<time>2017-11-06T18:41:59Z</time>
+				<extensions>
+					<speed>6.3437066078186035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01469669679971" lon="-84.21518410143277">
+				<ele>916.6568879373372</ele>
+				<time>2017-11-06T18:42:00Z</time>
+				<extensions>
+					<speed>5.75498628616333</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01471195915551" lon="-84.21513184217505">
+				<ele>917.0375541616231</ele>
+				<time>2017-11-06T18:42:01Z</time>
+				<extensions>
+					<speed>5.5408806800842285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014724702908525" lon="-84.2150847018778">
+				<ele>917.5687474906445</ele>
+				<time>2017-11-06T18:42:02Z</time>
+				<extensions>
+					<speed>5.310462951660156</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014734022184792" lon="-84.21503625387683">
+				<ele>917.9780448004603</ele>
+				<time>2017-11-06T18:42:03Z</time>
+				<extensions>
+					<speed>5.109076023101807</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01473973595711" lon="-84.2149911955378">
+				<ele>918.4199491878971</ele>
+				<time>2017-11-06T18:42:04Z</time>
+				<extensions>
+					<speed>4.787824630737305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014744198390213" lon="-84.21495073550074">
+				<ele>918.5650502797216</ele>
+				<time>2017-11-06T18:42:05Z</time>
+				<extensions>
+					<speed>4.406627655029297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0147496174687" lon="-84.21491486904529">
+				<ele>918.7678614407778</ele>
+				<time>2017-11-06T18:42:06Z</time>
+				<extensions>
+					<speed>4.063138961791992</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014755820861991" lon="-84.21488521783064">
+				<ele>919.0933564025909</ele>
+				<time>2017-11-06T18:42:07Z</time>
+				<extensions>
+					<speed>3.5422494411468506</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014761547452176" lon="-84.2148641801819">
+				<ele>919.769573783502</ele>
+				<time>2017-11-06T18:42:08Z</time>
+				<extensions>
+					<speed>2.3801167011260986</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014762780058813" lon="-84.21485243867424">
+				<ele>919.9929183740169</ele>
+				<time>2017-11-06T18:42:09Z</time>
+				<extensions>
+					<speed>1.0485061407089233</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014759776897145" lon="-84.21485140240947">
+				<ele>920.2309990432113</ele>
+				<time>2017-11-06T18:42:10Z</time>
+				<extensions>
+					<speed>0.06760674715042114</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014759776897145" lon="-84.21485140240947">
+				<ele>920.2309990432113</ele>
+				<time>2017-11-06T18:42:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014755349388713" lon="-84.21485658679977">
+				<ele>920.5210521640256</ele>
+				<time>2017-11-06T18:42:12Z</time>
+				<extensions>
+					<speed>0.7673442959785461</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014755349388713" lon="-84.21485658679977">
+				<ele>920.5210521640256</ele>
+				<time>2017-11-06T18:42:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01474725812813" lon="-84.2148573951248">
+				<ele>920.7064372068271</ele>
+				<time>2017-11-06T18:42:14Z</time>
+				<extensions>
+					<speed>0.5073042511940002</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01474725812813" lon="-84.2148573951248">
+				<ele>920.7064372068271</ele>
+				<time>2017-11-06T18:42:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014737039622087" lon="-84.21485606536207">
+				<ele>920.8868263978511</ele>
+				<time>2017-11-06T18:42:16Z</time>
+				<extensions>
+					<speed>0.4637294113636017</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014737039622087" lon="-84.21485606536207">
+				<ele>920.8868263978511</ele>
+				<time>2017-11-06T18:42:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014731249758796" lon="-84.21485506008383">
+				<ele>920.9866065857932</ele>
+				<time>2017-11-06T18:42:18Z</time>
+				<extensions>
+					<speed>0.4094527065753937</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014731249758796" lon="-84.21485506008383">
+				<ele>920.9866065857932</ele>
+				<time>2017-11-06T18:42:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014729363563657" lon="-84.21484983148163">
+				<ele>921.0054518654943</ele>
+				<time>2017-11-06T18:42:20Z</time>
+				<extensions>
+					<speed>0.2428247630596161</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014729363563657" lon="-84.21484983148163">
+				<ele>921.0054518654943</ele>
+				<time>2017-11-06T18:42:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014729363563657" lon="-84.21484983148163">
+				<ele>921.0054518654943</ele>
+				<time>2017-11-06T18:42:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014727124929577" lon="-84.21484600682828">
+				<ele>920.9663709904999</ele>
+				<time>2017-11-06T18:42:23Z</time>
+				<extensions>
+					<speed>0.20720519125461578</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014727124929577" lon="-84.21484600682828">
+				<ele>920.9663709904999</ele>
+				<time>2017-11-06T18:42:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014727124929577" lon="-84.21484600682828">
+				<ele>920.9663709904999</ele>
+				<time>2017-11-06T18:42:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014727124929577" lon="-84.21484600682828">
+				<ele>920.9663709904999</ele>
+				<time>2017-11-06T18:42:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014727124929577" lon="-84.21484600682828">
+				<ele>920.9663709904999</ele>
+				<time>2017-11-06T18:42:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014727124929577" lon="-84.21484600682828">
+				<ele>920.9663709904999</ele>
+				<time>2017-11-06T18:42:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014727124929577" lon="-84.21484600682828">
+				<ele>920.9663709904999</ele>
+				<time>2017-11-06T18:42:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014727124929577" lon="-84.21484600682828">
+				<ele>920.9663709904999</ele>
+				<time>2017-11-06T18:42:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014727124929577" lon="-84.21484600682828">
+				<ele>920.9663709904999</ele>
+				<time>2017-11-06T18:42:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014727124929577" lon="-84.21484600682828">
+				<ele>920.9663709904999</ele>
+				<time>2017-11-06T18:42:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014727124929577" lon="-84.21484600682828">
+				<ele>920.9663709904999</ele>
+				<time>2017-11-06T18:42:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014727124929577" lon="-84.21484600682828">
+				<ele>920.9663709904999</ele>
+				<time>2017-11-06T18:42:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014727124929577" lon="-84.21484600682828">
+				<ele>920.9663709904999</ele>
+				<time>2017-11-06T18:42:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014727124929577" lon="-84.21484600682828">
+				<ele>920.9663709904999</ele>
+				<time>2017-11-06T18:42:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014727124929577" lon="-84.21484600682828">
+				<ele>920.9663709904999</ele>
+				<time>2017-11-06T18:42:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014727124929577" lon="-84.21484600682828">
+				<ele>920.9663709904999</ele>
+				<time>2017-11-06T18:42:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014733090624853" lon="-84.21483442878606">
+				<ele>922.2547664148733</ele>
+				<time>2017-11-06T18:42:39Z</time>
+				<extensions>
+					<speed>1.5793640613555908</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014736658869898" lon="-84.2148122004112">
+				<ele>923.2237112596631</ele>
+				<time>2017-11-06T18:42:40Z</time>
+				<extensions>
+					<speed>3.0466063022613525</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014740011105156" lon="-84.21477769844262">
+				<ele>923.5749712036923</ele>
+				<time>2017-11-06T18:42:41Z</time>
+				<extensions>
+					<speed>4.050729751586914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01474679868381" lon="-84.21473593991497">
+				<ele>923.6417548526078</ele>
+				<time>2017-11-06T18:42:42Z</time>
+				<extensions>
+					<speed>4.622219085693359</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014771733196026" lon="-84.21469580371091">
+				<ele>923.0987869510427</ele>
+				<time>2017-11-06T18:42:43Z</time>
+				<extensions>
+					<speed>4.995937824249268</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014790279113186" lon="-84.214642924187">
+				<ele>923.0557970972732</ele>
+				<time>2017-11-06T18:42:44Z</time>
+				<extensions>
+					<speed>5.782808303833008</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01480503441474" lon="-84.21457775683582">
+				<ele>922.8010329650715</ele>
+				<time>2017-11-06T18:42:45Z</time>
+				<extensions>
+					<speed>6.61077880859375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014826730231231" lon="-84.21450741962883">
+				<ele>922.5076623829082</ele>
+				<time>2017-11-06T18:42:46Z</time>
+				<extensions>
+					<speed>7.394660472869873</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014852300986357" lon="-84.21443055017214">
+				<ele>922.1974535761401</ele>
+				<time>2017-11-06T18:42:47Z</time>
+				<extensions>
+					<speed>8.198768615722656</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014882324355186" lon="-84.21434953216173">
+				<ele>922.3074968894944</ele>
+				<time>2017-11-06T18:42:48Z</time>
+				<extensions>
+					<speed>8.807655334472656</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0149017927639" lon="-84.21426984930922">
+				<ele>922.3262220313773</ele>
+				<time>2017-11-06T18:42:49Z</time>
+				<extensions>
+					<speed>8.755634307861328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014918591943363" lon="-84.21419593489007">
+				<ele>921.9293956365436</ele>
+				<time>2017-11-06T18:42:50Z</time>
+				<extensions>
+					<speed>8.29747200012207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014934320354737" lon="-84.21413148008949">
+				<ele>921.1363545963541</ele>
+				<time>2017-11-06T18:42:51Z</time>
+				<extensions>
+					<speed>7.406500339508057</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014949868653877" lon="-84.21407490028253">
+				<ele>920.5048534795642</ele>
+				<time>2017-11-06T18:42:52Z</time>
+				<extensions>
+					<speed>6.282224655151367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014962174583195" lon="-84.2140294247863">
+				<ele>919.9655896369368</ele>
+				<time>2017-11-06T18:42:53Z</time>
+				<extensions>
+					<speed>4.673264026641846</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014973522150951" lon="-84.21399241816431">
+				<ele>919.7040078314021</ele>
+				<time>2017-11-06T18:42:54Z</time>
+				<extensions>
+					<speed>3.5015299320220947</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014975131104528" lon="-84.21398242429885">
+				<ele>919.2589664999396</ele>
+				<time>2017-11-06T18:42:55Z</time>
+				<extensions>
+					<speed>1.0577234029769897</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014983324453564" lon="-84.2139813005039">
+				<ele>919.2426915206015</ele>
+				<time>2017-11-06T18:42:56Z</time>
+				<extensions>
+					<speed>0.5176182389259338</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014983324453564" lon="-84.2139813005039">
+				<ele>919.2426915206015</ele>
+				<time>2017-11-06T18:42:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014979407852369" lon="-84.21399768525221">
+				<ele>919.0214892979711</ele>
+				<time>2017-11-06T18:42:58Z</time>
+				<extensions>
+					<speed>1.0637917518615723</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014974762320806" lon="-84.2140160077004">
+				<ele>918.905162028037</ele>
+				<time>2017-11-06T18:42:59Z</time>
+				<extensions>
+					<speed>1.2986021041870117</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014956408914248" lon="-84.21404227125554">
+				<ele>917.9080878421664</ele>
+				<time>2017-11-06T18:43:00Z</time>
+				<extensions>
+					<speed>1.3195947408676147</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014952310211104" lon="-84.21405655918394">
+				<ele>917.6057993276045</ele>
+				<time>2017-11-06T18:43:01Z</time>
+				<extensions>
+					<speed>0.9848788976669312</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014952310211104" lon="-84.21405655918394">
+				<ele>917.6057993276045</ele>
+				<time>2017-11-06T18:43:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014949407347077" lon="-84.21406427436752">
+				<ele>917.2940670438111</ele>
+				<time>2017-11-06T18:43:03Z</time>
+				<extensions>
+					<speed>0.3492021858692169</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014949407347077" lon="-84.21406427436752">
+				<ele>917.2940670438111</ele>
+				<time>2017-11-06T18:43:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014949407347077" lon="-84.21406427436752">
+				<ele>917.2940670438111</ele>
+				<time>2017-11-06T18:43:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014949407347077" lon="-84.21406427436752">
+				<ele>917.2940670438111</ele>
+				<time>2017-11-06T18:43:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014949407347077" lon="-84.21406427436752">
+				<ele>917.2940670438111</ele>
+				<time>2017-11-06T18:43:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014949407347077" lon="-84.21406427436752">
+				<ele>917.2940670438111</ele>
+				<time>2017-11-06T18:43:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014949407347077" lon="-84.21406427436752">
+				<ele>917.2940670438111</ele>
+				<time>2017-11-06T18:43:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014949407347077" lon="-84.21406427436752">
+				<ele>917.2940670438111</ele>
+				<time>2017-11-06T18:43:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014949407347077" lon="-84.21406427436752">
+				<ele>917.2940670438111</ele>
+				<time>2017-11-06T18:43:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014949407347077" lon="-84.21406427436752">
+				<ele>917.2940670438111</ele>
+				<time>2017-11-06T18:43:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014949407347077" lon="-84.21406427436752">
+				<ele>917.2940670438111</ele>
+				<time>2017-11-06T18:43:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014949407347077" lon="-84.21406427436752">
+				<ele>917.2940670438111</ele>
+				<time>2017-11-06T18:43:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014949407347077" lon="-84.21406427436752">
+				<ele>917.2940670438111</ele>
+				<time>2017-11-06T18:43:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014942663119422" lon="-84.21405801255499">
+				<ele>917.3290298469365</ele>
+				<time>2017-11-06T18:43:16Z</time>
+				<extensions>
+					<speed>0.26652270555496216</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014935953486408" lon="-84.21405062272788">
+				<ele>917.2187492242083</ele>
+				<time>2017-11-06T18:43:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014932873245643" lon="-84.21403962825484">
+				<ele>917.13141465839</ele>
+				<time>2017-11-06T18:43:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014932873245643" lon="-84.21403962825484">
+				<ele>917.13141465839</ele>
+				<time>2017-11-06T18:43:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014937025737076" lon="-84.21402399545809">
+				<ele>917.2127736546099</ele>
+				<time>2017-11-06T18:43:20Z</time>
+				<extensions>
+					<speed>1.844223141670227</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014959784445807" lon="-84.21400278044702">
+				<ele>917.4283355493098</ele>
+				<time>2017-11-06T18:43:21Z</time>
+				<extensions>
+					<speed>3.4541015625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01496461257556" lon="-84.21395508890302">
+				<ele>915.4337910814211</ele>
+				<time>2017-11-06T18:43:22Z</time>
+				<extensions>
+					<speed>4.6907758712768555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014973774804073" lon="-84.21389728490061">
+				<ele>912.8513885112479</ele>
+				<time>2017-11-06T18:43:23Z</time>
+				<extensions>
+					<speed>5.703554630279541</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014987682055315" lon="-84.21383781059014">
+				<ele>912.4056950500235</ele>
+				<time>2017-11-06T18:43:24Z</time>
+				<extensions>
+					<speed>6.321389675140381</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015001213786613" lon="-84.21376864131454">
+				<ele>912.1406643232331</ele>
+				<time>2017-11-06T18:43:25Z</time>
+				<extensions>
+					<speed>6.904417514801025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015018182031056" lon="-84.2137006651387">
+				<ele>912.8803288070485</ele>
+				<time>2017-11-06T18:43:26Z</time>
+				<extensions>
+					<speed>7.011137008666992</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0150445036791" lon="-84.21363646845906">
+				<ele>913.6044926512986</ele>
+				<time>2017-11-06T18:43:27Z</time>
+				<extensions>
+					<speed>7.371706008911133</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015072312694102" lon="-84.21357499189526">
+				<ele>916.4707559244707</ele>
+				<time>2017-11-06T18:43:28Z</time>
+				<extensions>
+					<speed>7.407351016998291</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015090122413307" lon="-84.21350528794297">
+				<ele>917.4257241431624</ele>
+				<time>2017-11-06T18:43:29Z</time>
+				<extensions>
+					<speed>7.463126182556152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015110753486706" lon="-84.21344052384067">
+				<ele>918.8674144698307</ele>
+				<time>2017-11-06T18:43:30Z</time>
+				<extensions>
+					<speed>7.415283679962158</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015139211966902" lon="-84.21338923236283">
+				<ele>919.7422400973737</ele>
+				<time>2017-11-06T18:43:31Z</time>
+				<extensions>
+					<speed>6.489277362823486</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01515935773401" lon="-84.21334260663191">
+				<ele>919.9175279214978</ele>
+				<time>2017-11-06T18:43:32Z</time>
+				<extensions>
+					<speed>5.2272114753723145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015173982885573" lon="-84.21330854095035">
+				<ele>920.4278657035902</ele>
+				<time>2017-11-06T18:43:33Z</time>
+				<extensions>
+					<speed>3.0720903873443604</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015180082563031" lon="-84.2132924774626">
+				<ele>920.7258258089423</ele>
+				<time>2017-11-06T18:43:34Z</time>
+				<extensions>
+					<speed>0.6480919122695923</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015170298399514" lon="-84.21328953287176">
+				<ele>916.7864627288654</ele>
+				<time>2017-11-06T18:43:35Z</time>
+				<extensions>
+					<speed>0.9822490811347961</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015165886348063" lon="-84.2133045337498">
+				<ele>917.1533205248415</ele>
+				<time>2017-11-06T18:43:36Z</time>
+				<extensions>
+					<speed>1.6826543807983398</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015165108611841" lon="-84.21331752342408">
+				<ele>919.3598243631423</ele>
+				<time>2017-11-06T18:43:37Z</time>
+				<extensions>
+					<speed>1.6174265146255493</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015169636320195" lon="-84.213328285451">
+				<ele>923.7608544817194</ele>
+				<time>2017-11-06T18:43:38Z</time>
+				<extensions>
+					<speed>1.4406687021255493</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01517981439563" lon="-84.21333819938411">
+				<ele>929.9943056264892</ele>
+				<time>2017-11-06T18:43:39Z</time>
+				<extensions>
+					<speed>1.1288493871688843</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:43:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:43:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:43:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:43:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:43:44Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:43:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:43:46Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:43:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:43:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:43:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:43:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:43:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:43:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:43:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:43:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:43:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:43:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:43:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:43:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:43:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:44:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:44:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:44:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015191207410863" lon="-84.21334405514422">
+				<ele>935.938239752315</ele>
+				<time>2017-11-06T18:44:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015196371668253" lon="-84.21333966122072">
+				<ele>937.2439171513543</ele>
+				<time>2017-11-06T18:44:04Z</time>
+				<extensions>
+					<speed>0.6869863867759705</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015202303720127" lon="-84.21333438406809">
+				<ele>938.3159415088594</ele>
+				<time>2017-11-06T18:44:05Z</time>
+				<extensions>
+					<speed>1.0840606689453125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015207351805575" lon="-84.21332221695779">
+				<ele>938.9817853290588</ele>
+				<time>2017-11-06T18:44:06Z</time>
+				<extensions>
+					<speed>1.4794433116912842</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015210291291927" lon="-84.21330774745097">
+				<ele>939.5548861660063</ele>
+				<time>2017-11-06T18:44:07Z</time>
+				<extensions>
+					<speed>1.7352086305618286</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015215641752182" lon="-84.2132846220679">
+				<ele>940.1407339051366</ele>
+				<time>2017-11-06T18:44:08Z</time>
+				<extensions>
+					<speed>2.208217144012451</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015220335039348" lon="-84.21325437660109">
+				<ele>940.4779390767217</ele>
+				<time>2017-11-06T18:44:09Z</time>
+				<extensions>
+					<speed>2.672950506210327</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01523015769061" lon="-84.21321770439259">
+				<ele>940.8827013606206</ele>
+				<time>2017-11-06T18:44:10Z</time>
+				<extensions>
+					<speed>3.155290365219116</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015243484750494" lon="-84.21318113471652">
+				<ele>941.3314980715513</ele>
+				<time>2017-11-06T18:44:11Z</time>
+				<extensions>
+					<speed>3.4234092235565186</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525657278774" lon="-84.21315005364582">
+				<ele>941.9025715198368</ele>
+				<time>2017-11-06T18:44:12Z</time>
+				<extensions>
+					<speed>3.5271663665771484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0152724076245" lon="-84.21311001682231">
+				<ele>942.4110377077013</ele>
+				<time>2017-11-06T18:44:13Z</time>
+				<extensions>
+					<speed>3.853271961212158</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015286241568603" lon="-84.21306398928152">
+				<ele>942.9564684424549</ele>
+				<time>2017-11-06T18:44:14Z</time>
+				<extensions>
+					<speed>4.314425945281982</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015298122295448" lon="-84.2130073054238">
+				<ele>944.1753469519317</ele>
+				<time>2017-11-06T18:44:15Z</time>
+				<extensions>
+					<speed>5.263851165771484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01531692533548" lon="-84.21294807575231">
+				<ele>945.06861537043</ele>
+				<time>2017-11-06T18:44:16Z</time>
+				<extensions>
+					<speed>5.559727191925049</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015337221629977" lon="-84.21288575483132">
+				<ele>946.1435187542811</ele>
+				<time>2017-11-06T18:44:17Z</time>
+				<extensions>
+					<speed>5.60645055770874</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015360999282347" lon="-84.2128385495426">
+				<ele>946.4709009444341</ele>
+				<time>2017-11-06T18:44:18Z</time>
+				<extensions>
+					<speed>5.411441326141357</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015386426248632" lon="-84.21279391897465">
+				<ele>946.553729293868</ele>
+				<time>2017-11-06T18:44:19Z</time>
+				<extensions>
+					<speed>5.260859966278076</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015412803471309" lon="-84.21275051350612">
+				<ele>946.5506366537884</ele>
+				<time>2017-11-06T18:44:20Z</time>
+				<extensions>
+					<speed>5.096503257751465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015431311820851" lon="-84.21270458348901">
+				<ele>946.8084445148706</ele>
+				<time>2017-11-06T18:44:21Z</time>
+				<extensions>
+					<speed>5.163735389709473</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015449536247282" lon="-84.21265506170867">
+				<ele>947.0099495202303</ele>
+				<time>2017-11-06T18:44:22Z</time>
+				<extensions>
+					<speed>5.190859794616699</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015463470141325" lon="-84.21259886126983">
+				<ele>947.3037353837863</ele>
+				<time>2017-11-06T18:44:23Z</time>
+				<extensions>
+					<speed>5.403353214263916</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015477625169025" lon="-84.2125475328177">
+				<ele>947.4853167999536</ele>
+				<time>2017-11-06T18:44:24Z</time>
+				<extensions>
+					<speed>5.451277732849121</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01548866644026" lon="-84.21249707135127">
+				<ele>947.637594781816</ele>
+				<time>2017-11-06T18:44:25Z</time>
+				<extensions>
+					<speed>5.455475330352783</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015501525464773" lon="-84.2124442864971">
+				<ele>947.8976924195886</ele>
+				<time>2017-11-06T18:44:26Z</time>
+				<extensions>
+					<speed>5.484665393829346</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015513877411276" lon="-84.21239568220889">
+				<ele>947.985737987794</ele>
+				<time>2017-11-06T18:44:27Z</time>
+				<extensions>
+					<speed>5.271803855895996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01552650494218" lon="-84.21235146736751">
+				<ele>948.303877835162</ele>
+				<time>2017-11-06T18:44:28Z</time>
+				<extensions>
+					<speed>5.118865489959717</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015544311720632" lon="-84.21231174140914">
+				<ele>948.805020051077</ele>
+				<time>2017-11-06T18:44:29Z</time>
+				<extensions>
+					<speed>5.081433296203613</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015576054528237" lon="-84.2122740211478">
+				<ele>950.3862266372889</ele>
+				<time>2017-11-06T18:44:30Z</time>
+				<extensions>
+					<speed>5.389063358306885</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015600606469679" lon="-84.21223093428819">
+				<ele>950.8933473303914</ele>
+				<time>2017-11-06T18:44:31Z</time>
+				<extensions>
+					<speed>5.446383476257324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015625314933457" lon="-84.21218385903403">
+				<ele>951.2973698889837</ele>
+				<time>2017-11-06T18:44:32Z</time>
+				<extensions>
+					<speed>5.4326019287109375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015642981938562" lon="-84.21212834104375">
+				<ele>951.69469443243</ele>
+				<time>2017-11-06T18:44:33Z</time>
+				<extensions>
+					<speed>5.591686248779297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015655491697832" lon="-84.21207288191263">
+				<ele>952.1937764305621</ele>
+				<time>2017-11-06T18:44:34Z</time>
+				<extensions>
+					<speed>5.859318733215332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015665829154287" lon="-84.21200963108984">
+				<ele>952.9914284925908</ele>
+				<time>2017-11-06T18:44:35Z</time>
+				<extensions>
+					<speed>5.993865013122559</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015674851312871" lon="-84.21195069712444">
+				<ele>953.8596282061189</ele>
+				<time>2017-11-06T18:44:36Z</time>
+				<extensions>
+					<speed>5.856054306030273</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01568031077797" lon="-84.21190244159337">
+				<ele>954.5327609982342</ele>
+				<time>2017-11-06T18:44:37Z</time>
+				<extensions>
+					<speed>5.0442986488342285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015681469531728" lon="-84.21186974457767">
+				<ele>955.0993717424572</ele>
+				<time>2017-11-06T18:44:38Z</time>
+				<extensions>
+					<speed>3.8348355293273926</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015681361737867" lon="-84.2118486507454">
+				<ele>955.5299186147749</ele>
+				<time>2017-11-06T18:44:39Z</time>
+				<extensions>
+					<speed>2.33024525642395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015682972551408" lon="-84.21184051291061">
+				<ele>956.0814775852486</ele>
+				<time>2017-11-06T18:44:40Z</time>
+				<extensions>
+					<speed>1.15923011302948</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015680965936175" lon="-84.21184873431281">
+				<ele>956.4509461941198</ele>
+				<time>2017-11-06T18:44:41Z</time>
+				<extensions>
+					<speed>0.47586721181869507</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015678732951129" lon="-84.21186318095381">
+				<ele>957.001257722266</ele>
+				<time>2017-11-06T18:44:42Z</time>
+				<extensions>
+					<speed>1.0476897954940796</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015674586867245" lon="-84.21187660573756">
+				<ele>957.4688345752656</ele>
+				<time>2017-11-06T18:44:43Z</time>
+				<extensions>
+					<speed>1.1306010484695435</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015672687403507" lon="-84.21188757068668">
+				<ele>957.922074271366</ele>
+				<time>2017-11-06T18:44:44Z</time>
+				<extensions>
+					<speed>0.8896997570991516</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015672687403507" lon="-84.21188757068668">
+				<ele>957.922074271366</ele>
+				<time>2017-11-06T18:44:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015675303475598" lon="-84.21189417610626">
+				<ele>958.279542923905</ele>
+				<time>2017-11-06T18:44:46Z</time>
+				<extensions>
+					<speed>0.4808046221733093</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015675303475598" lon="-84.21189417610626">
+				<ele>958.279542923905</ele>
+				<time>2017-11-06T18:44:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01567017573817" lon="-84.21190900748567">
+				<ele>958.2642067633569</ele>
+				<time>2017-11-06T18:44:48Z</time>
+				<extensions>
+					<speed>0.4968807101249695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01567017573817" lon="-84.21190900748567">
+				<ele>958.2642067633569</ele>
+				<time>2017-11-06T18:44:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015666991279419" lon="-84.21193423797678">
+				<ele>958.1243771230802</ele>
+				<time>2017-11-06T18:44:50Z</time>
+				<extensions>
+					<speed>0.8887699246406555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015667459937603" lon="-84.21195076151949">
+				<ele>958.0279413480312</ele>
+				<time>2017-11-06T18:44:51Z</time>
+				<extensions>
+					<speed>1.051685094833374</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015681867617134" lon="-84.21195862012536">
+				<ele>957.8114377111197</ele>
+				<time>2017-11-06T18:44:52Z</time>
+				<extensions>
+					<speed>1.1873725652694702</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015690683966435" lon="-84.21195819265375">
+				<ele>957.6982713574544</ele>
+				<time>2017-11-06T18:44:53Z</time>
+				<extensions>
+					<speed>0.8971672058105469</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015690683966435" lon="-84.21195819265375">
+				<ele>957.6982713574544</ele>
+				<time>2017-11-06T18:44:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:44:55Z</time>
+				<extensions>
+					<speed>0.11533044278621674</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:44:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:44:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:44:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:44:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015691846780129" lon="-84.21195536488557">
+				<ele>957.695838548243</ele>
+				<time>2017-11-06T18:45:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01569419781821" lon="-84.21194667302589">
+				<ele>957.8411542624235</ele>
+				<time>2017-11-06T18:45:21Z</time>
+				<extensions>
+					<speed>0.6258555054664612</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015700767756254" lon="-84.21191852997212">
+				<ele>957.7688691848889</ele>
+				<time>2017-11-06T18:45:22Z</time>
+				<extensions>
+					<speed>1.8706963062286377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015711542904917" lon="-84.2118779155694">
+				<ele>957.595929405652</ele>
+				<time>2017-11-06T18:45:23Z</time>
+				<extensions>
+					<speed>3.358199119567871</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015725289346443" lon="-84.21181957931685">
+				<ele>957.4023148883134</ele>
+				<time>2017-11-06T18:45:24Z</time>
+				<extensions>
+					<speed>4.842150688171387</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015739852510933" lon="-84.2117547042614">
+				<ele>957.2067256625742</ele>
+				<time>2017-11-06T18:45:25Z</time>
+				<extensions>
+					<speed>6.007031440734863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015758569985037" lon="-84.2116922525384">
+				<ele>957.3502350719646</ele>
+				<time>2017-11-06T18:45:26Z</time>
+				<extensions>
+					<speed>6.437346935272217</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015772137715153" lon="-84.21162797132808">
+				<ele>957.3139809649438</ele>
+				<time>2017-11-06T18:45:27Z</time>
+				<extensions>
+					<speed>6.53182315826416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015783661701699" lon="-84.21157438359528">
+				<ele>957.3541898699477</ele>
+				<time>2017-11-06T18:45:28Z</time>
+				<extensions>
+					<speed>5.85805606842041</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015789340828176" lon="-84.21153367541078">
+				<ele>957.2779469713569</ele>
+				<time>2017-11-06T18:45:29Z</time>
+				<extensions>
+					<speed>4.732063293457031</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01579005140018" lon="-84.211508816514">
+				<ele>957.21067151241</ele>
+				<time>2017-11-06T18:45:30Z</time>
+				<extensions>
+					<speed>1.936597228050232</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01578753100415" lon="-84.2114806352865">
+				<ele>956.3808030718938</ele>
+				<time>2017-11-06T18:45:31Z</time>
+				<extensions>
+					<speed>0.2410375475883484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015781411522793" lon="-84.21146399862492">
+				<ele>955.6487808683887</ele>
+				<time>2017-11-06T18:45:32Z</time>
+				<extensions>
+					<speed>0.8928322792053223</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015768556899303" lon="-84.21145073454524">
+				<ele>953.9272522516549</ele>
+				<time>2017-11-06T18:45:33Z</time>
+				<extensions>
+					<speed>1.0489038228988647</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015763624100883" lon="-84.21144757114659">
+				<ele>953.8974171997979</ele>
+				<time>2017-11-06T18:45:34Z</time>
+				<extensions>
+					<speed>1.071909785270691</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015762319151788" lon="-84.21145483193023">
+				<ele>955.5794969173148</ele>
+				<time>2017-11-06T18:45:35Z</time>
+				<extensions>
+					<speed>0.7971798777580261</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015762319151788" lon="-84.21145483193023">
+				<ele>955.5794969173148</ele>
+				<time>2017-11-06T18:45:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015759143055753" lon="-84.21145152393972">
+				<ele>957.0217162230983</ele>
+				<time>2017-11-06T18:45:37Z</time>
+				<extensions>
+					<speed>0.11471177637577057</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015759143055753" lon="-84.21145152393972">
+				<ele>957.0217162230983</ele>
+				<time>2017-11-06T18:45:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015762762386984" lon="-84.2114501297928">
+				<ele>959.9792087739334</ele>
+				<time>2017-11-06T18:45:39Z</time>
+				<extensions>
+					<speed>1.4452382326126099</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015757048392551" lon="-84.21144979143173">
+				<ele>961.0972923915833</ele>
+				<time>2017-11-06T18:45:40Z</time>
+				<extensions>
+					<speed>1.459349274635315</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015741603501517" lon="-84.21144365572121">
+				<ele>961.8352797497064</ele>
+				<time>2017-11-06T18:45:41Z</time>
+				<extensions>
+					<speed>1.8423141241073608</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015712670406545" lon="-84.21143049555913">
+				<ele>962.3641721308231</ele>
+				<time>2017-11-06T18:45:42Z</time>
+				<extensions>
+					<speed>3.1409623622894287</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015668025711483" lon="-84.21142142971561">
+				<ele>962.4457007432356</ele>
+				<time>2017-11-06T18:45:43Z</time>
+				<extensions>
+					<speed>5.031022548675537</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015610548111955" lon="-84.2114162680944">
+				<ele>962.2275169109926</ele>
+				<time>2017-11-06T18:45:44Z</time>
+				<extensions>
+					<speed>6.837553024291992</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015539796456762" lon="-84.21140394672223">
+				<ele>961.7917099716142</ele>
+				<time>2017-11-06T18:45:45Z</time>
+				<extensions>
+					<speed>8.025002479553223</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015460701594701" lon="-84.21138093895512">
+				<ele>961.563477599062</ele>
+				<time>2017-11-06T18:45:46Z</time>
+				<extensions>
+					<speed>8.817023277282715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0153841663855" lon="-84.21135537462611">
+				<ele>961.5796506870538</ele>
+				<time>2017-11-06T18:45:47Z</time>
+				<extensions>
+					<speed>8.644891738891602</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015319619639945" lon="-84.21133262917837">
+				<ele>961.751206709072</ele>
+				<time>2017-11-06T18:45:48Z</time>
+				<extensions>
+					<speed>8.133699417114258</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01525849785086" lon="-84.21130737191999">
+				<ele>961.760575064458</ele>
+				<time>2017-11-06T18:45:49Z</time>
+				<extensions>
+					<speed>7.506313800811768</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015198891016345" lon="-84.21127754651924">
+				<ele>961.6141824135557</ele>
+				<time>2017-11-06T18:45:50Z</time>
+				<extensions>
+					<speed>7.052183628082275</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015145888291778" lon="-84.21124720292104">
+				<ele>961.183383570984</ele>
+				<time>2017-11-06T18:45:51Z</time>
+				<extensions>
+					<speed>6.536549091339111</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01510508677627" lon="-84.21121897545095">
+				<ele>961.302055654116</ele>
+				<time>2017-11-06T18:45:52Z</time>
+				<extensions>
+					<speed>5.830880641937256</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015076720075413" lon="-84.21120394865392">
+				<ele>961.6772374743596</ele>
+				<time>2017-11-06T18:45:53Z</time>
+				<extensions>
+					<speed>5.090822696685791</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015058267812375" lon="-84.21120112823824">
+				<ele>961.8681184612215</ele>
+				<time>2017-11-06T18:45:54Z</time>
+				<extensions>
+					<speed>4.2745490074157715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015042301068732" lon="-84.21118575425679">
+				<ele>961.8899625129998</ele>
+				<time>2017-11-06T18:45:55Z</time>
+				<extensions>
+					<speed>3.7437140941619873</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015028895019144" lon="-84.21116255694336">
+				<ele>962.0910036982968</ele>
+				<time>2017-11-06T18:45:56Z</time>
+				<extensions>
+					<speed>3.631727933883667</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01502113745198" lon="-84.21114783321033">
+				<ele>962.2416044110432</ele>
+				<time>2017-11-06T18:45:57Z</time>
+				<extensions>
+					<speed>3.2243502140045166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015023123696123" lon="-84.21114311955779">
+				<ele>962.5033399555832</ele>
+				<time>2017-11-06T18:45:58Z</time>
+				<extensions>
+					<speed>2.698784828186035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015039092492596" lon="-84.21117054268228">
+				<ele>962.8691154103726</ele>
+				<time>2017-11-06T18:45:59Z</time>
+				<extensions>
+					<speed>1.8870692253112793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015050289289917" lon="-84.21116158969588">
+				<ele>963.3268208876252</ele>
+				<time>2017-11-06T18:46:00Z</time>
+				<extensions>
+					<speed>1.7568200826644897</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01506038696513" lon="-84.21116290685744">
+				<ele>963.9451468307525</ele>
+				<time>2017-11-06T18:46:01Z</time>
+				<extensions>
+					<speed>1.5495158433914185</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015066502096804" lon="-84.21116622017077">
+				<ele>964.6059213420376</ele>
+				<time>2017-11-06T18:46:02Z</time>
+				<extensions>
+					<speed>1.3503919839859009</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015079064314989" lon="-84.21118639267247">
+				<ele>964.8599364003167</ele>
+				<time>2017-11-06T18:46:03Z</time>
+				<extensions>
+					<speed>1.0999114513397217</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01509068803822" lon="-84.21120050327941">
+				<ele>964.9406877476722</ele>
+				<time>2017-11-06T18:46:04Z</time>
+				<extensions>
+					<speed>0.9501163959503174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01509068803822" lon="-84.21120050327941">
+				<ele>964.9406877476722</ele>
+				<time>2017-11-06T18:46:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015092280751675" lon="-84.21120706983068">
+				<ele>964.9683605385944</ele>
+				<time>2017-11-06T18:46:06Z</time>
+				<extensions>
+					<speed>0.6293044090270996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015092280751675" lon="-84.21120706983068">
+				<ele>964.9683605385944</ele>
+				<time>2017-11-06T18:46:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015094197270246" lon="-84.21121717854459">
+				<ele>965.2703262064606</ele>
+				<time>2017-11-06T18:46:08Z</time>
+				<extensions>
+					<speed>0.31496918201446533</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015094197270246" lon="-84.21121717854459">
+				<ele>965.2703262064606</ele>
+				<time>2017-11-06T18:46:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015094197270246" lon="-84.21121717854459">
+				<ele>965.2703262064606</ele>
+				<time>2017-11-06T18:46:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015094197270246" lon="-84.21121717854459">
+				<ele>965.2703262064606</ele>
+				<time>2017-11-06T18:46:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015094197270246" lon="-84.21121717854459">
+				<ele>965.2703262064606</ele>
+				<time>2017-11-06T18:46:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015094197270246" lon="-84.21121717854459">
+				<ele>965.2703262064606</ele>
+				<time>2017-11-06T18:46:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015094197270246" lon="-84.21121717854459">
+				<ele>965.2703262064606</ele>
+				<time>2017-11-06T18:46:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015094197270246" lon="-84.21121717854459">
+				<ele>965.2703262064606</ele>
+				<time>2017-11-06T18:46:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015094197270246" lon="-84.21121717854459">
+				<ele>965.2703262064606</ele>
+				<time>2017-11-06T18:46:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015081613870663" lon="-84.21123434030314">
+				<ele>965.3943760199472</ele>
+				<time>2017-11-06T18:46:17Z</time>
+				<extensions>
+					<speed>0.7017661929130554</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015066337750453" lon="-84.21124693676056">
+				<ele>965.4028495904058</ele>
+				<time>2017-11-06T18:46:18Z</time>
+				<extensions>
+					<speed>1.1759811639785767</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015039596428739" lon="-84.2112608955262">
+				<ele>965.5975041668862</ele>
+				<time>2017-11-06T18:46:19Z</time>
+				<extensions>
+					<speed>1.9371886253356934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014990143263727" lon="-84.2112576176509">
+				<ele>965.7933734906837</ele>
+				<time>2017-11-06T18:46:20Z</time>
+				<extensions>
+					<speed>3.571448802947998</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014950175011146" lon="-84.21125527872043">
+				<ele>965.8835231941193</ele>
+				<time>2017-11-06T18:46:21Z</time>
+				<extensions>
+					<speed>4.385471343994141</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014894096540697" lon="-84.2112377342853">
+				<ele>965.8118658270687</ele>
+				<time>2017-11-06T18:46:22Z</time>
+				<extensions>
+					<speed>5.895617485046387</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01482181067704" lon="-84.21115996953424">
+				<ele>965.6273473100737</ele>
+				<time>2017-11-06T18:46:23Z</time>
+				<extensions>
+					<speed>8.017701148986816</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014743812180146" lon="-84.21113253260953">
+				<ele>965.5940828965977</ele>
+				<time>2017-11-06T18:46:24Z</time>
+				<extensions>
+					<speed>9.121997833251953</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014658860725067" lon="-84.21110572852453">
+				<ele>965.7926703514531</ele>
+				<time>2017-11-06T18:46:25Z</time>
+				<extensions>
+					<speed>9.74675464630127</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014563582680939" lon="-84.21105907819884">
+				<ele>966.0609457222745</ele>
+				<time>2017-11-06T18:46:26Z</time>
+				<extensions>
+					<speed>10.821611404418945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014452440009926" lon="-84.21099965776733">
+				<ele>966.2698029382154</ele>
+				<time>2017-11-06T18:46:27Z</time>
+				<extensions>
+					<speed>11.982269287109375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014344062387883" lon="-84.21093894983045">
+				<ele>966.071861599572</ele>
+				<time>2017-11-06T18:46:28Z</time>
+				<extensions>
+					<speed>12.1377592086792</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014237651079098" lon="-84.21086867256062">
+				<ele>965.7427375009283</ele>
+				<time>2017-11-06T18:46:29Z</time>
+				<extensions>
+					<speed>12.163017272949219</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014119273155616" lon="-84.21075755085644">
+				<ele>964.7059969417751</ele>
+				<time>2017-11-06T18:46:30Z</time>
+				<extensions>
+					<speed>12.248750686645508</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014015487561194" lon="-84.21067735046086">
+				<ele>964.0435544578359</ele>
+				<time>2017-11-06T18:46:31Z</time>
+				<extensions>
+					<speed>11.906888961791992</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013933319008569" lon="-84.2106348232403">
+				<ele>963.4730407418683</ele>
+				<time>2017-11-06T18:46:32Z</time>
+				<extensions>
+					<speed>11.110729217529297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013851583091164" lon="-84.21059788638779">
+				<ele>963.3977814912796</ele>
+				<time>2017-11-06T18:46:33Z</time>
+				<extensions>
+					<speed>10.67066478729248</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013780506652937" lon="-84.21057032277145">
+				<ele>963.3023612005636</ele>
+				<time>2017-11-06T18:46:34Z</time>
+				<extensions>
+					<speed>10.052410125732422</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013717648800593" lon="-84.21055299460417">
+				<ele>962.6248644739389</ele>
+				<time>2017-11-06T18:46:35Z</time>
+				<extensions>
+					<speed>9.865926742553711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013643387125052" lon="-84.21052085136323">
+				<ele>962.410648428835</ele>
+				<time>2017-11-06T18:46:36Z</time>
+				<extensions>
+					<speed>9.940262794494629</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013569736211462" lon="-84.21049910645567">
+				<ele>961.923939647153</ele>
+				<time>2017-11-06T18:46:37Z</time>
+				<extensions>
+					<speed>9.819718360900879</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0135046957771" lon="-84.21046786585346">
+				<ele>962.0951184267178</ele>
+				<time>2017-11-06T18:46:38Z</time>
+				<extensions>
+					<speed>9.109841346740723</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013452302623076" lon="-84.21045488454187">
+				<ele>962.3678653659299</ele>
+				<time>2017-11-06T18:46:39Z</time>
+				<extensions>
+					<speed>7.70493745803833</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013402868533708" lon="-84.2104262795889">
+				<ele>962.4620474278927</ele>
+				<time>2017-11-06T18:46:40Z</time>
+				<extensions>
+					<speed>6.78780460357666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013356563085495" lon="-84.21040145704876">
+				<ele>962.4652448697016</ele>
+				<time>2017-11-06T18:46:41Z</time>
+				<extensions>
+					<speed>6.042041301727295</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013310952534582" lon="-84.2103704687949">
+				<ele>962.9190505715087</ele>
+				<time>2017-11-06T18:46:42Z</time>
+				<extensions>
+					<speed>5.875451564788818</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013267753391276" lon="-84.21034242902097">
+				<ele>963.3015765082091</ele>
+				<time>2017-11-06T18:46:43Z</time>
+				<extensions>
+					<speed>5.63425350189209</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013230449299003" lon="-84.21032535819458">
+				<ele>963.694654953666</ele>
+				<time>2017-11-06T18:46:44Z</time>
+				<extensions>
+					<speed>5.195952415466309</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013190043083997" lon="-84.21030265286278">
+				<ele>964.0910725248978</ele>
+				<time>2017-11-06T18:46:45Z</time>
+				<extensions>
+					<speed>5.091017246246338</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013152997817947" lon="-84.2102904682385">
+				<ele>965.1179939499125</ele>
+				<time>2017-11-06T18:46:46Z</time>
+				<extensions>
+					<speed>4.556708812713623</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013117810823731" lon="-84.21029043620817">
+				<ele>965.7354814540595</ele>
+				<time>2017-11-06T18:46:47Z</time>
+				<extensions>
+					<speed>4.478860855102539</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013078025946763" lon="-84.21028656033731">
+				<ele>966.3775605112314</ele>
+				<time>2017-11-06T18:46:48Z</time>
+				<extensions>
+					<speed>4.70797061920166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013042367343422" lon="-84.21029078605909">
+				<ele>966.6353987120092</ele>
+				<time>2017-11-06T18:46:49Z</time>
+				<extensions>
+					<speed>4.49215030670166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01302081231892" lon="-84.21029978035412">
+				<ele>967.4522914420813</ele>
+				<time>2017-11-06T18:46:50Z</time>
+				<extensions>
+					<speed>3.136423110961914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013006347253496" lon="-84.21030308865238">
+				<ele>968.021340129897</ele>
+				<time>2017-11-06T18:46:51Z</time>
+				<extensions>
+					<speed>2.1877150535583496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012998256034017" lon="-84.21029400618899">
+				<ele>968.6937333298847</ele>
+				<time>2017-11-06T18:46:52Z</time>
+				<extensions>
+					<speed>1.6036341190338135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012997437194123" lon="-84.21029657181012">
+				<ele>969.0616422547027</ele>
+				<time>2017-11-06T18:46:53Z</time>
+				<extensions>
+					<speed>1.0357393026351929</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012996087365584" lon="-84.21028982070123">
+				<ele>969.4727308014408</ele>
+				<time>2017-11-06T18:46:54Z</time>
+				<extensions>
+					<speed>0.7999407052993774</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012996087365584" lon="-84.21028982070123">
+				<ele>969.4727308014408</ele>
+				<time>2017-11-06T18:46:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:46:56Z</time>
+				<extensions>
+					<speed>0.061296992003917694</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:46:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:46:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:46:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012994531466807" lon="-84.21029129175878">
+				<ele>969.4891249062493</ele>
+				<time>2017-11-06T18:47:34Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012991189711729" lon="-84.21028631660278">
+				<ele>969.480192665942</ele>
+				<time>2017-11-06T18:47:35Z</time>
+				<extensions>
+					<speed>0.6166045665740967</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01298652147683" lon="-84.21028703572264">
+				<ele>969.2901988141239</ele>
+				<time>2017-11-06T18:47:36Z</time>
+				<extensions>
+					<speed>0.648987889289856</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012984358514853" lon="-84.21028975054213">
+				<ele>969.2688381783664</ele>
+				<time>2017-11-06T18:47:37Z</time>
+				<extensions>
+					<speed>0.5088891983032227</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012981105674381" lon="-84.2102966532984">
+				<ele>969.3665475845337</ele>
+				<time>2017-11-06T18:47:38Z</time>
+				<extensions>
+					<speed>0.2899163067340851</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012973137892391" lon="-84.21029770493988">
+				<ele>969.3563618976623</ele>
+				<time>2017-11-06T18:47:39Z</time>
+				<extensions>
+					<speed>0.6104750037193298</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01295961741774" lon="-84.21029719066655">
+				<ele>969.4566368637607</ele>
+				<time>2017-11-06T18:47:40Z</time>
+				<extensions>
+					<speed>1.5739612579345703</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0129367596635" lon="-84.21028985708779">
+				<ele>969.5158896390349</ele>
+				<time>2017-11-06T18:47:41Z</time>
+				<extensions>
+					<speed>2.90558123588562</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012902648574622" lon="-84.21026909322596">
+				<ele>969.1921321377158</ele>
+				<time>2017-11-06T18:47:42Z</time>
+				<extensions>
+					<speed>4.60732364654541</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012862442347158" lon="-84.21024087206071">
+				<ele>969.15457081981</ele>
+				<time>2017-11-06T18:47:43Z</time>
+				<extensions>
+					<speed>5.636348724365234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012817890024182" lon="-84.21021811333414">
+				<ele>969.3396454928443</ele>
+				<time>2017-11-06T18:47:44Z</time>
+				<extensions>
+					<speed>5.764825820922852</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012772055016338" lon="-84.2101998542754">
+				<ele>969.6283062659204</ele>
+				<time>2017-11-06T18:47:45Z</time>
+				<extensions>
+					<speed>5.693233489990234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012724953894804" lon="-84.21018448747125">
+				<ele>969.7392412442714</ele>
+				<time>2017-11-06T18:47:46Z</time>
+				<extensions>
+					<speed>5.724621295928955</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012678443377295" lon="-84.21017941724621">
+				<ele>969.5328185316175</ele>
+				<time>2017-11-06T18:47:47Z</time>
+				<extensions>
+					<speed>5.06633996963501</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012640912220743" lon="-84.21018509379607">
+				<ele>968.9732502028346</ele>
+				<time>2017-11-06T18:47:48Z</time>
+				<extensions>
+					<speed>4.461684703826904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012610170167116" lon="-84.210198507864">
+				<ele>969.159959889017</ele>
+				<time>2017-11-06T18:47:49Z</time>
+				<extensions>
+					<speed>3.677546977996826</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012587786567707" lon="-84.21021149237528">
+				<ele>969.6589295649901</ele>
+				<time>2017-11-06T18:47:50Z</time>
+				<extensions>
+					<speed>2.316814422607422</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01257829176566" lon="-84.21023592973721">
+				<ele>970.5433844989166</ele>
+				<time>2017-11-06T18:47:51Z</time>
+				<extensions>
+					<speed>1.7719260454177856</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012575982180195" lon="-84.21026095036977">
+				<ele>971.3605336593464</ele>
+				<time>2017-11-06T18:47:52Z</time>
+				<extensions>
+					<speed>1.7965067625045776</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012580356072204" lon="-84.21026738056658">
+				<ele>971.2634327942505</ele>
+				<time>2017-11-06T18:47:53Z</time>
+				<extensions>
+					<speed>1.36429762840271</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012590374611202" lon="-84.2102750050831">
+				<ele>970.9893706012517</ele>
+				<time>2017-11-06T18:47:54Z</time>
+				<extensions>
+					<speed>1.112197995185852</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012600880324522" lon="-84.2102785394693">
+				<ele>970.4759518094361</ele>
+				<time>2017-11-06T18:47:55Z</time>
+				<extensions>
+					<speed>0.8215078115463257</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012600880324522" lon="-84.2102785394693">
+				<ele>970.4759518094361</ele>
+				<time>2017-11-06T18:47:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012605179797132" lon="-84.21027386652176">
+				<ele>970.2259306609631</ele>
+				<time>2017-11-06T18:47:57Z</time>
+				<extensions>
+					<speed>0.1366741806268692</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012605179797132" lon="-84.21027386652176">
+				<ele>970.2259306609631</ele>
+				<time>2017-11-06T18:47:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012605179797132" lon="-84.21027386652176">
+				<ele>970.2259306609631</ele>
+				<time>2017-11-06T18:47:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012605179797132" lon="-84.21027386652176">
+				<ele>970.2259306609631</ele>
+				<time>2017-11-06T18:48:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012605179797132" lon="-84.21027386652176">
+				<ele>970.2259306609631</ele>
+				<time>2017-11-06T18:48:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012605179797132" lon="-84.21027386652176">
+				<ele>970.2259306609631</ele>
+				<time>2017-11-06T18:48:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012605179797132" lon="-84.21027386652176">
+				<ele>970.2259306609631</ele>
+				<time>2017-11-06T18:48:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012605179797132" lon="-84.21027386652176">
+				<ele>970.2259306609631</ele>
+				<time>2017-11-06T18:48:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012605179797132" lon="-84.21027386652176">
+				<ele>970.2259306609631</ele>
+				<time>2017-11-06T18:48:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012605179797132" lon="-84.21027386652176">
+				<ele>970.2259306609631</ele>
+				<time>2017-11-06T18:48:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012605179797132" lon="-84.21027386652176">
+				<ele>970.2259306609631</ele>
+				<time>2017-11-06T18:48:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012605179797132" lon="-84.21027386652176">
+				<ele>970.2259306609631</ele>
+				<time>2017-11-06T18:48:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012605179797132" lon="-84.21027386652176">
+				<ele>970.2259306609631</ele>
+				<time>2017-11-06T18:48:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012605179797132" lon="-84.21027386652176">
+				<ele>970.2259306609631</ele>
+				<time>2017-11-06T18:48:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012605179797132" lon="-84.21027386652176">
+				<ele>970.2259306609631</ele>
+				<time>2017-11-06T18:48:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012605179797132" lon="-84.21027386652176">
+				<ele>970.2259306609631</ele>
+				<time>2017-11-06T18:48:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012605179797132" lon="-84.21027386652176">
+				<ele>970.2259306609631</ele>
+				<time>2017-11-06T18:48:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012605179797132" lon="-84.21027386652176">
+				<ele>970.2259306609631</ele>
+				<time>2017-11-06T18:48:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012601823498725" lon="-84.21028235396282">
+				<ele>970.9534035734832</ele>
+				<time>2017-11-06T18:48:15Z</time>
+				<extensions>
+					<speed>0.7080255150794983</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01259217006293" lon="-84.21029644277849">
+				<ele>971.7393275601789</ele>
+				<time>2017-11-06T18:48:16Z</time>
+				<extensions>
+					<speed>1.1272979974746704</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012589711717302" lon="-84.21031167580618">
+				<ele>972.3127634739503</ele>
+				<time>2017-11-06T18:48:17Z</time>
+				<extensions>
+					<speed>0.9818978905677795</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0125877894077" lon="-84.21032313717842">
+				<ele>972.8967073969543</ele>
+				<time>2017-11-06T18:48:18Z</time>
+				<extensions>
+					<speed>1.2682998180389404</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012584968842503" lon="-84.21033811579">
+				<ele>973.2988044116646</ele>
+				<time>2017-11-06T18:48:19Z</time>
+				<extensions>
+					<speed>1.5061832666397095</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012578406855505" lon="-84.21036176797051">
+				<ele>973.6026985831559</ele>
+				<time>2017-11-06T18:48:20Z</time>
+				<extensions>
+					<speed>2.2415270805358887</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012565328882724" lon="-84.21038749423093">
+				<ele>973.8748675510287</ele>
+				<time>2017-11-06T18:48:21Z</time>
+				<extensions>
+					<speed>2.7395246028900146</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012547705682755" lon="-84.21040598044836">
+				<ele>974.2178395297378</ele>
+				<time>2017-11-06T18:48:22Z</time>
+				<extensions>
+					<speed>2.725161552429199</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012539000134717" lon="-84.21043798983257">
+				<ele>974.521555589512</ele>
+				<time>2017-11-06T18:48:23Z</time>
+				<extensions>
+					<speed>2.842154026031494</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012537770400813" lon="-84.21048617593128">
+				<ele>974.8173129847273</ele>
+				<time>2017-11-06T18:48:24Z</time>
+				<extensions>
+					<speed>3.3275771141052246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012534157840136" lon="-84.21060821520625">
+				<ele>974.0195167930797</ele>
+				<time>2017-11-06T18:48:25Z</time>
+				<extensions>
+					<speed>5.6491594314575195</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012517843606627" lon="-84.21063118553468">
+				<ele>979.5362435523421</ele>
+				<time>2017-11-06T18:48:26Z</time>
+				<extensions>
+					<speed>8.59343147277832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012494122058149" lon="-84.21071799415076">
+				<ele>979.7417013449594</ele>
+				<time>2017-11-06T18:48:27Z</time>
+				<extensions>
+					<speed>10.037626266479492</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012469279406599" lon="-84.2107987155905">
+				<ele>979.7085902448744</ele>
+				<time>2017-11-06T18:48:28Z</time>
+				<extensions>
+					<speed>10.150270462036133</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012435200453464" lon="-84.21088790912887">
+				<ele>979.8485846379772</ele>
+				<time>2017-11-06T18:48:29Z</time>
+				<extensions>
+					<speed>10.567731857299805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012396975442847" lon="-84.21098624950102">
+				<ele>980.1755495723337</ele>
+				<time>2017-11-06T18:48:30Z</time>
+				<extensions>
+					<speed>11.066485404968262</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012377324595985" lon="-84.21114762074725">
+				<ele>979.2177539169788</ele>
+				<time>2017-11-06T18:48:31Z</time>
+				<extensions>
+					<speed>12.715383529663086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01235703987739" lon="-84.21131257256998">
+				<ele>978.2326843226328</ele>
+				<time>2017-11-06T18:48:32Z</time>
+				<extensions>
+					<speed>14.287256240844727</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012326345759874" lon="-84.21143745813738">
+				<ele>978.3884555278346</ele>
+				<time>2017-11-06T18:48:33Z</time>
+				<extensions>
+					<speed>14.263747215270996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012286982445685" lon="-84.21156395668781">
+				<ele>978.5063710408285</ele>
+				<time>2017-11-06T18:48:34Z</time>
+				<extensions>
+					<speed>14.528961181640625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01225229607771" lon="-84.21169414168634">
+				<ele>978.2122979648411</ele>
+				<time>2017-11-06T18:48:35Z</time>
+				<extensions>
+					<speed>14.208990097045898</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012218013408912" lon="-84.21182320132088">
+				<ele>977.7678175261244</ele>
+				<time>2017-11-06T18:48:36Z</time>
+				<extensions>
+					<speed>14.08765697479248</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012184991580602" lon="-84.21194313160832">
+				<ele>977.6531402524561</ele>
+				<time>2017-11-06T18:48:37Z</time>
+				<extensions>
+					<speed>13.99826717376709</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012150641222869" lon="-84.21206357800905">
+				<ele>977.7669554576278</ele>
+				<time>2017-11-06T18:48:38Z</time>
+				<extensions>
+					<speed>13.823774337768555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01211922998351" lon="-84.21217205187135">
+				<ele>977.7408323800191</ele>
+				<time>2017-11-06T18:48:39Z</time>
+				<extensions>
+					<speed>12.850738525390625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012089050996144" lon="-84.21227209013323">
+				<ele>977.6503609083593</ele>
+				<time>2017-11-06T18:48:40Z</time>
+				<extensions>
+					<speed>12.168652534484863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012055427390337" lon="-84.21236708577209">
+				<ele>977.5344249401242</ele>
+				<time>2017-11-06T18:48:41Z</time>
+				<extensions>
+					<speed>11.556282997131348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012024908206811" lon="-84.21246055542373">
+				<ele>977.3832610258833</ele>
+				<time>2017-11-06T18:48:42Z</time>
+				<extensions>
+					<speed>10.890181541442871</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01199672714644" lon="-84.2125501607645">
+				<ele>977.0301682883874</ele>
+				<time>2017-11-06T18:48:43Z</time>
+				<extensions>
+					<speed>10.1884765625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011975709060575" lon="-84.21262613401122">
+				<ele>976.6479683425277</ele>
+				<time>2017-11-06T18:48:44Z</time>
+				<extensions>
+					<speed>8.741044998168945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01195976222795" lon="-84.21269791131667">
+				<ele>976.5251840818673</ele>
+				<time>2017-11-06T18:48:45Z</time>
+				<extensions>
+					<speed>7.032878398895264</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011946774487326" lon="-84.21275756221208">
+				<ele>976.101160836406</ele>
+				<time>2017-11-06T18:48:46Z</time>
+				<extensions>
+					<speed>5.450774192810059</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011935745150717" lon="-84.2127979599028">
+				<ele>975.7488744240254</ele>
+				<time>2017-11-06T18:48:47Z</time>
+				<extensions>
+					<speed>3.633305072784424</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011928047648064" lon="-84.2128198209447">
+				<ele>975.4498270452023</ele>
+				<time>2017-11-06T18:48:48Z</time>
+				<extensions>
+					<speed>1.8940470218658447</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01192610676845" lon="-84.21282798735886">
+				<ele>975.1981507623568</ele>
+				<time>2017-11-06T18:48:49Z</time>
+				<extensions>
+					<speed>0.40980198979377747</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011928267091163" lon="-84.21282149537346">
+				<ele>974.6865760218352</ele>
+				<time>2017-11-06T18:48:50Z</time>
+				<extensions>
+					<speed>1.3087787628173828</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011929888704278" lon="-84.21280992939018">
+				<ele>974.20555763226</ele>
+				<time>2017-11-06T18:48:51Z</time>
+				<extensions>
+					<speed>1.5550647974014282</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01193294144036" lon="-84.21278875640093">
+				<ele>973.5114389900118</ele>
+				<time>2017-11-06T18:48:52Z</time>
+				<extensions>
+					<speed>1.4552505016326904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011920928062112" lon="-84.21277246836372">
+				<ele>972.4626954160631</ele>
+				<time>2017-11-06T18:48:53Z</time>
+				<extensions>
+					<speed>1.2324423789978027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011911541054806" lon="-84.21275734200366">
+				<ele>971.2697277376428</ele>
+				<time>2017-11-06T18:48:54Z</time>
+				<extensions>
+					<speed>1.1959112882614136</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011904504775377" lon="-84.21273986387779">
+				<ele>970.6786287166178</ele>
+				<time>2017-11-06T18:48:55Z</time>
+				<extensions>
+					<speed>1.2070387601852417</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:48:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:48:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:48:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:48:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:31Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:32Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011891650208849" lon="-84.212731294745">
+				<ele>970.70283177495</ele>
+				<time>2017-11-06T18:49:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011882942875632" lon="-84.21275858291516">
+				<ele>970.8653386803344</ele>
+				<time>2017-11-06T18:49:34Z</time>
+				<extensions>
+					<speed>0.8021445870399475</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01187658659866" lon="-84.21277972284665">
+				<ele>971.0681798178703</ele>
+				<time>2017-11-06T18:49:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01187364301894" lon="-84.21279189230394">
+				<ele>971.3517635772005</ele>
+				<time>2017-11-06T18:49:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01187364301894" lon="-84.21279189230394">
+				<ele>971.3517635772005</ele>
+				<time>2017-11-06T18:49:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01187364301894" lon="-84.21279189230394">
+				<ele>971.3517635772005</ele>
+				<time>2017-11-06T18:49:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01187364301894" lon="-84.21279189230394">
+				<ele>971.3517635772005</ele>
+				<time>2017-11-06T18:49:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01187364301894" lon="-84.21279189230394">
+				<ele>971.3517635772005</ele>
+				<time>2017-11-06T18:49:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011868619307032" lon="-84.21282021508958">
+				<ele>970.9579200353473</ele>
+				<time>2017-11-06T18:49:41Z</time>
+				<extensions>
+					<speed>0.9685716032981873</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011860788409853" lon="-84.21284471005701">
+				<ele>970.8101139618084</ele>
+				<time>2017-11-06T18:49:42Z</time>
+				<extensions>
+					<speed>1.6524180173873901</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011852035287994" lon="-84.21287011566456">
+				<ele>970.3683867538348</ele>
+				<time>2017-11-06T18:49:43Z</time>
+				<extensions>
+					<speed>2.182960033416748</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011842010142786" lon="-84.21289440370553">
+				<ele>969.5878638941795</ele>
+				<time>2017-11-06T18:49:44Z</time>
+				<extensions>
+					<speed>2.522477865219116</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011831736229192" lon="-84.21294034624101">
+				<ele>968.8454323429614</ele>
+				<time>2017-11-06T18:49:45Z</time>
+				<extensions>
+					<speed>3.3588271141052246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011818972289147" lon="-84.2130007556726">
+				<ele>968.2263697702438</ele>
+				<time>2017-11-06T18:49:46Z</time>
+				<extensions>
+					<speed>4.385557174682617</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011805696774902" lon="-84.21305638496685">
+				<ele>968.1572561468929</ele>
+				<time>2017-11-06T18:49:47Z</time>
+				<extensions>
+					<speed>5.442324638366699</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011790454162874" lon="-84.21311315603756">
+				<ele>967.8783837771043</ele>
+				<time>2017-11-06T18:49:48Z</time>
+				<extensions>
+					<speed>5.857096195220947</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011772773606728" lon="-84.21316374595729">
+				<ele>967.5840773256496</ele>
+				<time>2017-11-06T18:49:49Z</time>
+				<extensions>
+					<speed>5.730207443237305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011758470202459" lon="-84.21321151403882">
+				<ele>966.9222897579893</ele>
+				<time>2017-11-06T18:49:50Z</time>
+				<extensions>
+					<speed>5.344754695892334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011745457657746" lon="-84.21325675538814">
+				<ele>966.3799024410546</ele>
+				<time>2017-11-06T18:49:51Z</time>
+				<extensions>
+					<speed>4.527790546417236</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011736382323603" lon="-84.21329595092499">
+				<ele>966.0742886206135</ele>
+				<time>2017-11-06T18:49:52Z</time>
+				<extensions>
+					<speed>3.3853509426116943</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011731863351693" lon="-84.21332708956527">
+				<ele>965.4966965038329</ele>
+				<time>2017-11-06T18:49:53Z</time>
+				<extensions>
+					<speed>1.4037456512451172</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:49:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:49:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01174158951195" lon="-84.21333919220915">
+				<ele>965.1968119814992</ele>
+				<time>2017-11-06T18:49:56Z</time>
+				<extensions>
+					<speed>0.6341599822044373</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:49:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:49:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:49:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:50:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:50:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:50:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:50:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:50:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:50:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:50:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:50:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:50:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:50:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:50:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:50:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:50:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:50:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:50:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:50:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:50:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:50:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734346492606" lon="-84.213346830307">
+				<ele>965.2579658469185</ele>
+				<time>2017-11-06T18:50:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011734856703749" lon="-84.21335904842914">
+				<ele>965.1733036190271</ele>
+				<time>2017-11-06T18:50:19Z</time>
+				<extensions>
+					<speed>0.8634811043739319</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011729026265916" lon="-84.2133839997268">
+				<ele>965.4988749930635</ele>
+				<time>2017-11-06T18:50:20Z</time>
+				<extensions>
+					<speed>2.474653959274292</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011719450443598" lon="-84.2134182732816">
+				<ele>965.7060147924349</ele>
+				<time>2017-11-06T18:50:21Z</time>
+				<extensions>
+					<speed>4.249876499176025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0117035872028" lon="-84.21346303465018">
+				<ele>965.9051695903763</ele>
+				<time>2017-11-06T18:50:22Z</time>
+				<extensions>
+					<speed>5.34001350402832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011689400190269" lon="-84.21351870352032">
+				<ele>966.2104562781751</ele>
+				<time>2017-11-06T18:50:23Z</time>
+				<extensions>
+					<speed>6.241644859313965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011676808934597" lon="-84.21357894648317">
+				<ele>966.5196247631684</ele>
+				<time>2017-11-06T18:50:24Z</time>
+				<extensions>
+					<speed>6.546930313110352</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01166165762048" lon="-84.21363920589225">
+				<ele>966.6484314361587</ele>
+				<time>2017-11-06T18:50:25Z</time>
+				<extensions>
+					<speed>6.661571025848389</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01164207058341" lon="-84.21369690137087">
+				<ele>966.8011528737843</ele>
+				<time>2017-11-06T18:50:26Z</time>
+				<extensions>
+					<speed>6.557217121124268</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011620426606406" lon="-84.21375262984542">
+				<ele>966.9487664410844</ele>
+				<time>2017-11-06T18:50:27Z</time>
+				<extensions>
+					<speed>6.529960632324219</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011590809285925" lon="-84.21379930992289">
+				<ele>967.0833068685606</ele>
+				<time>2017-11-06T18:50:28Z</time>
+				<extensions>
+					<speed>6.173574447631836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01155089150925" lon="-84.21382772526242">
+				<ele>967.1924260351807</ele>
+				<time>2017-11-06T18:50:29Z</time>
+				<extensions>
+					<speed>5.628880977630615</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011504517076101" lon="-84.21384945643958">
+				<ele>967.3269748575985</ele>
+				<time>2017-11-06T18:50:30Z</time>
+				<extensions>
+					<speed>5.567433834075928</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011451884411985" lon="-84.21385855694915">
+				<ele>967.5315739354119</ele>
+				<time>2017-11-06T18:50:31Z</time>
+				<extensions>
+					<speed>5.61693811416626</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011393969605248" lon="-84.21386138314385">
+				<ele>967.7006340511143</ele>
+				<time>2017-11-06T18:50:32Z</time>
+				<extensions>
+					<speed>5.968935489654541</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011316226360789" lon="-84.21383993407206">
+				<ele>968.0032216254622</ele>
+				<time>2017-11-06T18:50:33Z</time>
+				<extensions>
+					<speed>7.060144424438477</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011220099432984" lon="-84.21383117297135">
+				<ele>968.718677685596</ele>
+				<time>2017-11-06T18:50:34Z</time>
+				<extensions>
+					<speed>8.587905883789063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011109141205395" lon="-84.21381186209058">
+				<ele>969.3608591742814</ele>
+				<time>2017-11-06T18:50:35Z</time>
+				<extensions>
+					<speed>9.546343803405762</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010968218628635" lon="-84.2137420846977">
+				<ele>970.2389631578699</ele>
+				<time>2017-11-06T18:50:36Z</time>
+				<extensions>
+					<speed>11.401307106018066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010851136853784" lon="-84.21368246027406">
+				<ele>970.4704576376826</ele>
+				<time>2017-11-06T18:50:37Z</time>
+				<extensions>
+					<speed>12.204293251037598</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010736915752735" lon="-84.21362776171503">
+				<ele>970.6858565844595</ele>
+				<time>2017-11-06T18:50:38Z</time>
+				<extensions>
+					<speed>12.510316848754883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010627888144622" lon="-84.21357112305044">
+				<ele>970.8795232996345</ele>
+				<time>2017-11-06T18:50:39Z</time>
+				<extensions>
+					<speed>12.464673042297363</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010529572236056" lon="-84.2134969150338">
+				<ele>970.9662421653047</ele>
+				<time>2017-11-06T18:50:40Z</time>
+				<extensions>
+					<speed>12.38210391998291</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010433549229134" lon="-84.21344740968114">
+				<ele>971.0210055634379</ele>
+				<time>2017-11-06T18:50:41Z</time>
+				<extensions>
+					<speed>12.032147407531738</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010348169406107" lon="-84.21342920059539">
+				<ele>971.1573898764327</ele>
+				<time>2017-11-06T18:50:42Z</time>
+				<extensions>
+					<speed>11.154250144958496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010260613784954" lon="-84.21339744994205">
+				<ele>971.302964345552</ele>
+				<time>2017-11-06T18:50:43Z</time>
+				<extensions>
+					<speed>10.70996379852295</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010176285312404" lon="-84.21335597110443">
+				<ele>971.4209439838305</ele>
+				<time>2017-11-06T18:50:44Z</time>
+				<extensions>
+					<speed>10.344666481018066</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01009716510208" lon="-84.21331278590789">
+				<ele>971.5275164814666</ele>
+				<time>2017-11-06T18:50:45Z</time>
+				<extensions>
+					<speed>9.928877830505371</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010024816904219" lon="-84.21327655288331">
+				<ele>971.6159128304571</ele>
+				<time>2017-11-06T18:50:46Z</time>
+				<extensions>
+					<speed>9.626046180725098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009962434453284" lon="-84.21324185815843">
+				<ele>971.7397004682571</ele>
+				<time>2017-11-06T18:50:47Z</time>
+				<extensions>
+					<speed>8.959094047546387</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009895998682298" lon="-84.2132034349822">
+				<ele>971.8247358230874</ele>
+				<time>2017-11-06T18:50:48Z</time>
+				<extensions>
+					<speed>8.657013893127441</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00983161207129" lon="-84.21315323595984">
+				<ele>971.8763535721228</ele>
+				<time>2017-11-06T18:50:49Z</time>
+				<extensions>
+					<speed>8.679178237915039</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009756837551743" lon="-84.21307850538352">
+				<ele>971.9482954898849</ele>
+				<time>2017-11-06T18:50:50Z</time>
+				<extensions>
+					<speed>9.057720184326172</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009708229597093" lon="-84.21302107258937">
+				<ele>971.9922104561701</ele>
+				<time>2017-11-06T18:50:51Z</time>
+				<extensions>
+					<speed>9.098356246948242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009656821849399" lon="-84.2129686415076">
+				<ele>972.0603417102247</ele>
+				<time>2017-11-06T18:50:52Z</time>
+				<extensions>
+					<speed>9.04376220703125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00964559377827" lon="-84.21293601317308">
+				<ele>972.1277630459517</ele>
+				<time>2017-11-06T18:50:53Z</time>
+				<extensions>
+					<speed>8.393033981323242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010340108536209" lon="-84.21305126271855">
+				<ele>975.2006728230044</ele>
+				<time>2017-11-06T18:51:00Z</time>
+				<extensions>
+					<speed>7.950812816619873</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010405054878484" lon="-84.21312710588617">
+				<ele>998.2124222368002</ele>
+				<time>2017-11-06T18:51:01Z</time>
+				<extensions>
+					<speed>9.465665817260742</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01046992814752" lon="-84.2132266133683">
+				<ele>1018.5539158685133</ele>
+				<time>2017-11-06T18:51:02Z</time>
+				<extensions>
+					<speed>10.950784683227539</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010513118728877" lon="-84.21330811556591">
+				<ele>1040.266527515836</ele>
+				<time>2017-11-06T18:51:03Z</time>
+				<extensions>
+					<speed>10.472033500671387</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010510287727197" lon="-84.21338174451849">
+				<ele>1061.841170977801</ele>
+				<time>2017-11-06T18:51:04Z</time>
+				<extensions>
+					<speed>9.270874977111816</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010535740262931" lon="-84.21345974303158">
+				<ele>1084.0024540126324</ele>
+				<time>2017-11-06T18:51:05Z</time>
+				<extensions>
+					<speed>9.184538841247559</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010561206665228" lon="-84.21350430214164">
+				<ele>1109.9344017365947</ele>
+				<time>2017-11-06T18:51:06Z</time>
+				<extensions>
+					<speed>8.629213333129883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010600580038874" lon="-84.21355928056433">
+				<ele>1137.4695798801258</ele>
+				<time>2017-11-06T18:51:07Z</time>
+				<extensions>
+					<speed>8.551718711853027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008908329968634" lon="-84.21165245045724">
+				<ele>975.1986205810681</ele>
+				<time>2017-11-06T18:52:00Z</time>
+				<extensions>
+					<speed>8.509505271911621</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008790694860632" lon="-84.21137685540123">
+				<ele>978.3727094754577</ele>
+				<time>2017-11-06T18:52:01Z</time>
+				<extensions>
+					<speed>20.08727264404297</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008742957303763" lon="-84.2111101178443">
+				<ele>984.2605765648186</ele>
+				<time>2017-11-06T18:52:02Z</time>
+				<extensions>
+					<speed>22.493040084838867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008742957303763" lon="-84.2111101178443">
+				<ele>978.5433075791225</ele>
+				<time>2017-11-06T18:52:03Z</time>
+				<extensions>
+					<speed>12.648774147033691</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008823438991486" lon="-84.21104899811901">
+				<ele>975.210834948346</ele>
+				<time>2017-11-06T18:52:04Z</time>
+				<extensions>
+					<speed>12.036080360412598</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008815062718824" lon="-84.21092995426434">
+				<ele>981.4383511217311</ele>
+				<time>2017-11-06T18:52:05Z</time>
+				<extensions>
+					<speed>11.528168678283691</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008781772173851" lon="-84.21075796595692">
+				<ele>981.787557230331</ele>
+				<time>2017-11-06T18:52:06Z</time>
+				<extensions>
+					<speed>11.129474639892578</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008770801275867" lon="-84.21066456740739">
+				<ele>989.6843757629395</ele>
+				<time>2017-11-06T18:52:07Z</time>
+				<extensions>
+					<speed>10.514646530151367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008760301242488" lon="-84.21059724257489">
+				<ele>998.6148831099272</ele>
+				<time>2017-11-06T18:52:08Z</time>
+				<extensions>
+					<speed>9.360325813293457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008730485766332" lon="-84.21052106009361">
+				<ele>1002.6800554655492</ele>
+				<time>2017-11-06T18:52:09Z</time>
+				<extensions>
+					<speed>8.31796932220459</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008706708326987" lon="-84.21047729610153">
+				<ele>994.011393466033</ele>
+				<time>2017-11-06T18:52:10Z</time>
+				<extensions>
+					<speed>5.5862202644348145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008700902283262" lon="-84.21048186215991">
+				<ele>991.8856813125312</ele>
+				<time>2017-11-06T18:52:11Z</time>
+				<extensions>
+					<speed>2.3074257373809814</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008675482477773" lon="-84.21043546910558">
+				<ele>991.0917028496042</ele>
+				<time>2017-11-06T18:52:12Z</time>
+				<extensions>
+					<speed>0.725706160068512</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008661489231852" lon="-84.21039546639525">
+				<ele>1002.9198077078909</ele>
+				<time>2017-11-06T18:52:13Z</time>
+				<extensions>
+					<speed>0.8191115856170654</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008616456081953" lon="-84.21036941512088">
+				<ele>971.1498019229621</ele>
+				<time>2017-11-06T18:52:14Z</time>
+				<extensions>
+					<speed>0.9237106442451477</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008595614468245" lon="-84.21033926340475">
+				<ele>969.9400557298213</ele>
+				<time>2017-11-06T18:52:15Z</time>
+				<extensions>
+					<speed>0.4844369888305664</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008572322616953" lon="-84.21030362478909">
+				<ele>967.3152715796605</ele>
+				<time>2017-11-06T18:52:16Z</time>
+				<extensions>
+					<speed>0.26918157935142517</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008572322616953" lon="-84.21030362478909">
+				<ele>952.6371500436217</ele>
+				<time>2017-11-06T18:52:17Z</time>
+				<extensions>
+					<speed>0.15690350532531738</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00852578440926" lon="-84.21024161911797">
+				<ele>942.5782631747425</ele>
+				<time>2017-11-06T18:52:18Z</time>
+				<extensions>
+					<speed>0.19576217234134674</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008517232289753" lon="-84.21021989383456">
+				<ele>937.5531214149669</ele>
+				<time>2017-11-06T18:52:19Z</time>
+				<extensions>
+					<speed>0.07145915925502777</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008517232289753" lon="-84.21021989383456">
+				<ele>924.2157311784104</ele>
+				<time>2017-11-06T18:52:20Z</time>
+				<extensions>
+					<speed>0.03896123543381691</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008517232289753" lon="-84.21021989383456">
+				<ele>918.8316904744133</ele>
+				<time>2017-11-06T18:52:21Z</time>
+				<extensions>
+					<speed>0.10952182859182358</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008517232289753" lon="-84.21021989383456">
+				<ele>916.8872112976387</ele>
+				<time>2017-11-06T18:52:22Z</time>
+				<extensions>
+					<speed>0.33520621061325073</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008466700640838" lon="-84.21005935397076">
+				<ele>915.6468513021246</ele>
+				<time>2017-11-06T18:52:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008463700307669" lon="-84.21004028918398">
+				<ele>909.8921568514779</ele>
+				<time>2017-11-06T18:52:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008463700307669" lon="-84.21004028918398">
+				<ele>909.8921568514779</ele>
+				<time>2017-11-06T18:52:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008463700307669" lon="-84.21004028918398">
+				<ele>909.8921568514779</ele>
+				<time>2017-11-06T18:52:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008463700307669" lon="-84.21004028918398">
+				<ele>909.8921568514779</ele>
+				<time>2017-11-06T18:52:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008463700307669" lon="-84.21004028918398">
+				<ele>909.8921568514779</ele>
+				<time>2017-11-06T18:52:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008465684200408" lon="-84.21001331506044">
+				<ele>912.9272751649842</ele>
+				<time>2017-11-06T18:52:29Z</time>
+				<extensions>
+					<speed>1.6559909582138062</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008478616171073" lon="-84.2100089542992">
+				<ele>918.5894172368571</ele>
+				<time>2017-11-06T18:52:30Z</time>
+				<extensions>
+					<speed>2.940565586090088</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00849342519141" lon="-84.20999439994705">
+				<ele>923.9162410805002</ele>
+				<time>2017-11-06T18:52:31Z</time>
+				<extensions>
+					<speed>4.3309478759765625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008501738712603" lon="-84.20995785874425">
+				<ele>925.7385813659057</ele>
+				<time>2017-11-06T18:52:32Z</time>
+				<extensions>
+					<speed>5.35521936416626</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008508279201498" lon="-84.2099103834946">
+				<ele>928.1447877548635</ele>
+				<time>2017-11-06T18:52:33Z</time>
+				<extensions>
+					<speed>6.340835094451904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008512569705934" lon="-84.20984970196263">
+				<ele>929.8148722508922</ele>
+				<time>2017-11-06T18:52:34Z</time>
+				<extensions>
+					<speed>7.3009796142578125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0085121259693" lon="-84.2097817731527">
+				<ele>931.1320532700047</ele>
+				<time>2017-11-06T18:52:35Z</time>
+				<extensions>
+					<speed>7.5565032958984375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008516205797358" lon="-84.20970443906081">
+				<ele>929.1923589389771</ele>
+				<time>2017-11-06T18:52:36Z</time>
+				<extensions>
+					<speed>7.60615348815918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008520738435898" lon="-84.20962764105393">
+				<ele>927.5058306250721</ele>
+				<time>2017-11-06T18:52:37Z</time>
+				<extensions>
+					<speed>7.612475872039795</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008522895160745" lon="-84.20956404410673">
+				<ele>929.0599978473037</ele>
+				<time>2017-11-06T18:52:38Z</time>
+				<extensions>
+					<speed>7.713833808898926</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00852793140832" lon="-84.20950479868915">
+				<ele>932.6151136942208</ele>
+				<time>2017-11-06T18:52:39Z</time>
+				<extensions>
+					<speed>8.092037200927734</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00852173370303" lon="-84.209438024832">
+				<ele>931.7006396250799</ele>
+				<time>2017-11-06T18:52:40Z</time>
+				<extensions>
+					<speed>7.814209938049316</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00851623443901" lon="-84.20937263551812">
+				<ele>930.4574704580009</ele>
+				<time>2017-11-06T18:52:41Z</time>
+				<extensions>
+					<speed>7.437169075012207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008520744196481" lon="-84.20932729535788">
+				<ele>930.8877875711769</ele>
+				<time>2017-11-06T18:52:42Z</time>
+				<extensions>
+					<speed>6.264498710632324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00853044018577" lon="-84.20928983697259">
+				<ele>932.3735148897395</ele>
+				<time>2017-11-06T18:52:43Z</time>
+				<extensions>
+					<speed>4.62211799621582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008536632844589" lon="-84.20926228565355">
+				<ele>932.398484534584</ele>
+				<time>2017-11-06T18:52:44Z</time>
+				<extensions>
+					<speed>3.0042412281036377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008545927077462" lon="-84.2092530619736">
+				<ele>933.3071687305346</ele>
+				<time>2017-11-06T18:52:45Z</time>
+				<extensions>
+					<speed>1.5293816328048706</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008550189090588" lon="-84.2092514888046">
+				<ele>933.6214939113706</ele>
+				<time>2017-11-06T18:52:46Z</time>
+				<extensions>
+					<speed>0.9317905306816101</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008553010339336" lon="-84.20925192272905">
+				<ele>933.7173866312951</ele>
+				<time>2017-11-06T18:52:47Z</time>
+				<extensions>
+					<speed>0.6027788519859314</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008553010339336" lon="-84.20925192272905">
+				<ele>933.7173866312951</ele>
+				<time>2017-11-06T18:52:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008553188832483" lon="-84.20924528347726">
+				<ele>934.0240189116448</ele>
+				<time>2017-11-06T18:52:49Z</time>
+				<extensions>
+					<speed>0.7539005875587463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008554691845644" lon="-84.20923087907254">
+				<ele>935.0097057558596</ele>
+				<time>2017-11-06T18:52:50Z</time>
+				<extensions>
+					<speed>1.4506927728652954</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008556049584287" lon="-84.20921211097799">
+				<ele>935.3079420793802</ele>
+				<time>2017-11-06T18:52:51Z</time>
+				<extensions>
+					<speed>2.051330327987671</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00855757989523" lon="-84.20918458399323">
+				<ele>934.2644546926022</ele>
+				<time>2017-11-06T18:52:52Z</time>
+				<extensions>
+					<speed>2.4444942474365234</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008561760461575" lon="-84.20916247846138">
+				<ele>932.9857002384961</ele>
+				<time>2017-11-06T18:52:53Z</time>
+				<extensions>
+					<speed>2.528287887573242</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008566743819808" lon="-84.20913999399804">
+				<ele>932.4553381847218</ele>
+				<time>2017-11-06T18:52:54Z</time>
+				<extensions>
+					<speed>2.6402766704559326</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008569159344564" lon="-84.20911067814109">
+				<ele>931.4042492425069</ele>
+				<time>2017-11-06T18:52:55Z</time>
+				<extensions>
+					<speed>2.8905067443847656</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008571480037173" lon="-84.20907468566443">
+				<ele>930.2055528266355</ele>
+				<time>2017-11-06T18:52:56Z</time>
+				<extensions>
+					<speed>3.2660624980926514</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008574621183776" lon="-84.20903078385014">
+				<ele>929.8975047916174</ele>
+				<time>2017-11-06T18:52:57Z</time>
+				<extensions>
+					<speed>4.006923198699951</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008576871759567" lon="-84.20898486017467">
+				<ele>931.1290331631899</ele>
+				<time>2017-11-06T18:52:58Z</time>
+				<extensions>
+					<speed>4.660938262939453</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00858240567398" lon="-84.20892179520808">
+				<ele>933.5880525996909</ele>
+				<time>2017-11-06T18:52:59Z</time>
+				<extensions>
+					<speed>6.471346378326416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008585809013963" lon="-84.20885189274836">
+				<ele>934.0112005686387</ele>
+				<time>2017-11-06T18:53:00Z</time>
+				<extensions>
+					<speed>7.308367729187012</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008583727034205" lon="-84.20876856238573">
+				<ele>929.538890290074</ele>
+				<time>2017-11-06T18:53:01Z</time>
+				<extensions>
+					<speed>7.684874534606934</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00858708572305" lon="-84.20868766100102">
+				<ele>928.1494111651555</ele>
+				<time>2017-11-06T18:53:02Z</time>
+				<extensions>
+					<speed>8.13420295715332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008586682694254" lon="-84.20860896129773">
+				<ele>928.3411768255755</ele>
+				<time>2017-11-06T18:53:03Z</time>
+				<extensions>
+					<speed>8.614171981811523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008579884696704" lon="-84.20852623697249">
+				<ele>927.4213764611632</ele>
+				<time>2017-11-06T18:53:04Z</time>
+				<extensions>
+					<speed>9.063962936401367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00857008051995" lon="-84.20843411979432">
+				<ele>926.0953820366412</ele>
+				<time>2017-11-06T18:53:05Z</time>
+				<extensions>
+					<speed>9.973488807678223</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008560236557617" lon="-84.20832974590017">
+				<ele>922.988142836839</ele>
+				<time>2017-11-06T18:53:06Z</time>
+				<extensions>
+					<speed>10.710664749145508</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00855034477148" lon="-84.20821723934736">
+				<ele>919.7691224180162</ele>
+				<time>2017-11-06T18:53:07Z</time>
+				<extensions>
+					<speed>11.187960624694824</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008572082019887" lon="-84.20813940642597">
+				<ele>932.6154209533706</ele>
+				<time>2017-11-06T18:53:08Z</time>
+				<extensions>
+					<speed>10.597761154174805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008594516010708" lon="-84.20807254321544">
+				<ele>945.9138069385663</ele>
+				<time>2017-11-06T18:53:09Z</time>
+				<extensions>
+					<speed>9.059422492980957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008591857991032" lon="-84.20798901546685">
+				<ele>947.0916409380734</ele>
+				<time>2017-11-06T18:53:10Z</time>
+				<extensions>
+					<speed>8.788238525390625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008585549553832" lon="-84.20791201466191">
+				<ele>947.6390501763672</ele>
+				<time>2017-11-06T18:53:11Z</time>
+				<extensions>
+					<speed>8.191452026367188</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00857051498367" lon="-84.20786147848389">
+				<ele>948.7123892623931</ele>
+				<time>2017-11-06T18:53:12Z</time>
+				<extensions>
+					<speed>5.82797908782959</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008549168255797" lon="-84.20781805817263">
+				<ele>950.1467780265957</ele>
+				<time>2017-11-06T18:53:13Z</time>
+				<extensions>
+					<speed>4.947604179382324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00851937087708" lon="-84.2077895633641">
+				<ele>950.7109510777518</ele>
+				<time>2017-11-06T18:53:14Z</time>
+				<extensions>
+					<speed>4.5328688621521</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008489178223417" lon="-84.20776964189938">
+				<ele>950.8393354164436</ele>
+				<time>2017-11-06T18:53:15Z</time>
+				<extensions>
+					<speed>4.096548080444336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008441973309496" lon="-84.20775460289967">
+				<ele>945.6356874257326</ele>
+				<time>2017-11-06T18:53:16Z</time>
+				<extensions>
+					<speed>4.546604633331299</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008391486691709" lon="-84.2077335395526">
+				<ele>940.9122093087062</ele>
+				<time>2017-11-06T18:53:17Z</time>
+				<extensions>
+					<speed>5.031240463256836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008352850952523" lon="-84.20770459136112">
+				<ele>941.6420746268705</ele>
+				<time>2017-11-06T18:53:18Z</time>
+				<extensions>
+					<speed>5.510293483734131</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008305493623253" lon="-84.20767111063897">
+				<ele>942.1641708007082</ele>
+				<time>2017-11-06T18:53:19Z</time>
+				<extensions>
+					<speed>7.061225891113281</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008245697193225" lon="-84.2076272329565">
+				<ele>942.3323353892192</ele>
+				<time>2017-11-06T18:53:20Z</time>
+				<extensions>
+					<speed>8.502104759216309</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008180305387265" lon="-84.20756642236098">
+				<ele>943.932230995968</ele>
+				<time>2017-11-06T18:53:21Z</time>
+				<extensions>
+					<speed>10.296138763427734</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008105352046988" lon="-84.20749119645319">
+				<ele>945.7357421508059</ele>
+				<time>2017-11-06T18:53:22Z</time>
+				<extensions>
+					<speed>12.001609802246094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008023869555606" lon="-84.20741409178632">
+				<ele>946.9658418577164</ele>
+				<time>2017-11-06T18:53:23Z</time>
+				<extensions>
+					<speed>12.247822761535645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007938364547178" lon="-84.20733902421796">
+				<ele>947.8108547786251</ele>
+				<time>2017-11-06T18:53:24Z</time>
+				<extensions>
+					<speed>12.491875648498535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007843128195494" lon="-84.20725602025524">
+				<ele>948.1085385493934</ele>
+				<time>2017-11-06T18:53:25Z</time>
+				<extensions>
+					<speed>13.453866004943848</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007744589296077" lon="-84.20717397122672">
+				<ele>948.3393965400755</ele>
+				<time>2017-11-06T18:53:26Z</time>
+				<extensions>
+					<speed>14.132492065429688</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007641195910207" lon="-84.20708625692471">
+				<ele>947.4235804220662</ele>
+				<time>2017-11-06T18:53:27Z</time>
+				<extensions>
+					<speed>14.496405601501465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007538777852188" lon="-84.20700087069442">
+				<ele>948.1112951096147</ele>
+				<time>2017-11-06T18:53:28Z</time>
+				<extensions>
+					<speed>14.442952156066895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007446788869077" lon="-84.2069171380221">
+				<ele>948.1396800754592</ele>
+				<time>2017-11-06T18:53:29Z</time>
+				<extensions>
+					<speed>13.736320495605469</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007361439852126" lon="-84.20683258987098">
+				<ele>948.5544861285016</ele>
+				<time>2017-11-06T18:53:30Z</time>
+				<extensions>
+					<speed>13.29153060913086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007287827737837" lon="-84.20675888563699">
+				<ele>949.4110371889547</ele>
+				<time>2017-11-06T18:53:31Z</time>
+				<extensions>
+					<speed>11.690767288208008</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007232109603398" lon="-84.2066863958673">
+				<ele>949.6565091731027</ele>
+				<time>2017-11-06T18:53:32Z</time>
+				<extensions>
+					<speed>10.0006742477417</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007201478117379" lon="-84.20662019826979">
+				<ele>949.6301332488656</ele>
+				<time>2017-11-06T18:53:33Z</time>
+				<extensions>
+					<speed>7.748779296875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007190977343468" lon="-84.20657359502624">
+				<ele>949.9576341584325</ele>
+				<time>2017-11-06T18:53:34Z</time>
+				<extensions>
+					<speed>5.421123504638672</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007188511016897" lon="-84.20654761734798">
+				<ele>951.9180018762127</ele>
+				<time>2017-11-06T18:53:35Z</time>
+				<extensions>
+					<speed>3.166886329650879</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007184436710222" lon="-84.20653083403619">
+				<ele>953.3111506178975</ele>
+				<time>2017-11-06T18:53:36Z</time>
+				<extensions>
+					<speed>2.5796711444854736</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007185116491478" lon="-84.20652257041212">
+				<ele>953.829346684739</ele>
+				<time>2017-11-06T18:53:37Z</time>
+				<extensions>
+					<speed>1.9810845851898193</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007184184813614" lon="-84.20650997870001">
+				<ele>954.723559926264</ele>
+				<time>2017-11-06T18:53:38Z</time>
+				<extensions>
+					<speed>2.0209028720855713</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007187917345396" lon="-84.20651358697717">
+				<ele>955.5984145486727</ele>
+				<time>2017-11-06T18:53:39Z</time>
+				<extensions>
+					<speed>1.215467929840088</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007191802929396" lon="-84.20651328297755">
+				<ele>956.2366612637416</ele>
+				<time>2017-11-06T18:53:40Z</time>
+				<extensions>
+					<speed>0.8165103793144226</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007191802929396" lon="-84.20651328297755">
+				<ele>956.2366612637416</ele>
+				<time>2017-11-06T18:53:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007199145804528" lon="-84.20653283148344">
+				<ele>956.8872279180214</ele>
+				<time>2017-11-06T18:53:42Z</time>
+				<extensions>
+					<speed>0.8805860877037048</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0071977675649" lon="-84.20654572407841">
+				<ele>957.3143476983532</ele>
+				<time>2017-11-06T18:53:43Z</time>
+				<extensions>
+					<speed>1.180810809135437</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007185996096878" lon="-84.20655916286249">
+				<ele>954.6018634196371</ele>
+				<time>2017-11-06T18:53:44Z</time>
+				<extensions>
+					<speed>2.0076470375061035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007168444635534" lon="-84.20657881753772">
+				<ele>952.0907814893872</ele>
+				<time>2017-11-06T18:53:45Z</time>
+				<extensions>
+					<speed>2.8061394691467285</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007143386553219" lon="-84.2065893376259">
+				<ele>949.1200791615993</ele>
+				<time>2017-11-06T18:53:46Z</time>
+				<extensions>
+					<speed>3.1880528926849365</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007113411089874" lon="-84.20659285893662">
+				<ele>946.1489960607141</ele>
+				<time>2017-11-06T18:53:47Z</time>
+				<extensions>
+					<speed>3.771620035171509</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007086202711836" lon="-84.20659567052515">
+				<ele>945.4442795030773</ele>
+				<time>2017-11-06T18:53:48Z</time>
+				<extensions>
+					<speed>3.654249906539917</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007057271465953" lon="-84.20660595420985">
+				<ele>945.1528183314949</ele>
+				<time>2017-11-06T18:53:49Z</time>
+				<extensions>
+					<speed>3.500190258026123</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007025287006657" lon="-84.20659134733198">
+				<ele>944.713504624553</ele>
+				<time>2017-11-06T18:53:50Z</time>
+				<extensions>
+					<speed>3.840268135070801</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006985155071808" lon="-84.20655872700858">
+				<ele>944.1008389396593</ele>
+				<time>2017-11-06T18:53:51Z</time>
+				<extensions>
+					<speed>6.0154805183410645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006940341159254" lon="-84.20651565832605">
+				<ele>943.6332909269258</ele>
+				<time>2017-11-06T18:53:52Z</time>
+				<extensions>
+					<speed>7.0549116134643555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006890872021506" lon="-84.2064731619999">
+				<ele>942.9580614520237</ele>
+				<time>2017-11-06T18:53:53Z</time>
+				<extensions>
+					<speed>7.660687446594238</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006833587005895" lon="-84.20643069951">
+				<ele>942.9862876664847</ele>
+				<time>2017-11-06T18:53:54Z</time>
+				<extensions>
+					<speed>7.481717109680176</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006775721282342" lon="-84.20638938741295">
+				<ele>943.0830589793622</ele>
+				<time>2017-11-06T18:53:55Z</time>
+				<extensions>
+					<speed>7.704357147216797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006715217533962" lon="-84.20634738879198">
+				<ele>943.0295935841277</ele>
+				<time>2017-11-06T18:53:56Z</time>
+				<extensions>
+					<speed>8.345529556274414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006648113948353" lon="-84.2062986627372">
+				<ele>943.2480670856312</ele>
+				<time>2017-11-06T18:53:57Z</time>
+				<extensions>
+					<speed>8.900300979614258</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006578685746309" lon="-84.2062502005172">
+				<ele>943.6911542108282</ele>
+				<time>2017-11-06T18:53:58Z</time>
+				<extensions>
+					<speed>9.001343727111816</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006508741286169" lon="-84.2062064118823">
+				<ele>943.8412887286395</ele>
+				<time>2017-11-06T18:53:59Z</time>
+				<extensions>
+					<speed>9.109339714050293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006438668715598" lon="-84.20616528590023">
+				<ele>943.8324416307732</ele>
+				<time>2017-11-06T18:54:00Z</time>
+				<extensions>
+					<speed>9.148531913757324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006360766147953" lon="-84.20609986717811">
+				<ele>943.790413511917</ele>
+				<time>2017-11-06T18:54:01Z</time>
+				<extensions>
+					<speed>10.089040756225586</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006287544892285" lon="-84.20603672653006">
+				<ele>943.6955203255638</ele>
+				<time>2017-11-06T18:54:02Z</time>
+				<extensions>
+					<speed>10.519423484802246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006215654753847" lon="-84.20597247273042">
+				<ele>942.8738181246445</ele>
+				<time>2017-11-06T18:54:03Z</time>
+				<extensions>
+					<speed>10.875299453735352</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006145838088758" lon="-84.20590153001388">
+				<ele>942.7759896814823</ele>
+				<time>2017-11-06T18:54:04Z</time>
+				<extensions>
+					<speed>10.683396339416504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006078426539403" lon="-84.20582363052846">
+				<ele>942.4820528365672</ele>
+				<time>2017-11-06T18:54:05Z</time>
+				<extensions>
+					<speed>10.475179672241211</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006020739060133" lon="-84.20575496792722">
+				<ele>941.9888633787632</ele>
+				<time>2017-11-06T18:54:06Z</time>
+				<extensions>
+					<speed>9.88670825958252</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005965876224208" lon="-84.20567993741082">
+				<ele>941.9651272846386</ele>
+				<time>2017-11-06T18:54:07Z</time>
+				<extensions>
+					<speed>9.823257446289063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005919345836944" lon="-84.20561999875115">
+				<ele>941.9131498197094</ele>
+				<time>2017-11-06T18:54:08Z</time>
+				<extensions>
+					<speed>8.96055793762207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005869974494361" lon="-84.20555528039075">
+				<ele>941.9321694280952</ele>
+				<time>2017-11-06T18:54:09Z</time>
+				<extensions>
+					<speed>8.89034366607666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00581550840097" lon="-84.20549072853055">
+				<ele>941.9658987959847</ele>
+				<time>2017-11-06T18:54:10Z</time>
+				<extensions>
+					<speed>8.76396369934082</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005760574606516" lon="-84.20543752063726">
+				<ele>942.024537702091</ele>
+				<time>2017-11-06T18:54:11Z</time>
+				<extensions>
+					<speed>8.658933639526367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005706395244564" lon="-84.20538252206056">
+				<ele>942.047264884226</ele>
+				<time>2017-11-06T18:54:12Z</time>
+				<extensions>
+					<speed>8.681199073791504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005652048203526" lon="-84.20533421369376">
+				<ele>941.7482379358262</ele>
+				<time>2017-11-06T18:54:13Z</time>
+				<extensions>
+					<speed>8.652235984802246</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005597662719168" lon="-84.20528554153879">
+				<ele>941.7474003415555</ele>
+				<time>2017-11-06T18:54:14Z</time>
+				<extensions>
+					<speed>8.580843925476074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0055505367226" lon="-84.20526151069294">
+				<ele>941.610354045406</ele>
+				<time>2017-11-06T18:54:15Z</time>
+				<extensions>
+					<speed>8.249980926513672</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005491889005427" lon="-84.20525544942524">
+				<ele>941.5018469048664</ele>
+				<time>2017-11-06T18:54:16Z</time>
+				<extensions>
+					<speed>8.031516075134277</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005414412751634" lon="-84.20524850788466">
+				<ele>941.5885609146208</ele>
+				<time>2017-11-06T18:54:17Z</time>
+				<extensions>
+					<speed>8.18021297454834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005454593164487" lon="-84.20554125378705">
+				<ele>944.1305150575936</ele>
+				<time>2017-11-06T18:54:18Z</time>
+				<extensions>
+					<speed>6.819449424743652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005408156007718" lon="-84.20564702936852">
+				<ele>944.499898522161</ele>
+				<time>2017-11-06T18:54:19Z</time>
+				<extensions>
+					<speed>7.741221904754639</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005415377098142" lon="-84.20585046956117">
+				<ele>945.5033128093928</ele>
+				<time>2017-11-06T18:54:20Z</time>
+				<extensions>
+					<speed>8.93122386932373</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005391768416983" lon="-84.20599548791144">
+				<ele>946.0190970757976</ele>
+				<time>2017-11-06T18:54:21Z</time>
+				<extensions>
+					<speed>9.595528602600098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005339763544304" lon="-84.20609138257296">
+				<ele>946.2065557288006</ele>
+				<time>2017-11-06T18:54:22Z</time>
+				<extensions>
+					<speed>9.916271209716797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005295287798685" lon="-84.20620926678852">
+				<ele>946.1338201342151</ele>
+				<time>2017-11-06T18:54:23Z</time>
+				<extensions>
+					<speed>10.022873878479004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005241692211563" lon="-84.20630889430093">
+				<ele>946.1415012823418</ele>
+				<time>2017-11-06T18:54:24Z</time>
+				<extensions>
+					<speed>9.92943286895752</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005189186171318" lon="-84.20640402657025">
+				<ele>946.1325913192704</ele>
+				<time>2017-11-06T18:54:25Z</time>
+				<extensions>
+					<speed>9.701993942260742</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005149555419264" lon="-84.20645949024372">
+				<ele>945.8535520071164</ele>
+				<time>2017-11-06T18:54:26Z</time>
+				<extensions>
+					<speed>8.240204811096191</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005109559105652" lon="-84.2065599220445">
+				<ele>944.739584242925</ele>
+				<time>2017-11-06T18:54:27Z</time>
+				<extensions>
+					<speed>7.576322555541992</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005071225707097" lon="-84.20665105219256">
+				<ele>943.9932359708473</ele>
+				<time>2017-11-06T18:54:28Z</time>
+				<extensions>
+					<speed>7.528007984161377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005031668352489" lon="-84.20670549472767">
+				<ele>944.0594920637086</ele>
+				<time>2017-11-06T18:54:29Z</time>
+				<extensions>
+					<speed>7.024119853973389</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004995700540753" lon="-84.20675508774549">
+				<ele>944.1448618555441</ele>
+				<time>2017-11-06T18:54:30Z</time>
+				<extensions>
+					<speed>6.244242191314697</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004959541595959" lon="-84.20679013721444">
+				<ele>943.8365757549182</ele>
+				<time>2017-11-06T18:54:31Z</time>
+				<extensions>
+					<speed>5.403027534484863</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004919391221945" lon="-84.20680435906705">
+				<ele>943.3299790937454</ele>
+				<time>2017-11-06T18:54:32Z</time>
+				<extensions>
+					<speed>4.688910007476807</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004877704380597" lon="-84.20681766053201">
+				<ele>942.8741888608783</ele>
+				<time>2017-11-06T18:54:33Z</time>
+				<extensions>
+					<speed>4.228653430938721</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004832366645733" lon="-84.20682430514077">
+				<ele>942.323029011488</ele>
+				<time>2017-11-06T18:54:34Z</time>
+				<extensions>
+					<speed>3.95654296875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004788230850853" lon="-84.20682436848136">
+				<ele>941.9211219605058</ele>
+				<time>2017-11-06T18:54:35Z</time>
+				<extensions>
+					<speed>3.6215975284576416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004747789063186" lon="-84.20681026072958">
+				<ele>941.5544001525268</ele>
+				<time>2017-11-06T18:54:36Z</time>
+				<extensions>
+					<speed>3.599104404449463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004710604260445" lon="-84.20678793882075">
+				<ele>941.2452037334442</ele>
+				<time>2017-11-06T18:54:37Z</time>
+				<extensions>
+					<speed>3.675032615661621</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00468090450734" lon="-84.20672421280315">
+				<ele>940.4535921867937</ele>
+				<time>2017-11-06T18:54:38Z</time>
+				<extensions>
+					<speed>3.856502056121826</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004641885309269" lon="-84.20665252850172">
+				<ele>939.785706945695</ele>
+				<time>2017-11-06T18:54:39Z</time>
+				<extensions>
+					<speed>4.718730449676514</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004600948428163" lon="-84.20658682376138">
+				<ele>939.2080537667498</ele>
+				<time>2017-11-06T18:54:40Z</time>
+				<extensions>
+					<speed>5.469749450683594</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00454942102695" lon="-84.20652254963822">
+				<ele>938.9578301981091</ele>
+				<time>2017-11-06T18:54:41Z</time>
+				<extensions>
+					<speed>6.124171257019043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004496700395254" lon="-84.20645253350484">
+				<ele>938.4242369458079</ele>
+				<time>2017-11-06T18:54:42Z</time>
+				<extensions>
+					<speed>6.44174337387085</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004447008900492" lon="-84.20638015116818">
+				<ele>938.5473595615476</ele>
+				<time>2017-11-06T18:54:43Z</time>
+				<extensions>
+					<speed>6.686122894287109</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004398580305338" lon="-84.20630459299842">
+				<ele>939.4288820959628</ele>
+				<time>2017-11-06T18:54:44Z</time>
+				<extensions>
+					<speed>6.48207426071167</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004356486005838" lon="-84.20625262631819">
+				<ele>939.511738310568</ele>
+				<time>2017-11-06T18:54:45Z</time>
+				<extensions>
+					<speed>5.996862411499023</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004318776881687" lon="-84.20618323451103">
+				<ele>939.2067915536463</ele>
+				<time>2017-11-06T18:54:46Z</time>
+				<extensions>
+					<speed>5.847281455993652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004301605255058" lon="-84.20614156377394">
+				<ele>940.3276720466092</ele>
+				<time>2017-11-06T18:54:47Z</time>
+				<extensions>
+					<speed>5.3804450035095215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004307276319485" lon="-84.20610997064979">
+				<ele>939.568404414691</ele>
+				<time>2017-11-06T18:54:48Z</time>
+				<extensions>
+					<speed>3.577467918395996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004315330616896" lon="-84.20604516008636">
+				<ele>939.2563689369708</ele>
+				<time>2017-11-06T18:54:49Z</time>
+				<extensions>
+					<speed>4.385989665985107</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004345825096724" lon="-84.20602056304206">
+				<ele>939.9093350637704</ele>
+				<time>2017-11-06T18:54:50Z</time>
+				<extensions>
+					<speed>4.735851764678955</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004385427234126" lon="-84.20599827704966">
+				<ele>940.7515362361446</ele>
+				<time>2017-11-06T18:54:51Z</time>
+				<extensions>
+					<speed>5.086490154266357</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004424376874294" lon="-84.20595994086456">
+				<ele>941.8692459026352</ele>
+				<time>2017-11-06T18:54:52Z</time>
+				<extensions>
+					<speed>5.654934883117676</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004464226474752" lon="-84.20592498619185">
+				<ele>942.6838711369783</ele>
+				<time>2017-11-06T18:54:53Z</time>
+				<extensions>
+					<speed>5.576528549194336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004502902168644" lon="-84.20589378177813">
+				<ele>943.2405137661844</ele>
+				<time>2017-11-06T18:54:54Z</time>
+				<extensions>
+					<speed>5.571454048156738</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004544589123565" lon="-84.20586747269562">
+				<ele>944.1528430003673</ele>
+				<time>2017-11-06T18:54:55Z</time>
+				<extensions>
+					<speed>5.539915561676025</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004586612761386" lon="-84.20584321917131">
+				<ele>944.4691720781848</ele>
+				<time>2017-11-06T18:54:56Z</time>
+				<extensions>
+					<speed>5.4721503257751465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004630249817062" lon="-84.2058199819408">
+				<ele>944.3576090624556</ele>
+				<time>2017-11-06T18:54:57Z</time>
+				<extensions>
+					<speed>5.8730010986328125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004676221301283" lon="-84.20579489106989">
+				<ele>944.8404940115288</ele>
+				<time>2017-11-06T18:54:58Z</time>
+				<extensions>
+					<speed>6.456455707550049</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004723485007156" lon="-84.20576012998079">
+				<ele>945.4003905449063</ele>
+				<time>2017-11-06T18:54:59Z</time>
+				<extensions>
+					<speed>6.714140892028809</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004772365614315" lon="-84.20572321515844">
+				<ele>946.3023216165602</ele>
+				<time>2017-11-06T18:55:00Z</time>
+				<extensions>
+					<speed>6.760717868804932</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004818228392546" lon="-84.20568386036031">
+				<ele>946.7926529981196</ele>
+				<time>2017-11-06T18:55:01Z</time>
+				<extensions>
+					<speed>6.574569225311279</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004858065977043" lon="-84.20563450572851">
+				<ele>947.032704943791</ele>
+				<time>2017-11-06T18:55:02Z</time>
+				<extensions>
+					<speed>6.573111534118652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004897455291784" lon="-84.20559281517848">
+				<ele>948.2898915996775</ele>
+				<time>2017-11-06T18:55:03Z</time>
+				<extensions>
+					<speed>6.52384090423584</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004939830769386" lon="-84.20556082503202">
+				<ele>948.6117345308885</ele>
+				<time>2017-11-06T18:55:04Z</time>
+				<extensions>
+					<speed>6.415064811706543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.004980451914362" lon="-84.20553085605295">
+				<ele>948.6576978489757</ele>
+				<time>2017-11-06T18:55:05Z</time>
+				<extensions>
+					<speed>6.3722310066223145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005026278257361" lon="-84.20552325253271">
+				<ele>947.4122302038595</ele>
+				<time>2017-11-06T18:55:06Z</time>
+				<extensions>
+					<speed>6.0802998542785645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005052284750759" lon="-84.20547905018947">
+				<ele>948.1047949995846</ele>
+				<time>2017-11-06T18:55:07Z</time>
+				<extensions>
+					<speed>5.557258129119873</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005068128162465" lon="-84.20543518715981">
+				<ele>949.5541078066453</ele>
+				<time>2017-11-06T18:55:08Z</time>
+				<extensions>
+					<speed>4.610358238220215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005081903117135" lon="-84.20539776047347">
+				<ele>952.5390403578058</ele>
+				<time>2017-11-06T18:55:09Z</time>
+				<extensions>
+					<speed>3.250997543334961</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005092950292477" lon="-84.20535933532538">
+				<ele>954.3088297732174</ele>
+				<time>2017-11-06T18:55:10Z</time>
+				<extensions>
+					<speed>2.1969828605651855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005098041252417" lon="-84.20534686207549">
+				<ele>954.9812690503895</ele>
+				<time>2017-11-06T18:55:11Z</time>
+				<extensions>
+					<speed>0.7347666025161743</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005096290965907" lon="-84.20534970338065">
+				<ele>955.495391801931</ele>
+				<time>2017-11-06T18:55:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005096290965907" lon="-84.20534970338065">
+				<ele>955.495391801931</ele>
+				<time>2017-11-06T18:55:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005090159229544" lon="-84.20535289335827">
+				<ele>955.7743825158104</ele>
+				<time>2017-11-06T18:55:14Z</time>
+				<extensions>
+					<speed>0.7885358333587646</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005090159229544" lon="-84.20535289335827">
+				<ele>955.7743825158104</ele>
+				<time>2017-11-06T18:55:15Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00508733233315" lon="-84.20535542017905">
+				<ele>956.0266906488687</ele>
+				<time>2017-11-06T18:55:16Z</time>
+				<extensions>
+					<speed>0.6718052625656128</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00508733233315" lon="-84.20535542017905">
+				<ele>956.0266906488687</ele>
+				<time>2017-11-06T18:55:17Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005081685831446" lon="-84.20535598395195">
+				<ele>956.2567049916834</ele>
+				<time>2017-11-06T18:55:18Z</time>
+				<extensions>
+					<speed>0.5437592267990112</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005081685831446" lon="-84.20535598395195">
+				<ele>956.2567049916834</ele>
+				<time>2017-11-06T18:55:19Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005077141706824" lon="-84.20535169655497">
+				<ele>956.1889518424869</ele>
+				<time>2017-11-06T18:55:20Z</time>
+				<extensions>
+					<speed>0.11654012650251389</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005077141706824" lon="-84.20535169655497">
+				<ele>956.1889518424869</ele>
+				<time>2017-11-06T18:55:21Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005077141706824" lon="-84.20535169655497">
+				<ele>956.1889518424869</ele>
+				<time>2017-11-06T18:55:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005077141706824" lon="-84.20535169655497">
+				<ele>956.1889518424869</ele>
+				<time>2017-11-06T18:55:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005077141706824" lon="-84.20535169655497">
+				<ele>956.1889518424869</ele>
+				<time>2017-11-06T18:55:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005077141706824" lon="-84.20535169655497">
+				<ele>956.1889518424869</ele>
+				<time>2017-11-06T18:55:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005082514811859" lon="-84.20533290263207">
+				<ele>955.8434447245672</ele>
+				<time>2017-11-06T18:55:26Z</time>
+				<extensions>
+					<speed>1.6639143228530884</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005102691358406" lon="-84.20531241974322">
+				<ele>954.9580189399421</ele>
+				<time>2017-11-06T18:55:27Z</time>
+				<extensions>
+					<speed>2.731647253036499</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005130796201492" lon="-84.20529180995129">
+				<ele>954.0846626227722</ele>
+				<time>2017-11-06T18:55:28Z</time>
+				<extensions>
+					<speed>3.8134102821350098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00516513566725" lon="-84.20526759425745">
+				<ele>952.8060356229544</ele>
+				<time>2017-11-06T18:55:29Z</time>
+				<extensions>
+					<speed>4.506770610809326</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00519767490932" lon="-84.20523834308507">
+				<ele>952.2080965777859</ele>
+				<time>2017-11-06T18:55:30Z</time>
+				<extensions>
+					<speed>4.533318996429443</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005224877941128" lon="-84.20521232374458">
+				<ele>951.7238422660157</ele>
+				<time>2017-11-06T18:55:31Z</time>
+				<extensions>
+					<speed>3.7680509090423584</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005245294432328" lon="-84.20519125186846">
+				<ele>950.3710238309577</ele>
+				<time>2017-11-06T18:55:32Z</time>
+				<extensions>
+					<speed>2.7171125411987305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005259607509654" lon="-84.20517362238614">
+				<ele>949.5576019603759</ele>
+				<time>2017-11-06T18:55:33Z</time>
+				<extensions>
+					<speed>1.6128497123718262</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005268676064222" lon="-84.20516156113148">
+				<ele>948.6567091504112</ele>
+				<time>2017-11-06T18:55:34Z</time>
+				<extensions>
+					<speed>0.9857498407363892</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005275058744" lon="-84.20515748151062">
+				<ele>947.996744886972</ele>
+				<time>2017-11-06T18:55:35Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005275058744" lon="-84.20515748151062">
+				<ele>947.996744886972</ele>
+				<time>2017-11-06T18:55:36Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005275058744" lon="-84.20515748151062">
+				<ele>947.996744886972</ele>
+				<time>2017-11-06T18:55:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005275058744" lon="-84.20515748151062">
+				<ele>947.996744886972</ele>
+				<time>2017-11-06T18:55:38Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005275058744" lon="-84.20515748151062">
+				<ele>947.996744886972</ele>
+				<time>2017-11-06T18:55:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005275058744" lon="-84.20515748151062">
+				<ele>947.996744886972</ele>
+				<time>2017-11-06T18:55:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005275058744" lon="-84.20515748151062">
+				<ele>947.996744886972</ele>
+				<time>2017-11-06T18:55:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005275058744" lon="-84.20515748151062">
+				<ele>947.996744886972</ele>
+				<time>2017-11-06T18:55:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005285808447747" lon="-84.2051515111467">
+				<ele>948.5493284435943</ele>
+				<time>2017-11-06T18:55:43Z</time>
+				<extensions>
+					<speed>0.9118693470954895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005299245616419" lon="-84.20513541923475">
+				<ele>949.2843188205734</ele>
+				<time>2017-11-06T18:55:44Z</time>
+				<extensions>
+					<speed>1.8257352113723755</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005312518988193" lon="-84.20512176686515">
+				<ele>949.9628832740709</ele>
+				<time>2017-11-06T18:55:45Z</time>
+				<extensions>
+					<speed>1.6941405534744263</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00532470556014" lon="-84.20510699201209">
+				<ele>950.4640916874632</ele>
+				<time>2017-11-06T18:55:46Z</time>
+				<extensions>
+					<speed>1.9614760875701904</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005334951056707" lon="-84.20510975288761">
+				<ele>946.161077927798</ele>
+				<time>2017-11-06T18:55:47Z</time>
+				<extensions>
+					<speed>1.7766646146774292</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005347963877606" lon="-84.20511391512613">
+				<ele>945.3743297737092</ele>
+				<time>2017-11-06T18:55:48Z</time>
+				<extensions>
+					<speed>1.3453445434570313</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00535993331965" lon="-84.2051137763291">
+				<ele>944.7367215845734</ele>
+				<time>2017-11-06T18:55:49Z</time>
+				<extensions>
+					<speed>1.313913106918335</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005365766131684" lon="-84.20510984359387">
+				<ele>942.4397423556075</ele>
+				<time>2017-11-06T18:55:50Z</time>
+				<extensions>
+					<speed>0.2217554748058319</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005365766131684" lon="-84.20510984359387">
+				<ele>942.4397423556075</ele>
+				<time>2017-11-06T18:55:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005375574214941" lon="-84.20510449175762">
+				<ele>940.4292738409713</ele>
+				<time>2017-11-06T18:55:52Z</time>
+				<extensions>
+					<speed>1.0635062456130981</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005391414494804" lon="-84.20509201481777">
+				<ele>941.3850251920521</ele>
+				<time>2017-11-06T18:55:53Z</time>
+				<extensions>
+					<speed>3.104259967803955</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005412400618553" lon="-84.20507493828252">
+				<ele>942.1080022025853</ele>
+				<time>2017-11-06T18:55:54Z</time>
+				<extensions>
+					<speed>3.6145293712615967</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005435123053942" lon="-84.20505147074141">
+				<ele>942.8518567075953</ele>
+				<time>2017-11-06T18:55:55Z</time>
+				<extensions>
+					<speed>3.213320732116699</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005455552555713" lon="-84.2050285876697">
+				<ele>942.8231848031282</ele>
+				<time>2017-11-06T18:55:56Z</time>
+				<extensions>
+					<speed>2.526695489883423</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005472051547626" lon="-84.20501108820346">
+				<ele>942.9717381112278</ele>
+				<time>2017-11-06T18:55:57Z</time>
+				<extensions>
+					<speed>2.17598295211792</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005487136862266" lon="-84.20499454105135">
+				<ele>943.2116280132905</ele>
+				<time>2017-11-06T18:55:58Z</time>
+				<extensions>
+					<speed>2.2227165699005127</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005504624323681" lon="-84.20497485583702">
+				<ele>943.1223834026605</ele>
+				<time>2017-11-06T18:55:59Z</time>
+				<extensions>
+					<speed>2.978529691696167</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005525352948823" lon="-84.20494862839472">
+				<ele>943.3514751708135</ele>
+				<time>2017-11-06T18:56:00Z</time>
+				<extensions>
+					<speed>3.8889827728271484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005547549248691" lon="-84.20492129873399">
+				<ele>943.5839000437409</ele>
+				<time>2017-11-06T18:56:01Z</time>
+				<extensions>
+					<speed>3.5419485569000244</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005572899886818" lon="-84.20488819111809">
+				<ele>943.9638173347339</ele>
+				<time>2017-11-06T18:56:02Z</time>
+				<extensions>
+					<speed>4.565652370452881</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005600206734163" lon="-84.2048535540238">
+				<ele>944.2843065857887</ele>
+				<time>2017-11-06T18:56:03Z</time>
+				<extensions>
+					<speed>4.592787265777588</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005629210734812" lon="-84.20481578612397">
+				<ele>944.867566101253</ele>
+				<time>2017-11-06T18:56:04Z</time>
+				<extensions>
+					<speed>4.902097702026367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005658066312971" lon="-84.20477548649114">
+				<ele>945.2297483189031</ele>
+				<time>2017-11-06T18:56:05Z</time>
+				<extensions>
+					<speed>4.88174295425415</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005690670147231" lon="-84.20473437613477">
+				<ele>945.1746183251962</ele>
+				<time>2017-11-06T18:56:06Z</time>
+				<extensions>
+					<speed>5.482908725738525</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005723802086958" lon="-84.2046954459736">
+				<ele>945.3054742282256</ele>
+				<time>2017-11-06T18:56:07Z</time>
+				<extensions>
+					<speed>5.003547191619873</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005759883070324" lon="-84.20466035662245">
+				<ele>945.7901513529941</ele>
+				<time>2017-11-06T18:56:08Z</time>
+				<extensions>
+					<speed>5.140713214874268</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005793785696286" lon="-84.20462038230518">
+				<ele>945.8992941956967</ele>
+				<time>2017-11-06T18:56:09Z</time>
+				<extensions>
+					<speed>5.551154136657715</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005826590719" lon="-84.20457382826571">
+				<ele>946.1470376616344</ele>
+				<time>2017-11-06T18:56:10Z</time>
+				<extensions>
+					<speed>5.6259284019470215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005858430374698" lon="-84.20452546834427">
+				<ele>946.4929758673534</ele>
+				<time>2017-11-06T18:56:11Z</time>
+				<extensions>
+					<speed>6.012181282043457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00589097202894" lon="-84.20448022779674">
+				<ele>946.880853144452</ele>
+				<time>2017-11-06T18:56:12Z</time>
+				<extensions>
+					<speed>5.587703704833984</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005920786208781" lon="-84.20443956078022">
+				<ele>947.1537471404299</ele>
+				<time>2017-11-06T18:56:13Z</time>
+				<extensions>
+					<speed>5.0930585861206055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005942743805976" lon="-84.20440865884673">
+				<ele>947.4040490593761</ele>
+				<time>2017-11-06T18:56:14Z</time>
+				<extensions>
+					<speed>3.3740696907043457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005955522963552" lon="-84.20438709611165">
+				<ele>947.5534607348964</ele>
+				<time>2017-11-06T18:56:15Z</time>
+				<extensions>
+					<speed>1.5411548614501953</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005960338513166" lon="-84.20438010670206">
+				<ele>947.5654821628705</ele>
+				<time>2017-11-06T18:56:16Z</time>
+				<extensions>
+					<speed>0.24276524782180786</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005958398530353" lon="-84.20438085732368">
+				<ele>947.6725585283712</ele>
+				<time>2017-11-06T18:56:17Z</time>
+				<extensions>
+					<speed>0.8707219958305359</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005958398530353" lon="-84.20438085732368">
+				<ele>947.6725585283712</ele>
+				<time>2017-11-06T18:56:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005959092238038" lon="-84.2043810922485">
+				<ele>947.7134484834969</ele>
+				<time>2017-11-06T18:56:19Z</time>
+				<extensions>
+					<speed>0.7601491808891296</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005959092238038" lon="-84.2043810922485">
+				<ele>947.7134484834969</ele>
+				<time>2017-11-06T18:56:20Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005961622643577" lon="-84.20437795581144">
+				<ele>947.5866457903758</ele>
+				<time>2017-11-06T18:56:21Z</time>
+				<extensions>
+					<speed>0.5235424041748047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005961622643577" lon="-84.20437795581144">
+				<ele>947.5866457903758</ele>
+				<time>2017-11-06T18:56:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005965132178957" lon="-84.20437119406331">
+				<ele>947.4606100004166</ele>
+				<time>2017-11-06T18:56:23Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005965132178957" lon="-84.20437119406331">
+				<ele>947.4606100004166</ele>
+				<time>2017-11-06T18:56:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005965132178957" lon="-84.20437119406331">
+				<ele>947.4606100004166</ele>
+				<time>2017-11-06T18:56:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005965132178957" lon="-84.20437119406331">
+				<ele>947.4606100004166</ele>
+				<time>2017-11-06T18:56:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005965132178957" lon="-84.20437119406331">
+				<ele>947.4606100004166</ele>
+				<time>2017-11-06T18:56:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005965132178957" lon="-84.20437119406331">
+				<ele>947.4606100004166</ele>
+				<time>2017-11-06T18:56:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005965132178957" lon="-84.20437119406331">
+				<ele>947.4606100004166</ele>
+				<time>2017-11-06T18:56:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005965132178957" lon="-84.20437119406331">
+				<ele>947.4606100004166</ele>
+				<time>2017-11-06T18:56:30Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005977130503389" lon="-84.2043599925243">
+				<ele>946.8512305887416</ele>
+				<time>2017-11-06T18:56:31Z</time>
+				<extensions>
+					<speed>1.8188813924789429</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.005998345333643" lon="-84.20434322033039">
+				<ele>946.8521780138835</ele>
+				<time>2017-11-06T18:56:32Z</time>
+				<extensions>
+					<speed>3.0814321041107178</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006024948226475" lon="-84.20431736884221">
+				<ele>947.1215523360297</ele>
+				<time>2017-11-06T18:56:33Z</time>
+				<extensions>
+					<speed>4.03431510925293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006053817222165" lon="-84.20428763419055">
+				<ele>947.4473444689065</ele>
+				<time>2017-11-06T18:56:34Z</time>
+				<extensions>
+					<speed>4.262886047363281</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006085951897125" lon="-84.20425510149555">
+				<ele>947.5567112965509</ele>
+				<time>2017-11-06T18:56:35Z</time>
+				<extensions>
+					<speed>4.729382514953613</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006119168810654" lon="-84.20422208231658">
+				<ele>947.7737510763109</ele>
+				<time>2017-11-06T18:56:36Z</time>
+				<extensions>
+					<speed>4.893656253814697</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006153592569047" lon="-84.20418949044853">
+				<ele>948.3994436943904</ele>
+				<time>2017-11-06T18:56:37Z</time>
+				<extensions>
+					<speed>5.051037788391113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006187871331411" lon="-84.20415799920548">
+				<ele>949.1970315901563</ele>
+				<time>2017-11-06T18:56:38Z</time>
+				<extensions>
+					<speed>4.953315734863281</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006217211191302" lon="-84.2041321828512">
+				<ele>949.6689092265442</ele>
+				<time>2017-11-06T18:56:39Z</time>
+				<extensions>
+					<speed>3.8821818828582764</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006238773116742" lon="-84.20411363425242">
+				<ele>949.8136790106073</ele>
+				<time>2017-11-06T18:56:40Z</time>
+				<extensions>
+					<speed>2.503295660018921</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006253888994484" lon="-84.20410339193795">
+				<ele>949.9671591790393</ele>
+				<time>2017-11-06T18:56:41Z</time>
+				<extensions>
+					<speed>1.629332184791565</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00626953422114" lon="-84.204087793954">
+				<ele>949.4124831398949</ele>
+				<time>2017-11-06T18:56:42Z</time>
+				<extensions>
+					<speed>2.686797618865967</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006288321484954" lon="-84.20407450728096">
+				<ele>949.1505740731955</ele>
+				<time>2017-11-06T18:56:43Z</time>
+				<extensions>
+					<speed>2.1129696369171143</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006314922741435" lon="-84.20406687908029">
+				<ele>948.6085519781336</ele>
+				<time>2017-11-06T18:56:44Z</time>
+				<extensions>
+					<speed>3.424839973449707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006354086256376" lon="-84.20407057515072">
+				<ele>948.3204881362617</ele>
+				<time>2017-11-06T18:56:45Z</time>
+				<extensions>
+					<speed>4.597446918487549</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006400866860373" lon="-84.20408637799736">
+				<ele>948.4568665400147</ele>
+				<time>2017-11-06T18:56:46Z</time>
+				<extensions>
+					<speed>5.496761322021484</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006449564106264" lon="-84.2041139687227">
+				<ele>948.4529714491218</ele>
+				<time>2017-11-06T18:56:47Z</time>
+				<extensions>
+					<speed>6.556131362915039</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006501328899148" lon="-84.20414786436724">
+				<ele>948.1094516096637</ele>
+				<time>2017-11-06T18:56:48Z</time>
+				<extensions>
+					<speed>7.004815101623535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006550988137464" lon="-84.20418389167389">
+				<ele>947.950715999119</ele>
+				<time>2017-11-06T18:56:49Z</time>
+				<extensions>
+					<speed>6.305222511291504</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006587924416614" lon="-84.20421587395222">
+				<ele>947.8928878167644</ele>
+				<time>2017-11-06T18:56:50Z</time>
+				<extensions>
+					<speed>4.776209831237793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006613522811056" lon="-84.20424033560445">
+				<ele>947.8755851313472</ele>
+				<time>2017-11-06T18:56:51Z</time>
+				<extensions>
+					<speed>3.247713565826416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006625542854932" lon="-84.20425259523947">
+				<ele>947.6471698610112</ele>
+				<time>2017-11-06T18:56:52Z</time>
+				<extensions>
+					<speed>1.1764224767684937</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006625179803716" lon="-84.20425196395699">
+				<ele>947.4767510015517</ele>
+				<time>2017-11-06T18:56:53Z</time>
+				<extensions>
+					<speed>0.563359797000885</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006621337259407" lon="-84.20424318941727">
+				<ele>948.2756203003228</ele>
+				<time>2017-11-06T18:56:54Z</time>
+				<extensions>
+					<speed>1.4504815340042114</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006619051928398" lon="-84.20423835583047">
+				<ele>950.9678109372035</ele>
+				<time>2017-11-06T18:56:55Z</time>
+				<extensions>
+					<speed>1.0219056606292725</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00660332909569" lon="-84.20423398193118">
+				<ele>950.5630134381354</ele>
+				<time>2017-11-06T18:56:56Z</time>
+				<extensions>
+					<speed>1.116562008857727</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006592081915818" lon="-84.2042315569758">
+				<ele>950.1852772952989</ele>
+				<time>2017-11-06T18:56:57Z</time>
+				<extensions>
+					<speed>0.5646498799324036</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006592081915818" lon="-84.2042315569758">
+				<ele>950.1852772952989</ele>
+				<time>2017-11-06T18:56:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006590515111386" lon="-84.20423066073276">
+				<ele>950.2153089735657</ele>
+				<time>2017-11-06T18:56:59Z</time>
+				<extensions>
+					<speed>0.011772566474974155</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006590515111386" lon="-84.20423066073276">
+				<ele>950.2153089735657</ele>
+				<time>2017-11-06T18:57:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006594311408284" lon="-84.20423742941873">
+				<ele>950.7165319435298</ele>
+				<time>2017-11-06T18:57:01Z</time>
+				<extensions>
+					<speed>0.6012250185012817</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006605673492334" lon="-84.20424957306211">
+				<ele>951.3591079227626</ele>
+				<time>2017-11-06T18:57:02Z</time>
+				<extensions>
+					<speed>2.2064049243927</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006627696619056" lon="-84.20426525346016">
+				<ele>951.42492916435</ele>
+				<time>2017-11-06T18:57:03Z</time>
+				<extensions>
+					<speed>3.3146286010742188</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006657973940134" lon="-84.20428561298569">
+				<ele>951.5220613190904</ele>
+				<time>2017-11-06T18:57:04Z</time>
+				<extensions>
+					<speed>3.989719867706299</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006691240069214" lon="-84.20430822681963">
+				<ele>951.7694959668443</ele>
+				<time>2017-11-06T18:57:05Z</time>
+				<extensions>
+					<speed>4.186351299285889</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006722408987024" lon="-84.20433057414444">
+				<ele>952.0907377470285</ele>
+				<time>2017-11-06T18:57:06Z</time>
+				<extensions>
+					<speed>4.020151138305664</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006751839865675" lon="-84.2043541753718">
+				<ele>952.3260778961703</ele>
+				<time>2017-11-06T18:57:07Z</time>
+				<extensions>
+					<speed>3.9233574867248535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006779466967382" lon="-84.20437690092407">
+				<ele>952.5027562556788</ele>
+				<time>2017-11-06T18:57:08Z</time>
+				<extensions>
+					<speed>4.005496978759766</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006806920261198" lon="-84.2043981265595">
+				<ele>952.6896543316543</ele>
+				<time>2017-11-06T18:57:09Z</time>
+				<extensions>
+					<speed>4.103968620300293</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006839260948738" lon="-84.20442630664273">
+				<ele>953.3857922200114</ele>
+				<time>2017-11-06T18:57:10Z</time>
+				<extensions>
+					<speed>4.708664417266846</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006874079108316" lon="-84.2044519542122">
+				<ele>953.4187223436311</ele>
+				<time>2017-11-06T18:57:11Z</time>
+				<extensions>
+					<speed>5.053805828094482</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006915335138979" lon="-84.20448617565823">
+				<ele>953.3645260855556</ele>
+				<time>2017-11-06T18:57:12Z</time>
+				<extensions>
+					<speed>5.611513137817383</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.006962187084397" lon="-84.20452255724607">
+				<ele>953.2520627956837</ele>
+				<time>2017-11-06T18:57:13Z</time>
+				<extensions>
+					<speed>6.64589786529541</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007007407442066" lon="-84.20455786549998">
+				<ele>953.1070992546156</ele>
+				<time>2017-11-06T18:57:14Z</time>
+				<extensions>
+					<speed>6.701014041900635</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007049680741819" lon="-84.20458183567399">
+				<ele>952.8098951084539</ele>
+				<time>2017-11-06T18:57:15Z</time>
+				<extensions>
+					<speed>5.742775917053223</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00708832744035" lon="-84.20461097454731">
+				<ele>952.532832489349</ele>
+				<time>2017-11-06T18:57:16Z</time>
+				<extensions>
+					<speed>5.068521499633789</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007124552090962" lon="-84.20464059357172">
+				<ele>952.1793354768306</ele>
+				<time>2017-11-06T18:57:17Z</time>
+				<extensions>
+					<speed>4.902552127838135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007159656792595" lon="-84.20466564604843">
+				<ele>951.3726037358865</ele>
+				<time>2017-11-06T18:57:18Z</time>
+				<extensions>
+					<speed>4.16442346572876</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007193650913248" lon="-84.20467794813233">
+				<ele>950.5377164920792</ele>
+				<time>2017-11-06T18:57:19Z</time>
+				<extensions>
+					<speed>2.6281914710998535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007212499843979" lon="-84.20467872266606">
+				<ele>950.4654695512727</ele>
+				<time>2017-11-06T18:57:20Z</time>
+				<extensions>
+					<speed>1.2311840057373047</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007216859088395" lon="-84.20466910641665">
+				<ele>950.6602017208934</ele>
+				<time>2017-11-06T18:57:21Z</time>
+				<extensions>
+					<speed>0.37015455961227417</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007216859088395" lon="-84.20466910641665">
+				<ele>950.6602017208934</ele>
+				<time>2017-11-06T18:57:22Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007212427305893" lon="-84.20465429554001">
+				<ele>950.861415117979</ele>
+				<time>2017-11-06T18:57:23Z</time>
+				<extensions>
+					<speed>1.0583314895629883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007210207167823" lon="-84.2046460996264">
+				<ele>950.6896727113053</ele>
+				<time>2017-11-06T18:57:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007210207167823" lon="-84.2046460996264">
+				<ele>950.6896727113053</ele>
+				<time>2017-11-06T18:57:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007210207167823" lon="-84.2046460996264">
+				<ele>950.6896727113053</ele>
+				<time>2017-11-06T18:57:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007210207167823" lon="-84.2046460996264">
+				<ele>950.6896727113053</ele>
+				<time>2017-11-06T18:57:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007210207167823" lon="-84.2046460996264">
+				<ele>950.6896727113053</ele>
+				<time>2017-11-06T18:57:28Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007210207167823" lon="-84.2046460996264">
+				<ele>950.6896727113053</ele>
+				<time>2017-11-06T18:57:29Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00721166680989" lon="-84.20463614692032">
+				<ele>948.9870715588331</ele>
+				<time>2017-11-06T18:57:30Z</time>
+				<extensions>
+					<speed>0.883605420589447</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00721920874298" lon="-84.20462296434307">
+				<ele>947.8547750487924</ele>
+				<time>2017-11-06T18:57:31Z</time>
+				<extensions>
+					<speed>1.6698814630508423</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007233036677869" lon="-84.20460913084683">
+				<ele>946.936784545891</ele>
+				<time>2017-11-06T18:57:32Z</time>
+				<extensions>
+					<speed>2.2862436771392822</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007257910934378" lon="-84.20459635658766">
+				<ele>947.3437091615051</ele>
+				<time>2017-11-06T18:57:33Z</time>
+				<extensions>
+					<speed>3.4128711223602295</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007288807478693" lon="-84.20457813447113">
+				<ele>947.6374492794275</ele>
+				<time>2017-11-06T18:57:34Z</time>
+				<extensions>
+					<speed>3.97768497467041</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007321489431229" lon="-84.20455613205158">
+				<ele>947.91202528961</ele>
+				<time>2017-11-06T18:57:35Z</time>
+				<extensions>
+					<speed>4.281379222869873</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007348395325007" lon="-84.20453344854761">
+				<ele>948.1193582005799</ele>
+				<time>2017-11-06T18:57:36Z</time>
+				<extensions>
+					<speed>3.4500300884246826</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007366797423293" lon="-84.2045162256744">
+				<ele>948.0140994833782</ele>
+				<time>2017-11-06T18:57:37Z</time>
+				<extensions>
+					<speed>2.2595107555389404</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007378236401381" lon="-84.20450720777387">
+				<ele>948.0100590568036</ele>
+				<time>2017-11-06T18:57:38Z</time>
+				<extensions>
+					<speed>0.7910776734352112</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007381831713811" lon="-84.20450427960951">
+				<ele>947.6863559065387</ele>
+				<time>2017-11-06T18:57:39Z</time>
+				<extensions>
+					<speed>0.17540249228477478</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007381831713811" lon="-84.20450427960951">
+				<ele>947.6863559065387</ele>
+				<time>2017-11-06T18:57:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007381831713811" lon="-84.20450427960951">
+				<ele>947.6863559065387</ele>
+				<time>2017-11-06T18:57:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007381831713811" lon="-84.20450427960951">
+				<ele>947.6863559065387</ele>
+				<time>2017-11-06T18:57:42Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007387805950469" lon="-84.20450002950346">
+				<ele>947.3225156767294</ele>
+				<time>2017-11-06T18:57:43Z</time>
+				<extensions>
+					<speed>0.7847065329551697</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007401090445239" lon="-84.20449187069342">
+				<ele>946.924750989303</ele>
+				<time>2017-11-06T18:57:44Z</time>
+				<extensions>
+					<speed>2.1306662559509277</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007423444263202" lon="-84.20447708185226">
+				<ele>946.6096712751314</ele>
+				<time>2017-11-06T18:57:45Z</time>
+				<extensions>
+					<speed>3.449594736099243</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007457632390528" lon="-84.20445285372928">
+				<ele>946.363558520563</ele>
+				<time>2017-11-06T18:57:46Z</time>
+				<extensions>
+					<speed>5.346343994140625</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007500664878169" lon="-84.20441486664153">
+				<ele>946.116116440855</ele>
+				<time>2017-11-06T18:57:47Z</time>
+				<extensions>
+					<speed>6.796217441558838</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007548040404801" lon="-84.20437099794144">
+				<ele>946.3017213540152</ele>
+				<time>2017-11-06T18:57:48Z</time>
+				<extensions>
+					<speed>7.064550399780273</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007597236895135" lon="-84.2043270783537">
+				<ele>946.4832744691521</ele>
+				<time>2017-11-06T18:57:49Z</time>
+				<extensions>
+					<speed>7.48107385635376</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007650456966045" lon="-84.20427653067668">
+				<ele>947.1624966571108</ele>
+				<time>2017-11-06T18:57:50Z</time>
+				<extensions>
+					<speed>8.314611434936523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007705549569792" lon="-84.2042227388138">
+				<ele>947.3167457953095</ele>
+				<time>2017-11-06T18:57:51Z</time>
+				<extensions>
+					<speed>8.369479179382324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007759618334399" lon="-84.20417028139033">
+				<ele>947.2554993648082</ele>
+				<time>2017-11-06T18:57:52Z</time>
+				<extensions>
+					<speed>8.326813697814941</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007811980954633" lon="-84.20411962667845">
+				<ele>946.8705026321113</ele>
+				<time>2017-11-06T18:57:53Z</time>
+				<extensions>
+					<speed>8.019631385803223</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007858811799444" lon="-84.20407193874202">
+				<ele>946.2460388476029</ele>
+				<time>2017-11-06T18:57:54Z</time>
+				<extensions>
+					<speed>7.6054368019104</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007904183293302" lon="-84.20402779124854">
+				<ele>945.4441501628608</ele>
+				<time>2017-11-06T18:57:55Z</time>
+				<extensions>
+					<speed>7.027360916137695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007946324475983" lon="-84.20398822866798">
+				<ele>944.6456438982859</ele>
+				<time>2017-11-06T18:57:56Z</time>
+				<extensions>
+					<speed>7.047336578369141</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.007989846076477" lon="-84.20394846445548">
+				<ele>944.6218343228102</ele>
+				<time>2017-11-06T18:57:57Z</time>
+				<extensions>
+					<speed>6.798020362854004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008037761864603" lon="-84.2039087767717">
+				<ele>944.7120683621615</ele>
+				<time>2017-11-06T18:57:58Z</time>
+				<extensions>
+					<speed>6.919397830963135</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008085588340197" lon="-84.20387113390973">
+				<ele>944.8654701244086</ele>
+				<time>2017-11-06T18:57:59Z</time>
+				<extensions>
+					<speed>6.549849033355713</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008136963195708" lon="-84.20383486802154">
+				<ele>945.0644614091143</ele>
+				<time>2017-11-06T18:58:00Z</time>
+				<extensions>
+					<speed>6.6457133293151855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00818770994237" lon="-84.20379468871677">
+				<ele>945.0048266164958</ele>
+				<time>2017-11-06T18:58:01Z</time>
+				<extensions>
+					<speed>6.7714643478393555</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008236624597581" lon="-84.20375606824537">
+				<ele>944.9804354878142</ele>
+				<time>2017-11-06T18:58:02Z</time>
+				<extensions>
+					<speed>6.776904106140137</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008292411293757" lon="-84.20370711739173">
+				<ele>945.1788770360872</ele>
+				<time>2017-11-06T18:58:03Z</time>
+				<extensions>
+					<speed>7.10107946395874</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008343826736585" lon="-84.20366321198507">
+				<ele>945.2068023635074</ele>
+				<time>2017-11-06T18:58:04Z</time>
+				<extensions>
+					<speed>6.405088901519775</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008389847269546" lon="-84.20364224124293">
+				<ele>945.3977377489209</ele>
+				<time>2017-11-06T18:58:05Z</time>
+				<extensions>
+					<speed>4.970006465911865</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008418322532869" lon="-84.20361890143334">
+				<ele>946.1398429935798</ele>
+				<time>2017-11-06T18:58:06Z</time>
+				<extensions>
+					<speed>3.2479476928710938</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008433653754102" lon="-84.20360726486577">
+				<ele>946.593179882504</ele>
+				<time>2017-11-06T18:58:07Z</time>
+				<extensions>
+					<speed>1.8658767938613892</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008440453122228" lon="-84.20360693218245">
+				<ele>947.0884757582098</ele>
+				<time>2017-11-06T18:58:08Z</time>
+				<extensions>
+					<speed>0.8222500085830688</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00844508118797" lon="-84.20360898551458">
+				<ele>947.4113163473085</ele>
+				<time>2017-11-06T18:58:09Z</time>
+				<extensions>
+					<speed>0.6535609364509583</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00844508118797" lon="-84.20360898551458">
+				<ele>947.4113163473085</ele>
+				<time>2017-11-06T18:58:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008457712060613" lon="-84.20360427658069">
+				<ele>947.6182458978146</ele>
+				<time>2017-11-06T18:58:11Z</time>
+				<extensions>
+					<speed>1.5452637672424316</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008476875438777" lon="-84.20359391888815">
+				<ele>948.0311289178208</ele>
+				<time>2017-11-06T18:58:12Z</time>
+				<extensions>
+					<speed>2.344510555267334</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008508053546057" lon="-84.2035745159494">
+				<ele>948.659606221132</ele>
+				<time>2017-11-06T18:58:13Z</time>
+				<extensions>
+					<speed>3.300058364868164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008543947953553" lon="-84.20354993432609">
+				<ele>948.9520123461261</ele>
+				<time>2017-11-06T18:58:14Z</time>
+				<extensions>
+					<speed>4.227307319641113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008589991371297" lon="-84.20351765278569">
+				<ele>948.5849568294361</ele>
+				<time>2017-11-06T18:58:15Z</time>
+				<extensions>
+					<speed>5.500416278839111</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00863536488307" lon="-84.20349262575017">
+				<ele>948.3536617709324</ele>
+				<time>2017-11-06T18:58:16Z</time>
+				<extensions>
+					<speed>5.376265525817871</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008674311133445" lon="-84.20345578133957">
+				<ele>948.2129363175482</ele>
+				<time>2017-11-06T18:58:17Z</time>
+				<extensions>
+					<speed>5.450106143951416</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008713045171797" lon="-84.20341508505965">
+				<ele>947.4961750572547</ele>
+				<time>2017-11-06T18:58:18Z</time>
+				<extensions>
+					<speed>5.504133224487305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008752821831548" lon="-84.20338013526042">
+				<ele>948.1019011223689</ele>
+				<time>2017-11-06T18:58:19Z</time>
+				<extensions>
+					<speed>5.293756484985352</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008792243480576" lon="-84.20334743072118">
+				<ele>948.5768516045064</ele>
+				<time>2017-11-06T18:58:20Z</time>
+				<extensions>
+					<speed>4.895060062408447</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008826441936924" lon="-84.20331875739534">
+				<ele>948.8214838160202</ele>
+				<time>2017-11-06T18:58:21Z</time>
+				<extensions>
+					<speed>4.231682300567627</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0088511525493" lon="-84.20329992023439">
+				<ele>948.7461207192391</ele>
+				<time>2017-11-06T18:58:22Z</time>
+				<extensions>
+					<speed>2.516115188598633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008863809199543" lon="-84.20329318863672">
+				<ele>948.7844061832875</ele>
+				<time>2017-11-06T18:58:23Z</time>
+				<extensions>
+					<speed>0.6027820110321045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00886601543306" lon="-84.20329430648">
+				<ele>948.6411129748449</ele>
+				<time>2017-11-06T18:58:24Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00886601543306" lon="-84.20329430648">
+				<ele>948.6411129748449</ele>
+				<time>2017-11-06T18:58:25Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00886601543306" lon="-84.20329430648">
+				<ele>948.6411129748449</ele>
+				<time>2017-11-06T18:58:26Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00886601543306" lon="-84.20329430648">
+				<ele>948.6411129748449</ele>
+				<time>2017-11-06T18:58:27Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008872942275225" lon="-84.20328339931378">
+				<ele>948.0647122506052</ele>
+				<time>2017-11-06T18:58:28Z</time>
+				<extensions>
+					<speed>1.9927856922149658</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00889436211465" lon="-84.20326168074611">
+				<ele>947.8267469415441</ele>
+				<time>2017-11-06T18:58:29Z</time>
+				<extensions>
+					<speed>3.7914133071899414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008928541085478" lon="-84.20323318009682">
+				<ele>947.7153657311574</ele>
+				<time>2017-11-06T18:58:30Z</time>
+				<extensions>
+					<speed>5.035984039306641</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.008968732579016" lon="-84.20319752885953">
+				<ele>947.6268149260432</ele>
+				<time>2017-11-06T18:58:31Z</time>
+				<extensions>
+					<speed>5.5941596031188965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009009171870803" lon="-84.20315745198262">
+				<ele>947.4463314376771</ele>
+				<time>2017-11-06T18:58:32Z</time>
+				<extensions>
+					<speed>5.721346855163574</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009048022392859" lon="-84.20311970591096">
+				<ele>947.2290129102767</ele>
+				<time>2017-11-06T18:58:33Z</time>
+				<extensions>
+					<speed>5.545818328857422</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009081729663704" lon="-84.20308560480724">
+				<ele>946.767669797875</ele>
+				<time>2017-11-06T18:58:34Z</time>
+				<extensions>
+					<speed>4.497121810913086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00910722771212" lon="-84.20305795263312">
+				<ele>946.6299589453265</ele>
+				<time>2017-11-06T18:58:35Z</time>
+				<extensions>
+					<speed>2.797684907913208</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009123608024426" lon="-84.20303456944887">
+				<ele>946.3846372589469</ele>
+				<time>2017-11-06T18:58:36Z</time>
+				<extensions>
+					<speed>1.6594730615615845</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009134356981034" lon="-84.20302294648918">
+				<ele>946.1875800685957</ele>
+				<time>2017-11-06T18:58:37Z</time>
+				<extensions>
+					<speed>1.148073434829712</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009140876160053" lon="-84.20301028877478">
+				<ele>946.3181394003332</ele>
+				<time>2017-11-06T18:58:38Z</time>
+				<extensions>
+					<speed>1.0540214776992798</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009151225412865" lon="-84.20299680816662">
+				<ele>946.1577287344262</ele>
+				<time>2017-11-06T18:58:39Z</time>
+				<extensions>
+					<speed>1.6692577600479126</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00916478591624" lon="-84.20298106209039">
+				<ele>945.8386416528374</ele>
+				<time>2017-11-06T18:58:40Z</time>
+				<extensions>
+					<speed>2.2571756839752197</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00918536893294" lon="-84.20296120550078">
+				<ele>945.5288711218163</ele>
+				<time>2017-11-06T18:58:41Z</time>
+				<extensions>
+					<speed>3.244386911392212</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009213761697962" lon="-84.2029356285432">
+				<ele>945.4508659644052</ele>
+				<time>2017-11-06T18:58:42Z</time>
+				<extensions>
+					<speed>4.527171611785889</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00925133059383" lon="-84.20290061603968">
+				<ele>945.2703496729955</ele>
+				<time>2017-11-06T18:58:43Z</time>
+				<extensions>
+					<speed>5.979670524597168</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009298110425805" lon="-84.20285881671735">
+				<ele>945.1826599994674</ele>
+				<time>2017-11-06T18:58:44Z</time>
+				<extensions>
+					<speed>6.996654033660889</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009351922120064" lon="-84.20281197704746">
+				<ele>945.0456852540374</ele>
+				<time>2017-11-06T18:58:45Z</time>
+				<extensions>
+					<speed>8.099791526794434</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00941238121269" lon="-84.20275933329923">
+				<ele>944.8166277892888</ele>
+				<time>2017-11-06T18:58:46Z</time>
+				<extensions>
+					<speed>9.099802017211914</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009480341111724" lon="-84.20270359939946">
+				<ele>945.9185770507902</ele>
+				<time>2017-11-06T18:58:47Z</time>
+				<extensions>
+					<speed>9.71837329864502</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009548131162575" lon="-84.2026490929009">
+				<ele>946.6672722678632</ele>
+				<time>2017-11-06T18:58:48Z</time>
+				<extensions>
+					<speed>9.660134315490723</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00961539936757" lon="-84.20259325635962">
+				<ele>947.2365683848038</ele>
+				<time>2017-11-06T18:58:49Z</time>
+				<extensions>
+					<speed>9.322484970092773</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00968247500232" lon="-84.20253644109557">
+				<ele>947.9464914035052</ele>
+				<time>2017-11-06T18:58:50Z</time>
+				<extensions>
+					<speed>9.317094802856445</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009749722755565" lon="-84.20248043274846">
+				<ele>948.0975629165769</ele>
+				<time>2017-11-06T18:58:51Z</time>
+				<extensions>
+					<speed>9.329904556274414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.009818006592996" lon="-84.20241904074483">
+				<ele>948.9278801251203</ele>
+				<time>2017-11-06T18:58:52Z</time>
+				<extensions>
+					<speed>9.629973411560059</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00988949814726" lon="-84.20236533280912">
+				<ele>950.4486380703747</ele>
+				<time>2017-11-06T18:58:53Z</time>
+				<extensions>
+					<speed>9.206984519958496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.00995917627221" lon="-84.20231240145681">
+				<ele>951.65254873503</ele>
+				<time>2017-11-06T18:58:54Z</time>
+				<extensions>
+					<speed>9.081406593322754</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01002320341012" lon="-84.20225720787776">
+				<ele>952.0544991819188</ele>
+				<time>2017-11-06T18:58:55Z</time>
+				<extensions>
+					<speed>8.66331958770752</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010081633436556" lon="-84.20220431368298">
+				<ele>952.1076681688428</ele>
+				<time>2017-11-06T18:58:56Z</time>
+				<extensions>
+					<speed>7.848020553588867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010133524247879" lon="-84.20216031394013">
+				<ele>952.4177067223936</ele>
+				<time>2017-11-06T18:58:57Z</time>
+				<extensions>
+					<speed>6.7065534591674805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010177465666278" lon="-84.20212733098617">
+				<ele>952.397906026803</ele>
+				<time>2017-11-06T18:58:58Z</time>
+				<extensions>
+					<speed>4.95427942276001</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010207527120176" lon="-84.20210346323076">
+				<ele>952.4107434852049</ele>
+				<time>2017-11-06T18:58:59Z</time>
+				<extensions>
+					<speed>2.7478137016296387</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010233152526263" lon="-84.20210282539874">
+				<ele>955.448518880643</ele>
+				<time>2017-11-06T18:59:00Z</time>
+				<extensions>
+					<speed>1.0435938835144043</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010259469056397" lon="-84.20212822537178">
+				<ele>961.6234663464129</ele>
+				<time>2017-11-06T18:59:01Z</time>
+				<extensions>
+					<speed>0.7333159446716309</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010258883180505" lon="-84.20213709982337">
+				<ele>962.8589761024341</ele>
+				<time>2017-11-06T18:59:02Z</time>
+				<extensions>
+					<speed>1.413451910018921</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0102544469274" lon="-84.20214320405725">
+				<ele>963.394707034342</ele>
+				<time>2017-11-06T18:59:03Z</time>
+				<extensions>
+					<speed>1.1206517219543457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010247720037126" lon="-84.20214964351895">
+				<ele>963.761163495481</ele>
+				<time>2017-11-06T18:59:04Z</time>
+				<extensions>
+					<speed>1.1871260404586792</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01023910167858" lon="-84.20215582065431">
+				<ele>964.4066374050453</ele>
+				<time>2017-11-06T18:59:05Z</time>
+				<extensions>
+					<speed>1.1689435243606567</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010232508171464" lon="-84.20215992636048">
+				<ele>965.2458305535838</ele>
+				<time>2017-11-06T18:59:06Z</time>
+				<extensions>
+					<speed>0.7252112030982971</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010232508171464" lon="-84.20215992636048">
+				<ele>965.2458305535838</ele>
+				<time>2017-11-06T18:59:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01023012615816" lon="-84.20216512747797">
+				<ele>965.6298188567162</ele>
+				<time>2017-11-06T18:59:08Z</time>
+				<extensions>
+					<speed>0.2518136203289032</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01023012615816" lon="-84.20216512747797">
+				<ele>965.6298188567162</ele>
+				<time>2017-11-06T18:59:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01023012615816" lon="-84.20216512747797">
+				<ele>965.6298188567162</ele>
+				<time>2017-11-06T18:59:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010237538140428" lon="-84.20215891395699">
+				<ele>965.6491493023932</ele>
+				<time>2017-11-06T18:59:11Z</time>
+				<extensions>
+					<speed>1.499928593635559</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01025035223712" lon="-84.20214185643619">
+				<ele>965.4954339563847</ele>
+				<time>2017-11-06T18:59:12Z</time>
+				<extensions>
+					<speed>2.392805814743042</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010271723558988" lon="-84.2021185189619">
+				<ele>965.153607327491</ele>
+				<time>2017-11-06T18:59:13Z</time>
+				<extensions>
+					<speed>3.53605580329895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010303181529093" lon="-84.20209379044405">
+				<ele>964.9851025203243</ele>
+				<time>2017-11-06T18:59:14Z</time>
+				<extensions>
+					<speed>4.726714134216309</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01034387676327" lon="-84.20206557427282">
+				<ele>965.1854765014723</ele>
+				<time>2017-11-06T18:59:15Z</time>
+				<extensions>
+					<speed>5.592552185058594</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010390538816264" lon="-84.20203624145867">
+				<ele>965.3944626124576</ele>
+				<time>2017-11-06T18:59:16Z</time>
+				<extensions>
+					<speed>6.210485458374023</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010443456272492" lon="-84.202003305359">
+				<ele>965.5730198603123</ele>
+				<time>2017-11-06T18:59:17Z</time>
+				<extensions>
+					<speed>6.656571865081787</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010502703076588" lon="-84.20197219413257">
+				<ele>965.455951416865</ele>
+				<time>2017-11-06T18:59:18Z</time>
+				<extensions>
+					<speed>7.249500751495361</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010562147457868" lon="-84.20193979142641">
+				<ele>964.9203966120258</ele>
+				<time>2017-11-06T18:59:19Z</time>
+				<extensions>
+					<speed>7.479893207550049</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010625917576961" lon="-84.20190217978126">
+				<ele>964.9612911650911</ele>
+				<time>2017-11-06T18:59:20Z</time>
+				<extensions>
+					<speed>7.8558878898620605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010691969999579" lon="-84.20186537953536">
+				<ele>964.9342738157138</ele>
+				<time>2017-11-06T18:59:21Z</time>
+				<extensions>
+					<speed>8.126823425292969</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010757075975185" lon="-84.20182954070921">
+				<ele>964.9736364576966</ele>
+				<time>2017-11-06T18:59:22Z</time>
+				<extensions>
+					<speed>8.07587718963623</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010819578943208" lon="-84.20179682379961">
+				<ele>964.9681747267023</ele>
+				<time>2017-11-06T18:59:23Z</time>
+				<extensions>
+					<speed>7.770482540130615</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010883300088322" lon="-84.2017621816211">
+				<ele>964.918377071619</ele>
+				<time>2017-11-06T18:59:24Z</time>
+				<extensions>
+					<speed>7.621300220489502</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010942558275747" lon="-84.20172757572787">
+				<ele>964.9891807446256</ele>
+				<time>2017-11-06T18:59:25Z</time>
+				<extensions>
+					<speed>7.250770092010498</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.010996885736835" lon="-84.20169683399456">
+				<ele>964.8181110164151</ele>
+				<time>2017-11-06T18:59:26Z</time>
+				<extensions>
+					<speed>6.311672687530518</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011037051986118" lon="-84.20167115927863">
+				<ele>964.8290115371346</ele>
+				<time>2017-11-06T18:59:27Z</time>
+				<extensions>
+					<speed>4.734011650085449</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011059161060272" lon="-84.20165984389469">
+				<ele>964.9740021843463</ele>
+				<time>2017-11-06T18:59:28Z</time>
+				<extensions>
+					<speed>2.060204267501831</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011069911263789" lon="-84.20165522662914">
+				<ele>965.1828932613134</ele>
+				<time>2017-11-06T18:59:29Z</time>
+				<extensions>
+					<speed>1.2244906425476074</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011074828971612" lon="-84.20165009423364">
+				<ele>965.4860711703077</ele>
+				<time>2017-11-06T18:59:30Z</time>
+				<extensions>
+					<speed>0.7950798273086548</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011082354034166" lon="-84.20164508027808">
+				<ele>965.7911736629903</ele>
+				<time>2017-11-06T18:59:31Z</time>
+				<extensions>
+					<speed>1.1600943803787231</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011099295393516" lon="-84.2016343148969">
+				<ele>965.9679171377793</ele>
+				<time>2017-11-06T18:59:32Z</time>
+				<extensions>
+					<speed>2.3513588905334473</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011124028312954" lon="-84.20162022728564">
+				<ele>966.1516001336277</ele>
+				<time>2017-11-06T18:59:33Z</time>
+				<extensions>
+					<speed>3.703325033187866</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011157661906546" lon="-84.2015969271365">
+				<ele>966.3639756217599</ele>
+				<time>2017-11-06T18:59:34Z</time>
+				<extensions>
+					<speed>4.857239246368408</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011197976659489" lon="-84.20157219302102">
+				<ele>966.4721854655072</ele>
+				<time>2017-11-06T18:59:35Z</time>
+				<extensions>
+					<speed>5.15704870223999</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011246429481975" lon="-84.20154398642528">
+				<ele>966.532998512499</ele>
+				<time>2017-11-06T18:59:36Z</time>
+				<extensions>
+					<speed>5.729360103607178</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011294007274936" lon="-84.2015105556142">
+				<ele>966.6502366662025</ele>
+				<time>2017-11-06T18:59:37Z</time>
+				<extensions>
+					<speed>5.8651652336120605</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01133816933438" lon="-84.20147826759369">
+				<ele>966.9267844669521</ele>
+				<time>2017-11-06T18:59:38Z</time>
+				<extensions>
+					<speed>5.7854108810424805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011381470854584" lon="-84.20145202480255">
+				<ele>967.4275288116187</ele>
+				<time>2017-11-06T18:59:39Z</time>
+				<extensions>
+					<speed>5.5392327308654785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011419977244143" lon="-84.20143115861967">
+				<ele>967.7603595890105</ele>
+				<time>2017-11-06T18:59:40Z</time>
+				<extensions>
+					<speed>4.825587749481201</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011445200901845" lon="-84.2014170044606">
+				<ele>968.0914002601057</ele>
+				<time>2017-11-06T18:59:41Z</time>
+				<extensions>
+					<speed>2.99399995803833</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01146032260072" lon="-84.20141015923929">
+				<ele>968.2479384746403</ele>
+				<time>2017-11-06T18:59:42Z</time>
+				<extensions>
+					<speed>1.0457708835601807</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01146769741212" lon="-84.201413804682">
+				<ele>968.6724278526381</ele>
+				<time>2017-11-06T18:59:43Z</time>
+				<extensions>
+					<speed>0.5634670257568359</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011467888074792" lon="-84.20141931397507">
+				<ele>968.8018780332059</ele>
+				<time>2017-11-06T18:59:44Z</time>
+				<extensions>
+					<speed>1.0965542793273926</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011462665971068" lon="-84.20142178521975">
+				<ele>968.2179057775065</ele>
+				<time>2017-11-06T18:59:45Z</time>
+				<extensions>
+					<speed>1.197238564491272</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0114587869543" lon="-84.2014260936835">
+				<ele>967.8420029506087</ele>
+				<time>2017-11-06T18:59:46Z</time>
+				<extensions>
+					<speed>1.0443992614746094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011454251450528" lon="-84.20143292015615">
+				<ele>967.1498569063842</ele>
+				<time>2017-11-06T18:59:47Z</time>
+				<extensions>
+					<speed>0.7920248508453369</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011454251450528" lon="-84.20143292015615">
+				<ele>967.1498569063842</ele>
+				<time>2017-11-06T18:59:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011450239949532" lon="-84.20144361393056">
+				<ele>965.235668361187</ele>
+				<time>2017-11-06T18:59:49Z</time>
+				<extensions>
+					<speed>0.5991426706314087</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011450239949532" lon="-84.20144361393056">
+				<ele>965.235668361187</ele>
+				<time>2017-11-06T18:59:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011447432009541" lon="-84.20145092094259">
+				<ele>963.934150269255</ele>
+				<time>2017-11-06T18:59:51Z</time>
+				<extensions>
+					<speed>0.38605746626853943</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011447432009541" lon="-84.20145092094259">
+				<ele>963.934150269255</ele>
+				<time>2017-11-06T18:59:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011447432009541" lon="-84.20145092094259">
+				<ele>963.934150269255</ele>
+				<time>2017-11-06T18:59:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011447432009541" lon="-84.20145092094259">
+				<ele>963.934150269255</ele>
+				<time>2017-11-06T18:59:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011447432009541" lon="-84.20145092094259">
+				<ele>963.934150269255</ele>
+				<time>2017-11-06T18:59:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011459322850973" lon="-84.2014430964262">
+				<ele>963.5567918429151</ele>
+				<time>2017-11-06T18:59:56Z</time>
+				<extensions>
+					<speed>1.0824353694915771</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011471061159009" lon="-84.2014378905029">
+				<ele>963.7512743389234</ele>
+				<time>2017-11-06T18:59:57Z</time>
+				<extensions>
+					<speed>1.6518959999084473</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011491845202206" lon="-84.20143054273782">
+				<ele>963.9666843730956</ele>
+				<time>2017-11-06T18:59:58Z</time>
+				<extensions>
+					<speed>2.7253739833831787</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011528930348524" lon="-84.20141350691671">
+				<ele>963.9500619899482</ele>
+				<time>2017-11-06T18:59:59Z</time>
+				<extensions>
+					<speed>4.871449947357178</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011582634502094" lon="-84.20138737509566">
+				<ele>963.7352062873542</ele>
+				<time>2017-11-06T19:00:00Z</time>
+				<extensions>
+					<speed>7.235188007354736</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011649405568443" lon="-84.20135385264632">
+				<ele>963.2022717315704</ele>
+				<time>2017-11-06T19:00:01Z</time>
+				<extensions>
+					<speed>8.7425537109375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011725266243156" lon="-84.20131450169707">
+				<ele>962.7329722056165</ele>
+				<time>2017-11-06T19:00:02Z</time>
+				<extensions>
+					<speed>8.86589241027832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011805363657581" lon="-84.20127254850405">
+				<ele>961.8030185028911</ele>
+				<time>2017-11-06T19:00:03Z</time>
+				<extensions>
+					<speed>9.186708450317383</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0118852642892" lon="-84.20123060416493">
+				<ele>961.1871161777526</ele>
+				<time>2017-11-06T19:00:04Z</time>
+				<extensions>
+					<speed>9.226679801940918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.011966945511126" lon="-84.20118759860277">
+				<ele>960.9189863745123</ele>
+				<time>2017-11-06T19:00:05Z</time>
+				<extensions>
+					<speed>9.154362678527832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012042985481902" lon="-84.2011475943297">
+				<ele>960.7306528780609</ele>
+				<time>2017-11-06T19:00:06Z</time>
+				<extensions>
+					<speed>8.454084396362305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012108051225646" lon="-84.20111016751926">
+				<ele>960.416898031719</ele>
+				<time>2017-11-06T19:00:07Z</time>
+				<extensions>
+					<speed>7.0598368644714355</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012158714633498" lon="-84.20108018923251">
+				<ele>960.5003923792392</ele>
+				<time>2017-11-06T19:00:08Z</time>
+				<extensions>
+					<speed>5.2428879737854</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012192141208265" lon="-84.20105804591782">
+				<ele>960.3065465791151</ele>
+				<time>2017-11-06T19:00:09Z</time>
+				<extensions>
+					<speed>3.0384931564331055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012207441724401" lon="-84.20104865698444">
+				<ele>960.3867132691666</ele>
+				<time>2017-11-06T19:00:10Z</time>
+				<extensions>
+					<speed>0.8595783710479736</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012210245161066" lon="-84.20104272072417">
+				<ele>960.2932849479839</ele>
+				<time>2017-11-06T19:00:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012210245161066" lon="-84.20104272072417">
+				<ele>960.2932849479839</ele>
+				<time>2017-11-06T19:00:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012210245161066" lon="-84.20104272072417">
+				<ele>960.2932849479839</ele>
+				<time>2017-11-06T19:00:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012223612784975" lon="-84.20102799704749">
+				<ele>960.0585465505719</ele>
+				<time>2017-11-06T19:00:14Z</time>
+				<extensions>
+					<speed>2.2253265380859375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012247500232773" lon="-84.2010072975307">
+				<ele>959.8287497544661</ele>
+				<time>2017-11-06T19:00:15Z</time>
+				<extensions>
+					<speed>3.7823233604431152</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012284943427604" lon="-84.2009800113449">
+				<ele>959.6873818300664</ele>
+				<time>2017-11-06T19:00:16Z</time>
+				<extensions>
+					<speed>5.85187292098999</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012329839629762" lon="-84.20094562376703">
+				<ele>959.897573643364</ele>
+				<time>2017-11-06T19:00:17Z</time>
+				<extensions>
+					<speed>6.541203022003174</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012382370761697" lon="-84.20091272347881">
+				<ele>960.2949590692297</ele>
+				<time>2017-11-06T19:00:18Z</time>
+				<extensions>
+					<speed>6.571191310882568</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012429569923706" lon="-84.20089474028484">
+				<ele>961.8871600907296</ele>
+				<time>2017-11-06T19:00:19Z</time>
+				<extensions>
+					<speed>6.026204586029053</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012485264313403" lon="-84.20086842713202">
+				<ele>963.2144792107865</ele>
+				<time>2017-11-06T19:00:20Z</time>
+				<extensions>
+					<speed>6.693628311157227</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012539415325868" lon="-84.2008358347673">
+				<ele>963.6066975714639</ele>
+				<time>2017-11-06T19:00:21Z</time>
+				<extensions>
+					<speed>6.459422588348389</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012589033558074" lon="-84.2008062673603">
+				<ele>963.7120171375573</ele>
+				<time>2017-11-06T19:00:22Z</time>
+				<extensions>
+					<speed>5.243941307067871</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012628894940304" lon="-84.20078016855489">
+				<ele>963.5725834760815</ele>
+				<time>2017-11-06T19:00:23Z</time>
+				<extensions>
+					<speed>3.819829225540161</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012661420846952" lon="-84.20075614509734">
+				<ele>963.71989484597</ele>
+				<time>2017-11-06T19:00:24Z</time>
+				<extensions>
+					<speed>2.82393217086792</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012683148378999" lon="-84.20073726063465">
+				<ele>963.8309970013797</ele>
+				<time>2017-11-06T19:00:25Z</time>
+				<extensions>
+					<speed>2.0139806270599365</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012699349935096" lon="-84.2007236600758">
+				<ele>963.6604436105117</ele>
+				<time>2017-11-06T19:00:26Z</time>
+				<extensions>
+					<speed>1.4278686046600342</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012713486525112" lon="-84.20071009785623">
+				<ele>963.5280404696241</ele>
+				<time>2017-11-06T19:00:27Z</time>
+				<extensions>
+					<speed>1.608148455619812</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012730001913509" lon="-84.20069741426205">
+				<ele>963.6976623898372</ele>
+				<time>2017-11-06T19:00:28Z</time>
+				<extensions>
+					<speed>1.6882636547088623</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012748122923444" lon="-84.20068364168391">
+				<ele>963.6265892963856</ele>
+				<time>2017-11-06T19:00:29Z</time>
+				<extensions>
+					<speed>1.9816088676452637</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012775679538278" lon="-84.20066737553825">
+				<ele>963.4425581740215</ele>
+				<time>2017-11-06T19:00:30Z</time>
+				<extensions>
+					<speed>3.0742251873016357</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012810561472696" lon="-84.20065118354384">
+				<ele>963.6393537158147</ele>
+				<time>2017-11-06T19:00:31Z</time>
+				<extensions>
+					<speed>3.9673962593078613</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012849361842834" lon="-84.20063389983379">
+				<ele>963.4296067887917</ele>
+				<time>2017-11-06T19:00:32Z</time>
+				<extensions>
+					<speed>4.599314212799072</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01289033292637" lon="-84.20061797482875">
+				<ele>963.6336597409099</ele>
+				<time>2017-11-06T19:00:33Z</time>
+				<extensions>
+					<speed>4.434460639953613</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012931795708807" lon="-84.20060889663458">
+				<ele>964.0024231672287</ele>
+				<time>2017-11-06T19:00:34Z</time>
+				<extensions>
+					<speed>4.20192813873291</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012967986832349" lon="-84.2006100530197">
+				<ele>963.964845427312</ele>
+				<time>2017-11-06T19:00:35Z</time>
+				<extensions>
+					<speed>3.824716329574585</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.012998374705898" lon="-84.20061431620894">
+				<ele>964.1134480172768</ele>
+				<time>2017-11-06T19:00:36Z</time>
+				<extensions>
+					<speed>3.230747699737549</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013032066640367" lon="-84.20063344924878">
+				<ele>962.5989654352888</ele>
+				<time>2017-11-06T19:00:37Z</time>
+				<extensions>
+					<speed>4.573147773742676</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013059827200038" lon="-84.20066144779071">
+				<ele>961.7955822814256</ele>
+				<time>2017-11-06T19:00:38Z</time>
+				<extensions>
+					<speed>4.082425117492676</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013078968329667" lon="-84.20069518422365">
+				<ele>962.1352359177545</ele>
+				<time>2017-11-06T19:00:39Z</time>
+				<extensions>
+					<speed>4.169102191925049</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01309660384985" lon="-84.20073880901494">
+				<ele>962.8805162608624</ele>
+				<time>2017-11-06T19:00:40Z</time>
+				<extensions>
+					<speed>4.401458740234375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013114540772833" lon="-84.20078333423025">
+				<ele>962.8497745608911</ele>
+				<time>2017-11-06T19:00:41Z</time>
+				<extensions>
+					<speed>4.846338272094727</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01313040659289" lon="-84.20083141535878">
+				<ele>962.2359597431496</ele>
+				<time>2017-11-06T19:00:42Z</time>
+				<extensions>
+					<speed>5.194991588592529</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013151781947407" lon="-84.20087944870332">
+				<ele>961.5051962099969</ele>
+				<time>2017-11-06T19:00:43Z</time>
+				<extensions>
+					<speed>5.500959396362305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013174952609129" lon="-84.2009272517539">
+				<ele>961.2693603597581</ele>
+				<time>2017-11-06T19:00:44Z</time>
+				<extensions>
+					<speed>5.5991597175598145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013206028383024" lon="-84.20097511464623">
+				<ele>961.246284446679</ele>
+				<time>2017-11-06T19:00:45Z</time>
+				<extensions>
+					<speed>5.857195854187012</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013242724908139" lon="-84.20103325554823">
+				<ele>962.0268929051235</ele>
+				<time>2017-11-06T19:00:46Z</time>
+				<extensions>
+					<speed>6.484983444213867</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013279685055082" lon="-84.20109509620629">
+				<ele>961.3815768510103</ele>
+				<time>2017-11-06T19:00:47Z</time>
+				<extensions>
+					<speed>7.170124530792236</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013320617228002" lon="-84.20115360289928">
+				<ele>961.031555253081</ele>
+				<time>2017-11-06T19:00:48Z</time>
+				<extensions>
+					<speed>7.452490329742432</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01336633320761" lon="-84.20121000883134">
+				<ele>961.1288052769378</ele>
+				<time>2017-11-06T19:00:49Z</time>
+				<extensions>
+					<speed>7.982879638671875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013415347756741" lon="-84.20126547405138">
+				<ele>961.2092405594885</ele>
+				<time>2017-11-06T19:00:50Z</time>
+				<extensions>
+					<speed>7.7027106285095215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013463382138374" lon="-84.2013153795229">
+				<ele>961.4497898295522</ele>
+				<time>2017-11-06T19:00:51Z</time>
+				<extensions>
+					<speed>7.073585033416748</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013503764715065" lon="-84.20136143068994">
+				<ele>961.2930291714147</ele>
+				<time>2017-11-06T19:00:52Z</time>
+				<extensions>
+					<speed>6.178297996520996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013536518979373" lon="-84.20140303209118">
+				<ele>960.9938618550077</ele>
+				<time>2017-11-06T19:00:53Z</time>
+				<extensions>
+					<speed>5.108490943908691</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01356655619009" lon="-84.20144055874418">
+				<ele>961.3100889390334</ele>
+				<time>2017-11-06T19:00:54Z</time>
+				<extensions>
+					<speed>4.94871711730957</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013600165097975" lon="-84.20148027212842">
+				<ele>961.4473549248651</ele>
+				<time>2017-11-06T19:00:55Z</time>
+				<extensions>
+					<speed>5.458200931549072</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013636420311494" lon="-84.20152134945994">
+				<ele>961.1595349851996</ele>
+				<time>2017-11-06T19:00:56Z</time>
+				<extensions>
+					<speed>6.215803623199463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013679504702687" lon="-84.20156721227764">
+				<ele>961.1966640502214</ele>
+				<time>2017-11-06T19:00:57Z</time>
+				<extensions>
+					<speed>7.118021011352539</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013727433580133" lon="-84.20161751790488">
+				<ele>961.2516321707517</ele>
+				<time>2017-11-06T19:00:58Z</time>
+				<extensions>
+					<speed>7.279118061065674</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01377377944587" lon="-84.20167127487963">
+				<ele>960.7746479790658</ele>
+				<time>2017-11-06T19:00:59Z</time>
+				<extensions>
+					<speed>7.388469219207764</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013817790466154" lon="-84.2017248892087">
+				<ele>960.93282355275</ele>
+				<time>2017-11-06T19:01:00Z</time>
+				<extensions>
+					<speed>7.198068618774414</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013859662962668" lon="-84.20177646779024">
+				<ele>961.1847171476111</ele>
+				<time>2017-11-06T19:01:01Z</time>
+				<extensions>
+					<speed>7.077276229858398</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013896711598205" lon="-84.20182786092636">
+				<ele>961.1846911264583</ele>
+				<time>2017-11-06T19:01:02Z</time>
+				<extensions>
+					<speed>6.812448978424072</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013929736473084" lon="-84.20188121167995">
+				<ele>961.6383759686723</ele>
+				<time>2017-11-06T19:01:03Z</time>
+				<extensions>
+					<speed>6.157759666442871</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013956896109129" lon="-84.20193190525877">
+				<ele>961.8122041737661</ele>
+				<time>2017-11-06T19:01:04Z</time>
+				<extensions>
+					<speed>5.700686454772949</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013984758235129" lon="-84.20198804444438">
+				<ele>963.179707467556</ele>
+				<time>2017-11-06T19:01:05Z</time>
+				<extensions>
+					<speed>5.9358601570129395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014009819427326" lon="-84.20204641683449">
+				<ele>964.0877962429076</ele>
+				<time>2017-11-06T19:01:06Z</time>
+				<extensions>
+					<speed>6.059978008270264</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014033729979094" lon="-84.20210097991414">
+				<ele>964.6977559914812</ele>
+				<time>2017-11-06T19:01:07Z</time>
+				<extensions>
+					<speed>6.112710475921631</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014057404934976" lon="-84.20214921413661">
+				<ele>964.7242932198569</ele>
+				<time>2017-11-06T19:01:08Z</time>
+				<extensions>
+					<speed>5.380153179168701</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014077476312536" lon="-84.2021900444326">
+				<ele>964.7419292964041</ele>
+				<time>2017-11-06T19:01:09Z</time>
+				<extensions>
+					<speed>4.295777797698975</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0140905233546" lon="-84.2022200291101">
+				<ele>965.0782878259197</ele>
+				<time>2017-11-06T19:01:10Z</time>
+				<extensions>
+					<speed>2.4012291431427</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01409837363948" lon="-84.20223145998665">
+				<ele>964.751167469658</ele>
+				<time>2017-11-06T19:01:11Z</time>
+				<extensions>
+					<speed>0.9509873390197754</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014102987103172" lon="-84.20223332818344">
+				<ele>964.1068863496184</ele>
+				<time>2017-11-06T19:01:12Z</time>
+				<extensions>
+					<speed>0.6244277358055115</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014102987103172" lon="-84.20223332818344">
+				<ele>964.1068863496184</ele>
+				<time>2017-11-06T19:01:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014112292895234" lon="-84.20225239133318">
+				<ele>963.191013449803</ele>
+				<time>2017-11-06T19:01:14Z</time>
+				<extensions>
+					<speed>2.1802868843078613</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014125343188246" lon="-84.20227804878057">
+				<ele>960.8702618312091</ele>
+				<time>2017-11-06T19:01:15Z</time>
+				<extensions>
+					<speed>3.0722239017486572</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014142889570836" lon="-84.20231163961161">
+				<ele>958.9713453119621</ele>
+				<time>2017-11-06T19:01:16Z</time>
+				<extensions>
+					<speed>4.026217460632324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014163257993975" lon="-84.20235137086944">
+				<ele>957.6411317698658</ele>
+				<time>2017-11-06T19:01:17Z</time>
+				<extensions>
+					<speed>4.129518508911133</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014180344232194" lon="-84.20238534543216">
+				<ele>956.6000924929976</ele>
+				<time>2017-11-06T19:01:18Z</time>
+				<extensions>
+					<speed>3.2492918968200684</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014194965714443" lon="-84.20241024443784">
+				<ele>956.2361885728315</ele>
+				<time>2017-11-06T19:01:19Z</time>
+				<extensions>
+					<speed>3.003476619720459</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014208224791766" lon="-84.20243007718211">
+				<ele>955.5826435703784</ele>
+				<time>2017-11-06T19:01:20Z</time>
+				<extensions>
+					<speed>2.1454787254333496</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014220971692753" lon="-84.20244534889127">
+				<ele>955.1839832887053</ele>
+				<time>2017-11-06T19:01:21Z</time>
+				<extensions>
+					<speed>1.9838312864303589</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014236538411055" lon="-84.20245544112802">
+				<ele>954.7472915584221</ele>
+				<time>2017-11-06T19:01:22Z</time>
+				<extensions>
+					<speed>2.123668909072876</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014258565431252" lon="-84.20245735360156">
+				<ele>954.5986890569329</ele>
+				<time>2017-11-06T19:01:23Z</time>
+				<extensions>
+					<speed>2.726980686187744</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014288696576124" lon="-84.2024530830841">
+				<ele>954.872343194671</ele>
+				<time>2017-11-06T19:01:24Z</time>
+				<extensions>
+					<speed>3.7497034072875977</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01433127261934" lon="-84.20243712747518">
+				<ele>955.4700208231807</ele>
+				<time>2017-11-06T19:01:25Z</time>
+				<extensions>
+					<speed>5.285149097442627</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014382328828566" lon="-84.2024157798824">
+				<ele>955.6110496819019</ele>
+				<time>2017-11-06T19:01:26Z</time>
+				<extensions>
+					<speed>6.344838619232178</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014436089753346" lon="-84.20238488508583">
+				<ele>955.6926167886704</ele>
+				<time>2017-11-06T19:01:27Z</time>
+				<extensions>
+					<speed>6.658198356628418</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014487552973453" lon="-84.20235224316806">
+				<ele>955.9289629757404</ele>
+				<time>2017-11-06T19:01:28Z</time>
+				<extensions>
+					<speed>6.459025859832764</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01453311702731" lon="-84.20232010578131">
+				<ele>956.0265195639804</ele>
+				<time>2017-11-06T19:01:29Z</time>
+				<extensions>
+					<speed>6.112090587615967</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014573150317627" lon="-84.20229127277513">
+				<ele>956.1227703318</ele>
+				<time>2017-11-06T19:01:30Z</time>
+				<extensions>
+					<speed>5.508882522583008</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014610677869365" lon="-84.20226619912107">
+				<ele>956.1146596586332</ele>
+				<time>2017-11-06T19:01:31Z</time>
+				<extensions>
+					<speed>5.132078170776367</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014647986793463" lon="-84.20223805315695">
+				<ele>955.4285868322477</ele>
+				<time>2017-11-06T19:01:32Z</time>
+				<extensions>
+					<speed>5.211886882781982</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014687421438046" lon="-84.2022114579396">
+				<ele>955.1354436082765</ele>
+				<time>2017-11-06T19:01:33Z</time>
+				<extensions>
+					<speed>5.380131244659424</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014730587093224" lon="-84.20218064646365">
+				<ele>954.7348774736747</ele>
+				<time>2017-11-06T19:01:34Z</time>
+				<extensions>
+					<speed>5.777690887451172</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014780304391286" lon="-84.20214619192974">
+				<ele>954.1511847125366</ele>
+				<time>2017-11-06T19:01:35Z</time>
+				<extensions>
+					<speed>6.418911933898926</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014833678008918" lon="-84.20211494804879">
+				<ele>953.7004828220233</ele>
+				<time>2017-11-06T19:01:36Z</time>
+				<extensions>
+					<speed>6.894713401794434</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014893441003661" lon="-84.2020932584049">
+				<ele>952.9221742963418</ele>
+				<time>2017-11-06T19:01:37Z</time>
+				<extensions>
+					<speed>6.894656181335449</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014953137595628" lon="-84.20206096048086">
+				<ele>952.2534414334223</ele>
+				<time>2017-11-06T19:01:38Z</time>
+				<extensions>
+					<speed>7.02299165725708</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015012992699749" lon="-84.20202822745901">
+				<ele>951.3081373088062</ele>
+				<time>2017-11-06T19:01:39Z</time>
+				<extensions>
+					<speed>6.898715496063232</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01506891109301" lon="-84.20199264102517">
+				<ele>950.4617829583585</ele>
+				<time>2017-11-06T19:01:40Z</time>
+				<extensions>
+					<speed>7.0104594230651855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015122824256347" lon="-84.20195875139734">
+				<ele>949.9072770653293</ele>
+				<time>2017-11-06T19:01:41Z</time>
+				<extensions>
+					<speed>6.800499439239502</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015172207364403" lon="-84.20192388855041">
+				<ele>949.4671000577509</ele>
+				<time>2017-11-06T19:01:42Z</time>
+				<extensions>
+					<speed>6.401864528656006</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015218541987515" lon="-84.20188939962567">
+				<ele>949.2940481025726</ele>
+				<time>2017-11-06T19:01:43Z</time>
+				<extensions>
+					<speed>6.1633782386779785</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015260837723872" lon="-84.2018521803665">
+				<ele>949.5816785367206</ele>
+				<time>2017-11-06T19:01:44Z</time>
+				<extensions>
+					<speed>5.686106204986572</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01529543292663" lon="-84.20181529018562">
+				<ele>949.5351830879226</ele>
+				<time>2017-11-06T19:01:45Z</time>
+				<extensions>
+					<speed>4.955129623413086</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015322281709496" lon="-84.20177625097602">
+				<ele>949.4091786919162</ele>
+				<time>2017-11-06T19:01:46Z</time>
+				<extensions>
+					<speed>4.760832786560059</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015344723018293" lon="-84.20173974750583">
+				<ele>948.9946377007291</ele>
+				<time>2017-11-06T19:01:47Z</time>
+				<extensions>
+					<speed>4.307316780090332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01536214403402" lon="-84.20170815031379">
+				<ele>948.4423349788412</ele>
+				<time>2017-11-06T19:01:48Z</time>
+				<extensions>
+					<speed>3.282236099243164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015374628666734" lon="-84.20168788286563">
+				<ele>947.9143577199429</ele>
+				<time>2017-11-06T19:01:49Z</time>
+				<extensions>
+					<speed>2.185530185699463</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015380721307217" lon="-84.20167524112962">
+				<ele>946.4357580775395</ele>
+				<time>2017-11-06T19:01:50Z</time>
+				<extensions>
+					<speed>1.406244158744812</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:01:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:01:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:01:53Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:01:54Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:01:55Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:01:56Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:01:57Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:01:58Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:01:59Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:02:00Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:02:01Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:02:02Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:02:03Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:02:04Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:02:05Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:02:06Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:02:07Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:02:08Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:02:09Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:02:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:02:11Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:02:12Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:02:13Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:02:14Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015385809318934" lon="-84.20168151681861">
+				<ele>945.7875683708116</ele>
+				<time>2017-11-06T19:02:15Z</time>
+				<extensions>
+					<speed>0.6198335289955139</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:02:16Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015383268320628" lon="-84.20167624999236">
+				<ele>944.8859277609736</ele>
+				<time>2017-11-06T19:02:17Z</time>
+				<extensions>
+					<speed>0.717706024646759</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015387460880223" lon="-84.20166989795469">
+				<ele>944.7811749055982</ele>
+				<time>2017-11-06T19:02:18Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015382377547596" lon="-84.20167572734533">
+				<ele>944.6101675946265</ele>
+				<time>2017-11-06T19:02:19Z</time>
+				<extensions>
+					<speed>0.7777622938156128</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015375807748882" lon="-84.20167984739238">
+				<ele>943.9289141716436</ele>
+				<time>2017-11-06T19:02:20Z</time>
+				<extensions>
+					<speed>1.012178897857666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015368254352905" lon="-84.20168167746112">
+				<ele>943.2423913963139</ele>
+				<time>2017-11-06T19:02:21Z</time>
+				<extensions>
+					<speed>0.8076620101928711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015363241604817" lon="-84.20168532507498">
+				<ele>941.9073271593079</ele>
+				<time>2017-11-06T19:02:22Z</time>
+				<extensions>
+					<speed>0.628521740436554</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015359003092387" lon="-84.2016903885836">
+				<ele>941.3917906777933</ele>
+				<time>2017-11-06T19:02:23Z</time>
+				<extensions>
+					<speed>0.5951293110847473</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015355884557971" lon="-84.20169507877546">
+				<ele>941.9360944135115</ele>
+				<time>2017-11-06T19:02:24Z</time>
+				<extensions>
+					<speed>0.8942413330078125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015348633776956" lon="-84.20169561945457">
+				<ele>943.5911922398955</ele>
+				<time>2017-11-06T19:02:25Z</time>
+				<extensions>
+					<speed>0.8279584050178528</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015342051494416" lon="-84.20169481533017">
+				<ele>945.3105867644772</ele>
+				<time>2017-11-06T19:02:26Z</time>
+				<extensions>
+					<speed>0.8145037889480591</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015337409148149" lon="-84.20169626836557">
+				<ele>946.1833031503484</ele>
+				<time>2017-11-06T19:02:27Z</time>
+				<extensions>
+					<speed>0.5468333959579468</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01533050965739" lon="-84.20169476597748">
+				<ele>947.9398803757504</ele>
+				<time>2017-11-06T19:02:28Z</time>
+				<extensions>
+					<speed>0.8053189516067505</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015326676275897" lon="-84.20169182808057">
+				<ele>948.6347935367376</ele>
+				<time>2017-11-06T19:02:29Z</time>
+				<extensions>
+					<speed>0.6763968467712402</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015323411789497" lon="-84.20168886040774">
+				<ele>948.9975264491513</ele>
+				<time>2017-11-06T19:02:30Z</time>
+				<extensions>
+					<speed>0.6118835806846619</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015322115274488" lon="-84.20168836523054">
+				<ele>948.6067543346435</ele>
+				<time>2017-11-06T19:02:31Z</time>
+				<extensions>
+					<speed>0.6288193464279175</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015319557727159" lon="-84.20168701507154">
+				<ele>947.895090835169</ele>
+				<time>2017-11-06T19:02:32Z</time>
+				<extensions>
+					<speed>0.6371862292289734</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015317251203113" lon="-84.20168458786407">
+				<ele>947.6321693705395</ele>
+				<time>2017-11-06T19:02:33Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015313577265001" lon="-84.20168323187025">
+				<ele>947.1645176112652</ele>
+				<time>2017-11-06T19:02:34Z</time>
+				<extensions>
+					<speed>0.38256514072418213</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015310785849046" lon="-84.20168099365024">
+				<ele>947.8201875910163</ele>
+				<time>2017-11-06T19:02:35Z</time>
+				<extensions>
+					<speed>0.5251938700675964</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015308290517037" lon="-84.20167885771384">
+				<ele>948.2977287787944</ele>
+				<time>2017-11-06T19:02:36Z</time>
+				<extensions>
+					<speed>0.4849795997142792</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015308290517037" lon="-84.20167885771384">
+				<ele>948.2977287787944</ele>
+				<time>2017-11-06T19:02:37Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015308695357138" lon="-84.20167844284948">
+				<ele>947.9498177180067</ele>
+				<time>2017-11-06T19:02:38Z</time>
+				<extensions>
+					<speed>0.02235698699951172</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015308695357138" lon="-84.20167844284948">
+				<ele>947.9498177180067</ele>
+				<time>2017-11-06T19:02:39Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015308695357138" lon="-84.20167844284948">
+				<ele>947.9498177180067</ele>
+				<time>2017-11-06T19:02:40Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015305041716534" lon="-84.20168030380268">
+				<ele>948.2935534920543</ele>
+				<time>2017-11-06T19:02:41Z</time>
+				<extensions>
+					<speed>0.8268635272979736</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01530782873185" lon="-84.20168507595515">
+				<ele>948.8690241612494</ele>
+				<time>2017-11-06T19:02:42Z</time>
+				<extensions>
+					<speed>0.9917758703231812</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015314524149707" lon="-84.20169208459603">
+				<ele>949.5378634296358</ele>
+				<time>2017-11-06T19:02:43Z</time>
+				<extensions>
+					<speed>1.280904769897461</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015319012295056" lon="-84.20170537128487">
+				<ele>950.4209999935701</ele>
+				<time>2017-11-06T19:02:44Z</time>
+				<extensions>
+					<speed>1.5438226461410522</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015319778181333" lon="-84.20172445101483">
+				<ele>951.0788736511022</ele>
+				<time>2017-11-06T19:02:45Z</time>
+				<extensions>
+					<speed>1.749011516571045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015321147721433" lon="-84.20174730960538">
+				<ele>951.6250167740509</ele>
+				<time>2017-11-06T19:02:46Z</time>
+				<extensions>
+					<speed>2.2751903533935547</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015319562208303" lon="-84.20177429311084">
+				<ele>952.0001608198509</ele>
+				<time>2017-11-06T19:02:47Z</time>
+				<extensions>
+					<speed>2.985560894012451</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015313813049483" lon="-84.20181174561645">
+				<ele>953.4623913699761</ele>
+				<time>2017-11-06T19:02:48Z</time>
+				<extensions>
+					<speed>4.398717403411865</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01529746886092" lon="-84.201852190067">
+				<ele>954.6534304311499</ele>
+				<time>2017-11-06T19:02:49Z</time>
+				<extensions>
+					<speed>4.916114330291748</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01526646427594" lon="-84.20189441907694">
+				<ele>954.9222777737305</ele>
+				<time>2017-11-06T19:02:50Z</time>
+				<extensions>
+					<speed>6.250497817993164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015221256803322" lon="-84.20193512677623">
+				<ele>955.3819745108485</ele>
+				<time>2017-11-06T19:02:51Z</time>
+				<extensions>
+					<speed>7.060731410980225</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015164240886715" lon="-84.20196703423824">
+				<ele>954.8748235497624</ele>
+				<time>2017-11-06T19:02:52Z</time>
+				<extensions>
+					<speed>7.143282413482666</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015097894454087" lon="-84.20199558595921">
+				<ele>954.483568768017</ele>
+				<time>2017-11-06T19:02:53Z</time>
+				<extensions>
+					<speed>8.582377433776855</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015026230908315" lon="-84.20202882524545">
+				<ele>954.3320571444929</ele>
+				<time>2017-11-06T19:02:54Z</time>
+				<extensions>
+					<speed>8.466327667236328</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014953574917222" lon="-84.20206646740091">
+				<ele>954.0691488618031</ele>
+				<time>2017-11-06T19:02:55Z</time>
+				<extensions>
+					<speed>9.029219627380371</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014882633426406" lon="-84.20210596621328">
+				<ele>954.1779280444607</ele>
+				<time>2017-11-06T19:02:56Z</time>
+				<extensions>
+					<speed>8.795576095581055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014815403405283" lon="-84.20214376451247">
+				<ele>953.9799329042435</ele>
+				<time>2017-11-06T19:02:57Z</time>
+				<extensions>
+					<speed>8.152429580688477</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014750444933231" lon="-84.2021803399718">
+				<ele>953.9786588698626</ele>
+				<time>2017-11-06T19:02:58Z</time>
+				<extensions>
+					<speed>7.809645652770996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014689077096666" lon="-84.20221957430316">
+				<ele>953.6454408485442</ele>
+				<time>2017-11-06T19:02:59Z</time>
+				<extensions>
+					<speed>7.8807196617126465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014630456636194" lon="-84.20226065919319">
+				<ele>953.3383566932753</ele>
+				<time>2017-11-06T19:03:00Z</time>
+				<extensions>
+					<speed>7.682821273803711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014572710239252" lon="-84.20229818539751">
+				<ele>953.2142155952752</ele>
+				<time>2017-11-06T19:03:01Z</time>
+				<extensions>
+					<speed>7.4603447914123535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01451729164296" lon="-84.20233404946198">
+				<ele>953.1351242652163</ele>
+				<time>2017-11-06T19:03:02Z</time>
+				<extensions>
+					<speed>7.121737480163574</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01446496889826" lon="-84.20237036056469">
+				<ele>952.6706180106848</ele>
+				<time>2017-11-06T19:03:03Z</time>
+				<extensions>
+					<speed>6.850280284881592</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014416750989144" lon="-84.2024017849373">
+				<ele>952.2990670027211</ele>
+				<time>2017-11-06T19:03:04Z</time>
+				<extensions>
+					<speed>5.921291351318359</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014376378817714" lon="-84.20242988469816">
+				<ele>951.8498919336125</ele>
+				<time>2017-11-06T19:03:05Z</time>
+				<extensions>
+					<speed>4.816863059997559</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014342459811328" lon="-84.2024520474403">
+				<ele>951.5962753966451</ele>
+				<time>2017-11-06T19:03:06Z</time>
+				<extensions>
+					<speed>3.651502847671509</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014315516779668" lon="-84.20246524910641">
+				<ele>951.3765695793554</ele>
+				<time>2017-11-06T19:03:07Z</time>
+				<extensions>
+					<speed>2.2936861515045166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014299950407628" lon="-84.20247084127034">
+				<ele>950.930312352255</ele>
+				<time>2017-11-06T19:03:08Z</time>
+				<extensions>
+					<speed>1.0664035081863403</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014293209582501" lon="-84.20247108454335">
+				<ele>950.4972054157406</ele>
+				<time>2017-11-06T19:03:09Z</time>
+				<extensions>
+					<speed>0.5474494099617004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014293209582501" lon="-84.20247108454335">
+				<ele>950.4972054157406</ele>
+				<time>2017-11-06T19:03:10Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014284247340601" lon="-84.20246833069072">
+				<ele>950.2605802100152</ele>
+				<time>2017-11-06T19:03:11Z</time>
+				<extensions>
+					<speed>1.425114631652832</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014265513849804" lon="-84.20246412177659">
+				<ele>949.9468695558608</ele>
+				<time>2017-11-06T19:03:12Z</time>
+				<extensions>
+					<speed>2.1835873126983643</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423729302092" lon="-84.20245531344186">
+				<ele>949.8378583798185</ele>
+				<time>2017-11-06T19:03:13Z</time>
+				<extensions>
+					<speed>3.32745623588562</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014204196870901" lon="-84.20243935675344">
+				<ele>949.7803531438112</ele>
+				<time>2017-11-06T19:03:14Z</time>
+				<extensions>
+					<speed>4.006012916564941</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014175643813374" lon="-84.20241321011405">
+				<ele>949.6486636279151</ele>
+				<time>2017-11-06T19:03:15Z</time>
+				<extensions>
+					<speed>4.320517539978027</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014149084230104" lon="-84.20237719739241">
+				<ele>949.6267191879451</ele>
+				<time>2017-11-06T19:03:16Z</time>
+				<extensions>
+					<speed>5.370362281799316</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014119838541921" lon="-84.20233018328467">
+				<ele>949.5237534856424</ele>
+				<time>2017-11-06T19:03:17Z</time>
+				<extensions>
+					<speed>6.530187606811523</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014085088897906" lon="-84.20227889306103">
+				<ele>949.1986067751423</ele>
+				<time>2017-11-06T19:03:18Z</time>
+				<extensions>
+					<speed>6.532008647918701</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014054270265467" lon="-84.20222241351352">
+				<ele>949.0831385413185</ele>
+				<time>2017-11-06T19:03:19Z</time>
+				<extensions>
+					<speed>6.855371952056885</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014023933312163" lon="-84.20216389813974">
+				<ele>949.0093524865806</ele>
+				<time>2017-11-06T19:03:20Z</time>
+				<extensions>
+					<speed>6.976299285888672</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013996578585948" lon="-84.20210432750497">
+				<ele>948.771036868915</ele>
+				<time>2017-11-06T19:03:21Z</time>
+				<extensions>
+					<speed>6.836643695831299</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013965324357553" lon="-84.20204968013188">
+				<ele>948.5287507427856</ele>
+				<time>2017-11-06T19:03:22Z</time>
+				<extensions>
+					<speed>6.645385265350342</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013939905024172" lon="-84.2019943326583">
+				<ele>948.5262076398358</ele>
+				<time>2017-11-06T19:03:23Z</time>
+				<extensions>
+					<speed>6.434943675994873</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013916063840067" lon="-84.20194283843935">
+				<ele>948.61217316892</ele>
+				<time>2017-11-06T19:03:24Z</time>
+				<extensions>
+					<speed>5.908993721008301</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01389544880474" lon="-84.20189539452075">
+				<ele>948.883543908596</ele>
+				<time>2017-11-06T19:03:25Z</time>
+				<extensions>
+					<speed>5.3425726890563965</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013874370261265" lon="-84.2018527228654">
+				<ele>948.9949667844921</ele>
+				<time>2017-11-06T19:03:26Z</time>
+				<extensions>
+					<speed>5.155278205871582</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013852312512967" lon="-84.20181056982906">
+				<ele>949.1106545468792</ele>
+				<time>2017-11-06T19:03:27Z</time>
+				<extensions>
+					<speed>4.897341728210449</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013828788674335" lon="-84.20177142614442">
+				<ele>948.8569682324305</ele>
+				<time>2017-11-06T19:03:28Z</time>
+				<extensions>
+					<speed>4.810441493988037</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01380517378938" lon="-84.20173280199866">
+				<ele>948.6409375844523</ele>
+				<time>2017-11-06T19:03:29Z</time>
+				<extensions>
+					<speed>4.9029035568237305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013779477227681" lon="-84.20169668261131">
+				<ele>947.9819279275835</ele>
+				<time>2017-11-06T19:03:30Z</time>
+				<extensions>
+					<speed>4.4645185470581055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01375272366569" lon="-84.20166428927746">
+				<ele>947.2796695530415</ele>
+				<time>2017-11-06T19:03:31Z</time>
+				<extensions>
+					<speed>4.09410285949707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01372722344768" lon="-84.20163472857996">
+				<ele>947.4593487493694</ele>
+				<time>2017-11-06T19:03:32Z</time>
+				<extensions>
+					<speed>4.0016326904296875</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013699555754702" lon="-84.20160841098001">
+				<ele>948.2367176497355</ele>
+				<time>2017-11-06T19:03:33Z</time>
+				<extensions>
+					<speed>4.18791389465332</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013670690926372" lon="-84.20157945350877">
+				<ele>949.4371692501009</ele>
+				<time>2017-11-06T19:03:34Z</time>
+				<extensions>
+					<speed>4.578806400299072</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013640483706215" lon="-84.20155200526715">
+				<ele>950.1979706035927</ele>
+				<time>2017-11-06T19:03:35Z</time>
+				<extensions>
+					<speed>4.282079219818115</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013610800850936" lon="-84.20152384205555">
+				<ele>951.1170074492693</ele>
+				<time>2017-11-06T19:03:36Z</time>
+				<extensions>
+					<speed>4.201773643493652</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01358397472678" lon="-84.20149554772188">
+				<ele>951.7173601482064</ele>
+				<time>2017-11-06T19:03:37Z</time>
+				<extensions>
+					<speed>4.000434398651123</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01355879813959" lon="-84.20146758291517">
+				<ele>952.1548557551578</ele>
+				<time>2017-11-06T19:03:38Z</time>
+				<extensions>
+					<speed>3.8968610763549805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013532794679541" lon="-84.20144058303818">
+				<ele>952.4791460232809</ele>
+				<time>2017-11-06T19:03:39Z</time>
+				<extensions>
+					<speed>4.008763313293457</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013505963262697" lon="-84.20141448809137">
+				<ele>952.7774824500084</ele>
+				<time>2017-11-06T19:03:40Z</time>
+				<extensions>
+					<speed>4.003540992736816</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01348195268495" lon="-84.20138592368882">
+				<ele>953.0367114534602</ele>
+				<time>2017-11-06T19:03:41Z</time>
+				<extensions>
+					<speed>3.963582992553711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.0134567556193" lon="-84.2013589306105">
+				<ele>953.4719213852659</ele>
+				<time>2017-11-06T19:03:42Z</time>
+				<extensions>
+					<speed>3.937535285949707</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013431799095198" lon="-84.201332392056">
+				<ele>953.6269415970892</ele>
+				<time>2017-11-06T19:03:43Z</time>
+				<extensions>
+					<speed>3.8224246501922607</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013404127131755" lon="-84.20130718805531">
+				<ele>953.6570524917915</ele>
+				<time>2017-11-06T19:03:44Z</time>
+				<extensions>
+					<speed>3.9560306072235107</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013378934241414" lon="-84.20128189273011">
+				<ele>954.0759899951518</ele>
+				<time>2017-11-06T19:03:45Z</time>
+				<extensions>
+					<speed>3.7616841793060303</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013355884897921" lon="-84.20125468826105">
+				<ele>954.4083408648148</ele>
+				<time>2017-11-06T19:03:46Z</time>
+				<extensions>
+					<speed>3.8980531692504883</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013333852064994" lon="-84.20122821185275">
+				<ele>954.1793681802228</ele>
+				<time>2017-11-06T19:03:47Z</time>
+				<extensions>
+					<speed>3.5758132934570313</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013313928838958" lon="-84.20120456156543">
+				<ele>953.8792440984398</ele>
+				<time>2017-11-06T19:03:48Z</time>
+				<extensions>
+					<speed>3.1747734546661377</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013293924014526" lon="-84.20117786196761">
+				<ele>953.590403996408</ele>
+				<time>2017-11-06T19:03:49Z</time>
+				<extensions>
+					<speed>3.5040879249572754</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013273246562033" lon="-84.20114902505058">
+				<ele>953.3699644356966</ele>
+				<time>2017-11-06T19:03:50Z</time>
+				<extensions>
+					<speed>3.4600107669830322</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013250938365989" lon="-84.20112091285192">
+				<ele>953.3834822457284</ele>
+				<time>2017-11-06T19:03:51Z</time>
+				<extensions>
+					<speed>3.599325180053711</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013228027425649" lon="-84.20109264621863">
+				<ele>953.3181378021836</ele>
+				<time>2017-11-06T19:03:52Z</time>
+				<extensions>
+					<speed>3.6118266582489014</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013205647302907" lon="-84.20106308463276">
+				<ele>952.8041285509244</ele>
+				<time>2017-11-06T19:03:53Z</time>
+				<extensions>
+					<speed>3.770878314971924</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013183425685858" lon="-84.20103421077162">
+				<ele>952.4434450762346</ele>
+				<time>2017-11-06T19:03:54Z</time>
+				<extensions>
+					<speed>3.7376151084899902</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01315961119443" lon="-84.20100613794254">
+				<ele>951.9265932915732</ele>
+				<time>2017-11-06T19:03:55Z</time>
+				<extensions>
+					<speed>3.6878039836883545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013138416233708" lon="-84.20097803655678">
+				<ele>951.5791368922219</ele>
+				<time>2017-11-06T19:03:56Z</time>
+				<extensions>
+					<speed>3.4904139041900635</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013117333472872" lon="-84.20094506631983">
+				<ele>951.0989973219112</ele>
+				<time>2017-11-06T19:03:57Z</time>
+				<extensions>
+					<speed>4.1696553230285645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01309847502312" lon="-84.20091102118728">
+				<ele>951.2467501061037</ele>
+				<time>2017-11-06T19:03:58Z</time>
+				<extensions>
+					<speed>3.6829488277435303</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01307963091162" lon="-84.20087879755155">
+				<ele>951.4152263998985</ele>
+				<time>2017-11-06T19:03:59Z</time>
+				<extensions>
+					<speed>3.9796929359436035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013062895884698" lon="-84.20084888773087">
+				<ele>951.8378119403496</ele>
+				<time>2017-11-06T19:04:00Z</time>
+				<extensions>
+					<speed>3.6584815979003906</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013051361864072" lon="-84.20082183640359">
+				<ele>952.5989199709147</ele>
+				<time>2017-11-06T19:04:01Z</time>
+				<extensions>
+					<speed>2.720737934112549</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013044531556478" lon="-84.20079912157148">
+				<ele>952.565553274937</ele>
+				<time>2017-11-06T19:04:02Z</time>
+				<extensions>
+					<speed>1.6516227722167969</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013036011351245" lon="-84.20078611802454">
+				<ele>952.2388343876228</ele>
+				<time>2017-11-06T19:04:03Z</time>
+				<extensions>
+					<speed>1.2651652097702026</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01302575920179" lon="-84.20077276016342">
+				<ele>951.5651547396556</ele>
+				<time>2017-11-06T19:04:04Z</time>
+				<extensions>
+					<speed>1.252087116241455</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013015015438903" lon="-84.20075742295981">
+				<ele>951.3101511541754</ele>
+				<time>2017-11-06T19:04:05Z</time>
+				<extensions>
+					<speed>1.782347559928894</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01300799859343" lon="-84.20073275331752">
+				<ele>949.8388624377549</ele>
+				<time>2017-11-06T19:04:06Z</time>
+				<extensions>
+					<speed>2.657686948776245</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013010664777283" lon="-84.20069987990247">
+				<ele>949.5254188720137</ele>
+				<time>2017-11-06T19:04:07Z</time>
+				<extensions>
+					<speed>3.952735185623169</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013037107334222" lon="-84.2006601090642">
+				<ele>949.9039817387238</ele>
+				<time>2017-11-06T19:04:08Z</time>
+				<extensions>
+					<speed>4.6634202003479</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013075316687923" lon="-84.20062147131486">
+				<ele>950.7100070146844</ele>
+				<time>2017-11-06T19:04:09Z</time>
+				<extensions>
+					<speed>5.292079925537109</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013118264060239" lon="-84.2005831971727">
+				<ele>949.7861548280343</ele>
+				<time>2017-11-06T19:04:10Z</time>
+				<extensions>
+					<speed>6.19059419631958</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013168324502729" lon="-84.20054686932156">
+				<ele>948.7752667283639</ele>
+				<time>2017-11-06T19:04:11Z</time>
+				<extensions>
+					<speed>6.442863941192627</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013219517268503" lon="-84.20051397726502">
+				<ele>948.0053051728755</ele>
+				<time>2017-11-06T19:04:12Z</time>
+				<extensions>
+					<speed>6.4874653816223145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013272884826307" lon="-84.2004805797458">
+				<ele>948.244212619029</ele>
+				<time>2017-11-06T19:04:13Z</time>
+				<extensions>
+					<speed>6.478721618652344</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013324092446362" lon="-84.2004504883461">
+				<ele>948.0089490860701</ele>
+				<time>2017-11-06T19:04:14Z</time>
+				<extensions>
+					<speed>6.324189186096191</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013370584384413" lon="-84.2004232817985">
+				<ele>947.915867280215</ele>
+				<time>2017-11-06T19:04:15Z</time>
+				<extensions>
+					<speed>5.642312049865723</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013414845344046" lon="-84.20039753462932">
+				<ele>947.6211225325242</ele>
+				<time>2017-11-06T19:04:16Z</time>
+				<extensions>
+					<speed>6.041568279266357</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013462975293505" lon="-84.20037736269796">
+				<ele>948.6884581306949</ele>
+				<time>2017-11-06T19:04:17Z</time>
+				<extensions>
+					<speed>5.694397926330566</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013503412154797" lon="-84.20035380526446">
+				<ele>947.1854397887364</ele>
+				<time>2017-11-06T19:04:18Z</time>
+				<extensions>
+					<speed>5.176234722137451</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013544532046517" lon="-84.2003327157452">
+				<ele>946.536259575747</ele>
+				<time>2017-11-06T19:04:19Z</time>
+				<extensions>
+					<speed>5.0265583992004395</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013587256346648" lon="-84.20030967133303">
+				<ele>946.8813966708258</ele>
+				<time>2017-11-06T19:04:20Z</time>
+				<extensions>
+					<speed>5.1383161544799805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013629852335217" lon="-84.20028522750611">
+				<ele>947.3517508041114</ele>
+				<time>2017-11-06T19:04:21Z</time>
+				<extensions>
+					<speed>5.079174518585205</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013670396542707" lon="-84.20025921731175">
+				<ele>947.9360852260143</ele>
+				<time>2017-11-06T19:04:22Z</time>
+				<extensions>
+					<speed>5.039492607116699</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01370969465359" lon="-84.20022949096749">
+				<ele>947.649974161759</ele>
+				<time>2017-11-06T19:04:23Z</time>
+				<extensions>
+					<speed>5.322032928466797</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013748054105369" lon="-84.20019780136467">
+				<ele>947.7028383947909</ele>
+				<time>2017-11-06T19:04:24Z</time>
+				<extensions>
+					<speed>5.683625221252441</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013790735806689" lon="-84.20016964231856">
+				<ele>947.8083016918972</ele>
+				<time>2017-11-06T19:04:25Z</time>
+				<extensions>
+					<speed>5.630408763885498</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013836067348386" lon="-84.20013987667905">
+				<ele>948.006281430833</ele>
+				<time>2017-11-06T19:04:26Z</time>
+				<extensions>
+					<speed>6.070558547973633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013882065617368" lon="-84.20010495949842">
+				<ele>949.0737011749297</ele>
+				<time>2017-11-06T19:04:27Z</time>
+				<extensions>
+					<speed>6.415241241455078</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013925787998025" lon="-84.20006985732708">
+				<ele>949.7127967076376</ele>
+				<time>2017-11-06T19:04:28Z</time>
+				<extensions>
+					<speed>5.803501129150391</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.013966245872775" lon="-84.20003597780264">
+				<ele>950.4347463920712</ele>
+				<time>2017-11-06T19:04:29Z</time>
+				<extensions>
+					<speed>5.555267810821533</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014003366063601" lon="-84.19999391827736">
+				<ele>951.2916759327054</ele>
+				<time>2017-11-06T19:04:30Z</time>
+				<extensions>
+					<speed>5.886971473693848</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014040524434652" lon="-84.19994994995099">
+				<ele>951.9483464332297</ele>
+				<time>2017-11-06T19:04:31Z</time>
+				<extensions>
+					<speed>5.882418155670166</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014078646020614" lon="-84.19990590652998">
+				<ele>952.365327087231</ele>
+				<time>2017-11-06T19:04:32Z</time>
+				<extensions>
+					<speed>5.880059242248535</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014115021632694" lon="-84.1998614624126">
+				<ele>952.7321078991517</ele>
+				<time>2017-11-06T19:04:33Z</time>
+				<extensions>
+					<speed>5.812754154205322</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01415137027215" lon="-84.19982100807673">
+				<ele>953.1950664715841</ele>
+				<time>2017-11-06T19:04:34Z</time>
+				<extensions>
+					<speed>5.866541862487793</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014191064991135" lon="-84.1997811819081">
+				<ele>953.3303734157234</ele>
+				<time>2017-11-06T19:04:35Z</time>
+				<extensions>
+					<speed>6.1723198890686035</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01423533727936" lon="-84.19973904829264">
+				<ele>953.435708777979</ele>
+				<time>2017-11-06T19:04:36Z</time>
+				<extensions>
+					<speed>6.568131923675537</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014282098652213" lon="-84.19969258813055">
+				<ele>953.695186380297</ele>
+				<time>2017-11-06T19:04:37Z</time>
+				<extensions>
+					<speed>6.902561187744141</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014333839032503" lon="-84.19964433906503">
+				<ele>954.1437922567129</ele>
+				<time>2017-11-06T19:04:38Z</time>
+				<extensions>
+					<speed>7.283278465270996</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01438717986715" lon="-84.1995970540946">
+				<ele>954.5823226142675</ele>
+				<time>2017-11-06T19:04:39Z</time>
+				<extensions>
+					<speed>7.140609264373779</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014438038486004" lon="-84.19955559060917">
+				<ele>954.779173781164</ele>
+				<time>2017-11-06T19:04:40Z</time>
+				<extensions>
+					<speed>6.461848735809326</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014483969854117" lon="-84.19952069648204">
+				<ele>954.8994982326403</ele>
+				<time>2017-11-06T19:04:41Z</time>
+				<extensions>
+					<speed>5.399014949798584</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01452572970612" lon="-84.19949267217922">
+				<ele>954.8519580010325</ele>
+				<time>2017-11-06T19:04:42Z</time>
+				<extensions>
+					<speed>4.633447647094727</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014564670462885" lon="-84.19946913004898">
+				<ele>954.2105167414993</ele>
+				<time>2017-11-06T19:04:43Z</time>
+				<extensions>
+					<speed>3.875276565551758</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014598942653276" lon="-84.19944746932505">
+				<ele>953.4339146604761</ele>
+				<time>2017-11-06T19:04:44Z</time>
+				<extensions>
+					<speed>3.8226165771484375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014632416148535" lon="-84.19942113220259">
+				<ele>953.0179143939167</ele>
+				<time>2017-11-06T19:04:45Z</time>
+				<extensions>
+					<speed>4.137244701385498</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014667791755924" lon="-84.19939397638714">
+				<ele>952.9568369509652</ele>
+				<time>2017-11-06T19:04:46Z</time>
+				<extensions>
+					<speed>4.679040908813477</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014708877073252" lon="-84.19936504369225">
+				<ele>953.6206178329885</ele>
+				<time>2017-11-06T19:04:47Z</time>
+				<extensions>
+					<speed>5.3698577880859375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014752815787746" lon="-84.1993302005146">
+				<ele>953.7494101990014</ele>
+				<time>2017-11-06T19:04:48Z</time>
+				<extensions>
+					<speed>6.007414817810059</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014798750671353" lon="-84.1992909985847">
+				<ele>953.986766778864</ele>
+				<time>2017-11-06T19:04:49Z</time>
+				<extensions>
+					<speed>6.0516180992126465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014844165674647" lon="-84.19925519011315">
+				<ele>954.5405653277412</ele>
+				<time>2017-11-06T19:04:50Z</time>
+				<extensions>
+					<speed>5.830583572387695</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01488768933671" lon="-84.19922017398544">
+				<ele>955.295044244267</ele>
+				<time>2017-11-06T19:04:51Z</time>
+				<extensions>
+					<speed>5.786627292633057</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014928112594907" lon="-84.19918187199099">
+				<ele>956.2329112933949</ele>
+				<time>2017-11-06T19:04:52Z</time>
+				<extensions>
+					<speed>5.85127067565918</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.014970218490895" lon="-84.19914281931167">
+				<ele>957.2146679162979</ele>
+				<time>2017-11-06T19:04:53Z</time>
+				<extensions>
+					<speed>5.991540431976318</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015012791558856" lon="-84.19910433970495">
+				<ele>957.7658731127158</ele>
+				<time>2017-11-06T19:04:54Z</time>
+				<extensions>
+					<speed>5.945058345794678</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01505628513658" lon="-84.19906707001482">
+				<ele>958.6701699960977</ele>
+				<time>2017-11-06T19:04:55Z</time>
+				<extensions>
+					<speed>5.996856212615967</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01510041880392" lon="-84.19903095753787">
+				<ele>959.5981623325497</ele>
+				<time>2017-11-06T19:04:56Z</time>
+				<extensions>
+					<speed>6.077144145965576</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015143924437886" lon="-84.19898978999348">
+				<ele>961.6413228660822</ele>
+				<time>2017-11-06T19:04:57Z</time>
+				<extensions>
+					<speed>6.142909526824951</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015186666766171" lon="-84.19894885518143">
+				<ele>962.6041524074972</ele>
+				<time>2017-11-06T19:04:58Z</time>
+				<extensions>
+					<speed>6.0448079109191895</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015229110818034" lon="-84.19890713135321">
+				<ele>962.7061044173315</ele>
+				<time>2017-11-06T19:04:59Z</time>
+				<extensions>
+					<speed>5.918501377105713</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015271852353429" lon="-84.19886539166009">
+				<ele>962.8117374135181</ele>
+				<time>2017-11-06T19:05:00Z</time>
+				<extensions>
+					<speed>6.094228267669678</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015314196673076" lon="-84.19882466644786">
+				<ele>962.9167621070519</ele>
+				<time>2017-11-06T19:05:01Z</time>
+				<extensions>
+					<speed>6.223045349121094</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015356442743448" lon="-84.19878360368298">
+				<ele>963.544322709553</ele>
+				<time>2017-11-06T19:05:02Z</time>
+				<extensions>
+					<speed>6.086835861206055</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015398202607626" lon="-84.19874138130099">
+				<ele>964.6220424808562</ele>
+				<time>2017-11-06T19:05:03Z</time>
+				<extensions>
+					<speed>6.223238945007324</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015433416524626" lon="-84.198697984604">
+				<ele>966.4380553485826</ele>
+				<time>2017-11-06T19:05:04Z</time>
+				<extensions>
+					<speed>6.11143684387207</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015467112593813" lon="-84.19865195971718">
+				<ele>966.9629728263244</ele>
+				<time>2017-11-06T19:05:05Z</time>
+				<extensions>
+					<speed>6.057289123535156</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015497293999166" lon="-84.19860125690417">
+				<ele>967.3288413947448</ele>
+				<time>2017-11-06T19:05:06Z</time>
+				<extensions>
+					<speed>5.914560317993164</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01551936115217" lon="-84.19855137530895">
+				<ele>967.6133122341707</ele>
+				<time>2017-11-06T19:05:07Z</time>
+				<extensions>
+					<speed>6.039289474487305</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015540270563088" lon="-84.19850045995443">
+				<ele>968.0406300360337</ele>
+				<time>2017-11-06T19:05:08Z</time>
+				<extensions>
+					<speed>6.088529586791992</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015560584788963" lon="-84.1984467325782">
+				<ele>968.4584641447291</ele>
+				<time>2017-11-06T19:05:09Z</time>
+				<extensions>
+					<speed>6.271649360656738</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015579799865508" lon="-84.19839120642928">
+				<ele>969.1647707503289</ele>
+				<time>2017-11-06T19:05:10Z</time>
+				<extensions>
+					<speed>6.5049824714660645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015600334269216" lon="-84.19833225561601">
+				<ele>970.2222628425807</ele>
+				<time>2017-11-06T19:05:11Z</time>
+				<extensions>
+					<speed>7.10493803024292</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015623156899629" lon="-84.19826969971352">
+				<ele>971.4835639828816</ele>
+				<time>2017-11-06T19:05:12Z</time>
+				<extensions>
+					<speed>7.282458782196045</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015645087081463" lon="-84.19820943762936">
+				<ele>972.0259677907452</ele>
+				<time>2017-11-06T19:05:13Z</time>
+				<extensions>
+					<speed>6.6629157066345215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015667313305334" lon="-84.19815449054083">
+				<ele>972.2811024934053</ele>
+				<time>2017-11-06T19:05:14Z</time>
+				<extensions>
+					<speed>6.313508987426758</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01569502679956" lon="-84.19810672404874">
+				<ele>973.4290496557951</ele>
+				<time>2017-11-06T19:05:15Z</time>
+				<extensions>
+					<speed>5.9990339279174805</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015720623973897" lon="-84.19805776847481">
+				<ele>974.0726544968784</ele>
+				<time>2017-11-06T19:05:16Z</time>
+				<extensions>
+					<speed>5.675656795501709</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015745354189471" lon="-84.19800925759351">
+				<ele>974.5223878985271</ele>
+				<time>2017-11-06T19:05:17Z</time>
+				<extensions>
+					<speed>5.448208332061768</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015768177065127" lon="-84.1979595307437">
+				<ele>974.3369815722108</ele>
+				<time>2017-11-06T19:05:18Z</time>
+				<extensions>
+					<speed>5.2714667320251465</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015790332419" lon="-84.19791142462854">
+				<ele>974.1636658068746</ele>
+				<time>2017-11-06T19:05:19Z</time>
+				<extensions>
+					<speed>5.097879409790039</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015812106085221" lon="-84.19786520135828">
+				<ele>974.0007904330269</ele>
+				<time>2017-11-06T19:05:20Z</time>
+				<extensions>
+					<speed>4.870247840881348</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015833059150578" lon="-84.19782082864681">
+				<ele>973.9735104190186</ele>
+				<time>2017-11-06T19:05:21Z</time>
+				<extensions>
+					<speed>4.7973151206970215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015853461772346" lon="-84.1977767034401">
+				<ele>973.9422562932596</ele>
+				<time>2017-11-06T19:05:22Z</time>
+				<extensions>
+					<speed>4.790783882141113</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015872758125415" lon="-84.19773347275557">
+				<ele>973.9532344713807</ele>
+				<time>2017-11-06T19:05:23Z</time>
+				<extensions>
+					<speed>4.638052463531494</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015891009143164" lon="-84.19769104203534">
+				<ele>973.7859425088391</ele>
+				<time>2017-11-06T19:05:24Z</time>
+				<extensions>
+					<speed>4.728802680969238</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015909570610543" lon="-84.19764830714695">
+				<ele>973.5400674035773</ele>
+				<time>2017-11-06T19:05:25Z</time>
+				<extensions>
+					<speed>4.686692237854004</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015929856687837" lon="-84.19760453690049">
+				<ele>973.5878133773804</ele>
+				<time>2017-11-06T19:05:26Z</time>
+				<extensions>
+					<speed>5.133975028991699</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015949681257586" lon="-84.19755958664221">
+				<ele>973.9988718992099</ele>
+				<time>2017-11-06T19:05:27Z</time>
+				<extensions>
+					<speed>5.10280704498291</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015969306350383" lon="-84.19751335269049">
+				<ele>974.2509656799957</ele>
+				<time>2017-11-06T19:05:28Z</time>
+				<extensions>
+					<speed>5.3028411865234375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.015991373204853" lon="-84.19746734792822">
+				<ele>974.2905447883531</ele>
+				<time>2017-11-06T19:05:29Z</time>
+				<extensions>
+					<speed>5.31777286529541</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01601561901111" lon="-84.19742455006929">
+				<ele>974.0483541879803</ele>
+				<time>2017-11-06T19:05:30Z</time>
+				<extensions>
+					<speed>5.237257480621338</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01604060026849" lon="-84.19738084532125">
+				<ele>973.5721699912101</ele>
+				<time>2017-11-06T19:05:31Z</time>
+				<extensions>
+					<speed>5.463534832000732</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016067545025756" lon="-84.19733507103263">
+				<ele>973.4095878088847</ele>
+				<time>2017-11-06T19:05:32Z</time>
+				<extensions>
+					<speed>5.899660110473633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016095512098351" lon="-84.19729053619143">
+				<ele>973.0329168438911</ele>
+				<time>2017-11-06T19:05:33Z</time>
+				<extensions>
+					<speed>5.362042427062988</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01612143083425" lon="-84.19724772324965">
+				<ele>972.8506376687437</ele>
+				<time>2017-11-06T19:05:34Z</time>
+				<extensions>
+					<speed>5.286770343780518</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016143195891217" lon="-84.1972053541301">
+				<ele>972.8779208995402</ele>
+				<time>2017-11-06T19:05:35Z</time>
+				<extensions>
+					<speed>4.925539016723633</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016160614907774" lon="-84.19716883165565">
+				<ele>972.9603545572609</ele>
+				<time>2017-11-06T19:05:36Z</time>
+				<extensions>
+					<speed>3.6229634284973145</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016172991109974" lon="-84.19713699404532">
+				<ele>973.2517165280879</ele>
+				<time>2017-11-06T19:05:37Z</time>
+				<extensions>
+					<speed>2.7114408016204834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016182635246302" lon="-84.19711100954768">
+				<ele>973.443551803939</ele>
+				<time>2017-11-06T19:05:38Z</time>
+				<extensions>
+					<speed>2.145615339279175</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016189637856009" lon="-84.1970938190826">
+				<ele>973.5807329202071</ele>
+				<time>2017-11-06T19:05:39Z</time>
+				<extensions>
+					<speed>1.2927483320236206</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016193928973196" lon="-84.19708292244503">
+				<ele>973.6512430524454</ele>
+				<time>2017-11-06T19:05:40Z</time>
+				<extensions>
+					<speed>0.796538233757019</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016193928973196" lon="-84.19708292244503">
+				<ele>973.6512430524454</ele>
+				<time>2017-11-06T19:05:41Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016192767738808" lon="-84.19708271220631">
+				<ele>974.0166804278269</ele>
+				<time>2017-11-06T19:05:42Z</time>
+				<extensions>
+					<speed>0.727899432182312</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016192767738808" lon="-84.19708271220631">
+				<ele>974.0166804278269</ele>
+				<time>2017-11-06T19:05:43Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01619217285059" lon="-84.19708451008702">
+				<ele>974.2175234137103</ele>
+				<time>2017-11-06T19:05:44Z</time>
+				<extensions>
+					<speed>0.6486833095550537</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01619217285059" lon="-84.19708451008702">
+				<ele>974.2175234137103</ele>
+				<time>2017-11-06T19:05:45Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016191503764773" lon="-84.19708444106577">
+				<ele>974.3790884474292</ele>
+				<time>2017-11-06T19:05:46Z</time>
+				<extensions>
+					<speed>0.048956550657749176</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016191503764773" lon="-84.19708444106577">
+				<ele>974.3790884474292</ele>
+				<time>2017-11-06T19:05:47Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016191503764773" lon="-84.19708444106577">
+				<ele>974.3790884474292</ele>
+				<time>2017-11-06T19:05:48Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016191503764773" lon="-84.19708444106577">
+				<ele>974.3790884474292</ele>
+				<time>2017-11-06T19:05:49Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016191503764773" lon="-84.19708444106577">
+				<ele>974.3790884474292</ele>
+				<time>2017-11-06T19:05:50Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016191503764773" lon="-84.19708444106577">
+				<ele>974.3790884474292</ele>
+				<time>2017-11-06T19:05:51Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016191503764773" lon="-84.19708444106577">
+				<ele>974.3790884474292</ele>
+				<time>2017-11-06T19:05:52Z</time>
+				<extensions>
+					<speed>0.0</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016190990866825" lon="-84.19707822677549">
+				<ele>974.3878954667598</ele>
+				<time>2017-11-06T19:05:53Z</time>
+				<extensions>
+					<speed>0.8603558540344238</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016194007603508" lon="-84.19706390129153">
+				<ele>974.5432838601992</ele>
+				<time>2017-11-06T19:05:54Z</time>
+				<extensions>
+					<speed>2.2627511024475098</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016208125166456" lon="-84.19703860232606">
+				<ele>974.6325881155208</ele>
+				<time>2017-11-06T19:05:55Z</time>
+				<extensions>
+					<speed>3.585134983062744</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016225905828541" lon="-84.19700877029203">
+				<ele>974.7584414733574</ele>
+				<time>2017-11-06T19:05:56Z</time>
+				<extensions>
+					<speed>4.42858362197876</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016252431844078" lon="-84.19697202690615">
+				<ele>975.0862199431285</ele>
+				<time>2017-11-06T19:05:57Z</time>
+				<extensions>
+					<speed>5.168154716491699</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016284272452108" lon="-84.1969251028937">
+				<ele>975.8115687929094</ele>
+				<time>2017-11-06T19:05:58Z</time>
+				<extensions>
+					<speed>6.060328483581543</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016318290539099" lon="-84.19687437527932">
+				<ele>976.5219403356314</ele>
+				<time>2017-11-06T19:05:59Z</time>
+				<extensions>
+					<speed>6.405447483062744</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01635534192903" lon="-84.19682278785736">
+				<ele>976.8228127462789</ele>
+				<time>2017-11-06T19:06:00Z</time>
+				<extensions>
+					<speed>6.4899420738220215</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016390780449873" lon="-84.19677275398321">
+				<ele>977.1245894730091</ele>
+				<time>2017-11-06T19:06:01Z</time>
+				<extensions>
+					<speed>6.620715618133545</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016428816281746" lon="-84.19672388315672">
+				<ele>977.236610269174</ele>
+				<time>2017-11-06T19:06:02Z</time>
+				<extensions>
+					<speed>6.773824214935303</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016469261269968" lon="-84.19667429928575">
+				<ele>977.3472659252584</ele>
+				<time>2017-11-06T19:06:03Z</time>
+				<extensions>
+					<speed>6.901464939117432</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016509406345872" lon="-84.19662540294456">
+				<ele>977.3232899587601</ele>
+				<time>2017-11-06T19:06:04Z</time>
+				<extensions>
+					<speed>6.601839065551758</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016548657803833" lon="-84.1965802763929">
+				<ele>977.3167067812756</ele>
+				<time>2017-11-06T19:06:05Z</time>
+				<extensions>
+					<speed>6.2198076248168945</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016586799533492" lon="-84.19653718373787">
+				<ele>977.3558055441827</ele>
+				<time>2017-11-06T19:06:06Z</time>
+				<extensions>
+					<speed>6.063945770263672</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01662818055407" lon="-84.19649595217722">
+				<ele>978.4337877947837</ele>
+				<time>2017-11-06T19:06:07Z</time>
+				<extensions>
+					<speed>6.19437313079834</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016670291779565" lon="-84.19645576574146">
+				<ele>979.1158811990172</ele>
+				<time>2017-11-06T19:06:08Z</time>
+				<extensions>
+					<speed>6.1341328620910645</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016712422514285" lon="-84.19641891047867">
+				<ele>979.7322980705649</ele>
+				<time>2017-11-06T19:06:09Z</time>
+				<extensions>
+					<speed>5.883657455444336</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016749854703944" lon="-84.1963860450724">
+				<ele>979.8209135523066</ele>
+				<time>2017-11-06T19:06:10Z</time>
+				<extensions>
+					<speed>4.918338775634766</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01677695448806" lon="-84.19636291575674">
+				<ele>979.9695594990626</ele>
+				<time>2017-11-06T19:06:11Z</time>
+				<extensions>
+					<speed>2.9341812133789063</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016793810728858" lon="-84.19634812470599">
+				<ele>979.8549362355843</ele>
+				<time>2017-11-06T19:06:12Z</time>
+				<extensions>
+					<speed>1.5877091884613037</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016801509829744" lon="-84.1963399115696">
+				<ele>979.7692362964153</ele>
+				<time>2017-11-06T19:06:13Z</time>
+				<extensions>
+					<speed>1.0292885303497314</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016809220372956" lon="-84.19633305827713">
+				<ele>979.6643985826522</ele>
+				<time>2017-11-06T19:06:14Z</time>
+				<extensions>
+					<speed>1.0254669189453125</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016817890329083" lon="-84.19632300159289">
+				<ele>978.8555395519361</ele>
+				<time>2017-11-06T19:06:15Z</time>
+				<extensions>
+					<speed>1.61801278591156</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016823721282329" lon="-84.1963018959618">
+				<ele>977.9420228758827</ele>
+				<time>2017-11-06T19:06:16Z</time>
+				<extensions>
+					<speed>2.0586493015289307</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016842298214748" lon="-84.19628457762765">
+				<ele>977.8720519840717</ele>
+				<time>2017-11-06T19:06:17Z</time>
+				<extensions>
+					<speed>3.165618658065796</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016876650134636" lon="-84.19626083374885">
+				<ele>977.9793932046741</ele>
+				<time>2017-11-06T19:06:18Z</time>
+				<extensions>
+					<speed>4.49763298034668</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016916627000386" lon="-84.19622271376464">
+				<ele>977.8448708429933</ele>
+				<time>2017-11-06T19:06:19Z</time>
+				<extensions>
+					<speed>5.502187728881836</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.016960499544322" lon="-84.19618657122187">
+				<ele>977.8027928452939</ele>
+				<time>2017-11-06T19:06:20Z</time>
+				<extensions>
+					<speed>5.92962646484375</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017006688215478" lon="-84.19614797047183">
+				<ele>977.771293331869</ele>
+				<time>2017-11-06T19:06:21Z</time>
+				<extensions>
+					<speed>6.147075176239014</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.01705212570238" lon="-84.19610928777416">
+				<ele>977.6799247758463</ele>
+				<time>2017-11-06T19:06:22Z</time>
+				<extensions>
+					<speed>5.700877666473389</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017093038825411" lon="-84.19607252936932">
+				<ele>977.7796544479206</ele>
+				<time>2017-11-06T19:06:23Z</time>
+				<extensions>
+					<speed>5.444622993469238</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017129435591219" lon="-84.1960385202122">
+				<ele>977.9206099705771</ele>
+				<time>2017-11-06T19:06:24Z</time>
+				<extensions>
+					<speed>4.896353244781494</speed>
+				</extensions>
+			</trkpt>
+			<trkpt lat="10.017159557338585" lon="-84.19600610452889">
+				<ele>978.1013307068497</ele>
+				<time>2017-11-06T19:06:25Z</time>
+				<extensions>
+					<speed>3.9975533485412598</speed>
+				</extensions>
+			</trkpt>
+		</trkseg>
+	</trk>
+</gpx>


### PR DESCRIPTION
Están todas las trazas faltantes menos las del día 23 de octubre y 27 de noviembre